### PR TITLE
Add pause/resume admin console commands

### DIFF
--- a/sources/config.c
+++ b/sources/config.c
@@ -778,6 +778,7 @@ od_config_validate(od_config_t *config, od_logger_t *logger)
 		}
 		if (strcmp(storage->type, "remote") == 0) {
 			storage->storage_type = OD_STORAGE_TYPE_REMOTE;
+			storage->state = OD_STORAGE_ACTIVE;
 		} else
 		if (strcmp(storage->type, "local") == 0) {
 			storage->storage_type = OD_STORAGE_TYPE_LOCAL;

--- a/sources/config.h
+++ b/sources/config.h
@@ -44,11 +44,18 @@ typedef enum
 	OD_STORAGE_TYPE_LOCAL
 } od_storage_type_t;
 
+typedef enum
+{
+	OD_STORAGE_ACTIVE,
+	OD_STORAGE_PAUSE
+} od_storage_state_t;
+
 struct od_config_storage
 {
 	char              *name;
 	char              *type;
 	od_storage_type_t  storage_type;
+	od_storage_state_t state;
 	char              *host;
 	int                port;
 	od_tls_t           tls_mode;

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -120,6 +120,16 @@ od_cron_expire_mark(od_server_t *server, void *arg)
 		return 0;
 	}
 
+    /* expire by server pool pause */
+    if (route->config->storage->state == OD_STORAGE_PAUSE)
+    {
+        od_debug(&instance->logger, "expire", NULL, server,
+                "server pool is paused, schedule closing");
+        od_server_pool_set(&route->server_pool, server,
+                OD_SERVER_EXPIRE);
+        return 0;
+    }
+
 	/* expire by time-to-live */
 	if (! route->config->pool_ttl)
 		return 0;

--- a/sources/router.c
+++ b/sources/router.c
@@ -99,6 +99,11 @@ od_router_attacher(void *arg)
 	od_server_t *server;
 	for (;;)
 	{
+		if (route->config->storage->state == OD_STORAGE_PAUSE)
+		{
+			machine_sleep(1000);
+			continue;
+		}
 		server = od_server_pool_next(&route->server_pool, OD_SERVER_IDLE);
 		if (server)
 			goto on_attach;


### PR DESCRIPTION
Adds `PAUSE`/`RESUME` admin console commands.

This puts pause/resume `state` on `config_storage`s. Any attempt to use a route with a paused storage is blocked for 1 second then retried, and any idle servers with paused storage are marked for gc.

`PAUSE` can be called with or without the name of a storage to pause. If no storage name is given, all storages will be paused. `RESUME` operates similarly.

Open to comments/critiques; wasn't 100% confident on how to block attempts to attach. Initially tried to aim for a way to let clients still be able to connect but not be given a server until `RESUME`, but that seemed to create something too fragile.