### PR TITLE
Use shared channel for route wait bus

### DIFF
--- a/sources/route.h
+++ b/sources/route.h
@@ -53,13 +53,13 @@ od_route_free(od_route_t *route)
 }
 
 static inline od_route_t*
-od_route_allocate(int is_shared)
+od_route_allocate()
 {
 	od_route_t *route = malloc(sizeof(*route));
 	if (route == NULL)
 		return NULL;
 	od_route_init(route);
-	route->wait_bus = machine_channel_create(is_shared);
+	route->wait_bus = machine_channel_create(true);
 	if (route->wait_bus == NULL) {
 		od_route_free(route);
 		return NULL;

--- a/sources/route_pool.h
+++ b/sources/route_pool.h
@@ -47,10 +47,9 @@ od_route_pool_free(od_route_pool_t *pool)
 }
 
 static inline od_route_t*
-od_route_pool_new(od_route_pool_t *pool, int is_shared, od_route_id_t *id,
-                  od_rule_t *rule)
+od_route_pool_new(od_route_pool_t *pool, od_route_id_t *id, od_rule_t *rule)
 {
-	od_route_t *route = od_route_allocate(is_shared);
+	od_route_t *route = od_route_allocate();
 	if (route == NULL)
 		return NULL;
 	int rc;

--- a/sources/router.c
+++ b/sources/router.c
@@ -250,9 +250,7 @@ od_router_route(od_router_t *router, od_config_t *config, od_client_t *client)
 	od_route_t *route;
 	route = od_route_pool_match(&router->route_pool, &id, rule);
 	if (route == NULL) {
-		int is_shared;
-		is_shared = od_config_is_multi_workers(config);
-		route = od_route_pool_new(&router->route_pool, is_shared, &id, rule);
+		route = od_route_pool_new(&router->route_pool, &id, rule);
 		if (route == NULL) {
 			od_router_unlock(router);
 			return OD_ROUTER_ERROR;


### PR DESCRIPTION
This fixes #50 

Wait bus employed in the size-limit pool is used in a multithreaded environment and therefore should be declared shared.

@pmwkaa plz review this 