### PR TITLE
Handle skipped results correctly during connection deploy

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -651,7 +651,9 @@ od_frontend_remote(od_client_t *client)
 		if (server == NULL)
 			continue;
 
-		status = od_relay_step(&server->relay);
+		do {
+		    status = od_relay_step(&server->relay);
+		} while (status == OD_SKIP);
 		if (status == OD_DETACH)
 		{
 			/* write any pending data to server first */


### PR DESCRIPTION
Connection reconfiguration during deploy may issue queries. These queries need to be read from the server, but not shown to the client.
These queries were not handled correctly, causing a connection leak.

Also, it seems like that client HW read errors will lead to similar behaviour.