### PR TITLE
Use memory contexts for allocated objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-
-project(odyssey C)
+cmake_minimum_required(VERSION 3.5)
+project(odyssey LANGUAGES C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -21,7 +20,7 @@ endif()
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     set(CMAKE_C_FLAGS "-std=gnu99 -pedantic -Wall -Wextra -Wstrict-aliasing -g -O2")
 elseif("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    set(CMAKE_C_FLAGS "-std=gnu99 -pedantic -Wall -Wextra -Wstrict-aliasing -g -O0")
+    set(CMAKE_C_FLAGS "-std=gnu99 -pedantic -Wall -Wextra -Wstrict-aliasing -g3 -O0")
 endif()
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} OD_VERSION_BUILD)
@@ -63,6 +62,10 @@ include(BuildKiwi)
 build_kiwi()
 set(od_libraries ${od_libraries} ${KIWI_LIBRARIES})
 include_directories(${KIWI_INCLUDE_DIRS})
+
+#memcontext
+add_subdirectory(third_party/memcontext)
+set(od_libraries ${od_libraries} memcontext)
 
 message (STATUS "")
 message (STATUS "Odyssey (version: ${OD_VERSION_GIT} ${OD_VERSION_BUILD})")

--- a/sources/auth.c
+++ b/sources/auth.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static inline int

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static inline int
@@ -191,7 +180,7 @@ od_auth_query(od_global_t *global, od_rule_t *rule,
 
 	/* create internal auth client */
 	od_client_t *auth_client;
-	auth_client = od_client_allocate();
+	auth_client = od_client_allocate(instance->top_mcxt);
 	if (auth_client == NULL)
 		return -1;
 	auth_client->global = global;
@@ -208,14 +197,14 @@ od_auth_query(od_global_t *global, od_rule_t *rule,
 
 	/* route */
 	od_router_status_t status;
-	status = od_router_route(router, &instance->config, auth_client);
+	status = od_router_route(router, instance->config, auth_client);
 	if (status != OD_ROUTER_OK) {
 		od_client_free(auth_client);
 		return -1;
 	}
 
 	/* attach */
-	status = od_router_attach(router, &instance->config, auth_client);
+	status = od_router_attach(router, instance->config, auth_client);
 	if (status != OD_ROUTER_OK) {
 		od_router_unroute(router, auth_client);
 		od_client_free(auth_client);
@@ -255,7 +244,7 @@ od_auth_query(od_global_t *global, od_rule_t *rule,
 	}
 
 	/* detach and unroute */
-	od_router_detach(router, &instance->config, auth_client);
+	od_router_detach(router, instance->config, auth_client);
 	od_router_unroute(router, auth_client);
 	od_client_free(auth_client);
 	return 0;

--- a/sources/backend.c
+++ b/sources/backend.c
@@ -5,18 +5,8 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
+#include <c.h>
 #include <arpa/inet.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 void
@@ -250,11 +240,11 @@ od_backend_connect_to(od_server_t *server, char *context,
 		return -1;
 
 	/* set network options */
-	machine_set_nodelay(io, instance->config.nodelay);
-	if (instance->config.keepalive > 0)
-		machine_set_keepalive(io, 1, instance->config.keepalive);
+	machine_set_nodelay(io, instance->config->nodelay);
+	if (instance->config->keepalive > 0)
+		machine_set_keepalive(io, 1, instance->config->keepalive);
 	int rc;
-	rc = od_io_prepare(&server->io, io, instance->config.readahead);
+	rc = od_io_prepare(&server->io, io, instance->config->readahead);
 	if (rc == -1) {
 		od_error(&instance->logger, context, NULL, server,
 		         "failed to set server io");
@@ -271,7 +261,7 @@ od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	uint64_t time_connect_start = 0;
-	if (instance->config.log_session)
+	if (instance->config->log_session)
 		time_connect_start = machine_time_us();
 
 	struct sockaddr_un   saddr_un;
@@ -324,12 +314,12 @@ od_backend_connect_to(od_server_t *server, char *context,
 		saddr = (struct sockaddr*)&saddr_un;
 		od_snprintf(saddr_un.sun_path, sizeof(saddr_un.sun_path),
 		            "%s/.s.PGSQL.%d",
-		            instance->config.unix_socket_dir,
+		            instance->config->unix_socket_dir,
 		            storage->port);
 	}
 
 	uint64_t time_resolve = 0;
-	if (instance->config.log_session)
+	if (instance->config->log_session)
 		time_resolve = machine_time_us() - time_connect_start;
 
 	/* connect to server */
@@ -356,11 +346,11 @@ od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	uint64_t time_connect = 0;
-	if (instance->config.log_session)
+	if (instance->config->log_session)
 		time_connect = machine_time_us() - time_connect_start;
 
 	/* log server connection */
-	if (instance->config.log_session) {
+	if (instance->config->log_session) {
 		if (storage->host) {
 			od_log(&instance->logger, context, server->client, server,
 			       "new server connection %s:%d (connect time: %d usec, resolve time: %d usec)",

--- a/sources/c.h
+++ b/sources/c.h
@@ -1,0 +1,14 @@
+#ifndef C_H
+#define C_H
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#endif

--- a/sources/cancel.c
+++ b/sources/cancel.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 int

--- a/sources/client.h
+++ b/sources/client.h
@@ -31,6 +31,8 @@ struct od_client_ctl
 
 struct od_client
 {
+	mcxt_context_t		mcxt;
+
 	od_client_state_t   state;
 	od_id_t             id;
 	od_client_ctl_t     ctl;
@@ -80,12 +82,21 @@ od_client_init(od_client_t *client)
 }
 
 static inline od_client_t*
-od_client_allocate(void)
+od_client_allocate(mcxt_context_t mcxt)
 {
-	od_client_t *client = malloc(sizeof(*client));
+	mcxt_context_t	client_mcxt = mcxt_new(mcxt),
+					old;
+
+	old = mcxt_switch_to(client_mcxt);
+	od_client_t *client = mcxt_alloc0(sizeof(*client));
+
 	if (client == NULL)
 		return NULL;
+
 	od_client_init(client);
+	client->mcxt = client_mcxt;
+	mcxt_switch_to(old);
+
 	return client;
 }
 
@@ -96,7 +107,8 @@ od_client_free(od_client_t *client)
 	od_io_free(&client->io);
 	if (client->cond)
 		machine_cond_free(client->cond);
-	free(client);
+
+	mcxt_delete(client->mcxt);
 }
 
 static inline void

--- a/sources/config.h
+++ b/sources/config.h
@@ -35,6 +35,8 @@ struct od_config_listen
 
 struct od_config
 {
+	mcxt_context_t	mcxt;
+
 	int        daemonize;
 	int        priority;
 	int        log_to_stdout;
@@ -71,7 +73,7 @@ od_config_is_multi_workers(od_config_t *config)
 	return config->workers > 1;
 }
 
-void od_config_init(od_config_t*);
+od_config_t *od_config_allocate(mcxt_context_t mcxt);
 void od_config_free(od_config_t*);
 int  od_config_validate(od_config_t*, od_logger_t*);
 void od_config_print(od_config_t*, od_logger_t*);

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -5,24 +5,16 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
+#include <c.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
+
+static char *default_name = "default";
 
 enum
 {
@@ -95,6 +87,8 @@ enum
 
 typedef struct
 {
+	mcxt_context_t	mcxt;
+
 	od_parser_t  parser;
 	od_config_t *config;
 	od_rules_t  *rules;
@@ -190,18 +184,18 @@ od_config_reader_open(od_config_reader_t *reader, char *config_file)
 		goto error;
 	char *config_buf = NULL;
 	if (st.st_size > 0) {
-		config_buf = malloc(st.st_size);
+		config_buf = mcxt_alloc(st.st_size);
 		if (config_buf == NULL)
 			goto error;
 		FILE *file = fopen(config_file, "r");
 		if (file == NULL) {
-			free(config_buf);
+			mcxt_free(config_buf);
 			goto error;
 		}
 		rc = fread(config_buf, st.st_size, 1, file);
 		fclose(file);
+
 		if (rc != 1) {
-			free(config_buf);
 			goto error;
 		}
 	}
@@ -213,13 +207,6 @@ error:
 	od_errorf(reader->error, "failed to open config file '%s'",
 	          config_file);
 	return -1;
-}
-
-static void
-od_config_reader_close(od_config_reader_t *reader)
-{
-	if (reader->data_size > 0)
-		free(reader->data);
 }
 
 static void
@@ -289,17 +276,23 @@ error:
 }
 
 static bool
-od_config_reader_string(od_config_reader_t *reader, char **value)
+od_config_reader_string(od_config_reader_t *reader, char **value,
+		mcxt_context_t mcxt)
 {
-	od_token_t token;
-	int rc;
+	char	   *copy;
+	od_token_t	token;
+	int			rc;
+
 	rc = od_parser_next(&reader->parser, &token);
 	if (rc != OD_PARSER_STRING) {
 		od_parser_push(&reader->parser, &token);
 		od_config_reader_error(reader, &token, "expected 'string'");
 		return false;
 	}
-	char *copy = malloc(token.value.string.size + 1);
+
+	assert(mcxt != NULL);
+	copy = mcxt_alloc_mem(mcxt, token.value.string.size + 1, false);
+
 	if (copy == NULL) {
 		od_parser_push(&reader->parser, &token);
 		od_config_reader_error(reader, &token, "memory allocation error");
@@ -308,7 +301,8 @@ od_config_reader_string(od_config_reader_t *reader, char **value)
 	memcpy(copy, token.value.string.pointer, token.value.string.size);
 	copy[token.value.string.size] = 0;
 	if (*value)
-		free(*value);
+		mcxt_free(*value);
+
 	*value = copy;
 	return true;
 }
@@ -364,6 +358,7 @@ od_config_reader_listen(od_config_reader_t *reader)
 	od_config_t *config = reader->config;
 
 	od_config_listen_t *listen;
+
 	listen = od_config_listen_add(config);
 	if (listen == NULL) {
 		return -1;
@@ -402,7 +397,7 @@ od_config_reader_listen(od_config_reader_t *reader)
 		switch (keyword->id) {
 		/* host */
 		case OD_LHOST:
-			if (! od_config_reader_string(reader, &listen->host))
+			if (! od_config_reader_string(reader, &listen->host, config->mcxt))
 				return -1;
 			continue;
 		/* port */
@@ -417,27 +412,27 @@ od_config_reader_listen(od_config_reader_t *reader)
 			continue;
 		/* tls */
 		case OD_LTLS:
-			if (! od_config_reader_string(reader, &listen->tls))
+			if (! od_config_reader_string(reader, &listen->tls, config->mcxt))
 				return -1;
 			continue;
 		/* tls_ca_file */
 		case OD_LTLS_CA_FILE:
-			if (! od_config_reader_string(reader, &listen->tls_ca_file))
+			if (! od_config_reader_string(reader, &listen->tls_ca_file, config->mcxt))
 				return -1;
 			continue;
 		/* tls_key_file */
 		case OD_LTLS_KEY_FILE:
-			if (! od_config_reader_string(reader, &listen->tls_key_file))
+			if (! od_config_reader_string(reader, &listen->tls_key_file, config->mcxt))
 				return -1;
 			continue;
 		/* tls_cert_file */
 		case OD_LTLS_CERT_FILE:
-			if (! od_config_reader_string(reader, &listen->tls_cert_file))
+			if (! od_config_reader_string(reader, &listen->tls_cert_file, config->mcxt))
 				return -1;
 			continue;
 		/* tls_protocols */
 		case OD_LTLS_PROTOCOLS:
-			if (! od_config_reader_string(reader, &listen->tls_protocols))
+			if (! od_config_reader_string(reader, &listen->tls_protocols, config->mcxt))
 				return -1;
 			continue;
 		default:
@@ -453,11 +448,13 @@ static int
 od_config_reader_storage(od_config_reader_t *reader)
 {
 	od_rule_storage_t *storage;
+
+	assert(current_mcxt == reader->rules->mcxt);
 	storage = od_rules_storage_add(reader->rules);
 	if (storage == NULL)
 		return -1;
 	/* name */
-	if (! od_config_reader_string(reader, &storage->name))
+	if (! od_config_reader_string(reader, &storage->name, storage->mcxt))
 		return -1;
 	/* { */
 	if (! od_config_reader_symbol(reader, '{'))
@@ -492,12 +489,12 @@ od_config_reader_storage(od_config_reader_t *reader)
 		switch (keyword->id) {
 		/* type */
 		case OD_LTYPE:
-			if (! od_config_reader_string(reader, &storage->type))
+			if (! od_config_reader_string(reader, &storage->type, storage->mcxt))
 				return -1;
 			continue;
 		/* host */
 		case OD_LHOST:
-			if (! od_config_reader_string(reader, &storage->host))
+			if (! od_config_reader_string(reader, &storage->host, storage->mcxt))
 				return -1;
 			continue;
 		/* port */
@@ -507,27 +504,27 @@ od_config_reader_storage(od_config_reader_t *reader)
 			continue;
 		/* tls */
 		case OD_LTLS:
-			if (! od_config_reader_string(reader, &storage->tls))
+			if (! od_config_reader_string(reader, &storage->tls, storage->mcxt))
 				return -1;
 			continue;
 		/* tls_ca_file */
 		case OD_LTLS_CA_FILE:
-			if (! od_config_reader_string(reader, &storage->tls_ca_file))
+			if (! od_config_reader_string(reader, &storage->tls_ca_file, storage->mcxt))
 				return -1;
 			continue;
 		/* tls_key_file */
 		case OD_LTLS_KEY_FILE:
-			if (! od_config_reader_string(reader, &storage->tls_key_file))
+			if (! od_config_reader_string(reader, &storage->tls_key_file, storage->mcxt))
 				return -1;
 			continue;
 		/* tls_cert_file */
 		case OD_LTLS_CERT_FILE:
-			if (! od_config_reader_string(reader, &storage->tls_cert_file))
+			if (! od_config_reader_string(reader, &storage->tls_cert_file, storage->mcxt))
 				return -1;
 			continue;
 		/* tls_protocols */
 		case OD_LTLS_PROTOCOLS:
-			if (! od_config_reader_string(reader, &storage->tls_protocols))
+			if (! od_config_reader_string(reader, &storage->tls_protocols, storage->mcxt))
 				return -1;
 			continue;
 		default:
@@ -549,15 +546,13 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 
 	/* user name or default */
 	if (od_config_reader_is(reader, OD_PARSER_STRING)) {
-		if (! od_config_reader_string(reader, &user_name))
+		if (! od_config_reader_string(reader, &user_name, reader->mcxt))
 			return -1;
 	} else {
 		if (! od_config_reader_keyword(reader, &od_config_keywords[OD_LDEFAULT]))
 			return -1;
 		user_is_default = 1;
-		user_name = strdup("default");
-		if (user_name == NULL)
-			return -1;
+		user_name = default_name;
 	}
 	user_name_len = strlen(user_name);
 
@@ -567,23 +562,22 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 	if (route) {
 		od_errorf(reader->error, "route '%s.%s': is redefined",
 		          db_name, user_name);
-		free(user_name);
 		return -1;
 	}
 	route = od_rules_add(reader->rules);
 	if (route == NULL) {
-		free(user_name);
 		return -1;
 	}
 	route->user_is_default = user_is_default;
 	route->user_name_len = user_name_len;
-	route->user_name = strdup(user_name);
-	free(user_name);
+	route->user_name = mcxt_strdup_in(route->mcxt, user_name);
+
 	if (route->user_name == NULL)
 		return -1;
+
 	route->db_is_default = db_is_default;
 	route->db_name_len = db_name_len;
-	route->db_name = strdup(db_name);
+	route->db_name = mcxt_strdup_in(route->mcxt, db_name);
 	if (route->db_name == NULL)
 		return -1;
 
@@ -620,7 +614,7 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 		switch (keyword->id) {
 		/* authentication */
 		case OD_LAUTHENTICATION:
-			if (! od_config_reader_string(reader, &route->auth))
+			if (! od_config_reader_string(reader, &route->auth, route->mcxt))
 				return -1;
 			break;
 		/* auth_common_name */
@@ -636,34 +630,34 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 			auth = od_rules_auth_add(route);
 			if (auth == NULL)
 				return -1;
-			if (! od_config_reader_string(reader, &auth->common_name))
+			if (! od_config_reader_string(reader, &auth->common_name, route->mcxt))
 				return -1;
 			break;
 		}
 		/* auth_query */
 		case OD_LAUTH_QUERY:
-			if (! od_config_reader_string(reader, &route->auth_query))
+			if (! od_config_reader_string(reader, &route->auth_query, route->mcxt))
 				return -1;
 			break;
 		/* auth_query_db */
 		case OD_LAUTH_QUERY_DB:
-			if (! od_config_reader_string(reader, &route->auth_query_db))
+			if (! od_config_reader_string(reader, &route->auth_query_db, route->mcxt))
 				return -1;
 			break;
 		/* auth_query_user */
 		case OD_LAUTH_QUERY_USER:
-			if (! od_config_reader_string(reader, &route->auth_query_user))
+			if (! od_config_reader_string(reader, &route->auth_query_user, route->mcxt))
 				return -1;
 			break;
 		/* password */
 		case OD_LPASSWORD:
-			if (! od_config_reader_string(reader, &route->password))
+			if (! od_config_reader_string(reader, &route->password, route->mcxt))
 				return -1;
 			route->password_len = strlen(route->password);
 			continue;
 		/* storage */
 		case OD_LSTORAGE:
-			if (! od_config_reader_string(reader, &route->storage_name))
+			if (! od_config_reader_string(reader, &route->storage_name, route->mcxt))
 				return -1;
 			continue;
 		/* client_max */
@@ -679,7 +673,7 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 			continue;
 		/* pool */
 		case OD_LPOOL:
-			if (! od_config_reader_string(reader, &route->pool_sz))
+			if (! od_config_reader_string(reader, &route->pool_sz, route->mcxt))
 				return -1;
 			continue;
 		/* pool_size */
@@ -699,18 +693,18 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 			continue;
 		/* storage_database */
 		case OD_LSTORAGE_DB:
-			if (! od_config_reader_string(reader, &route->storage_db))
+			if (! od_config_reader_string(reader, &route->storage_db, route->mcxt))
 				return -1;
 			continue;
 		/* storage_user */
 		case OD_LSTORAGE_USER:
-			if (! od_config_reader_string(reader, &route->storage_user))
+			if (! od_config_reader_string(reader, &route->storage_user, route->mcxt))
 				return -1;
 			route->storage_user_len = strlen(route->storage_user);
 			continue;
 		/* storage_password */
 		case OD_LSTORAGE_PASSWORD:
-			if (! od_config_reader_string(reader, &route->storage_password))
+			if (! od_config_reader_string(reader, &route->storage_password, route->mcxt))
 				return -1;
 			route->storage_password_len = strlen(route->storage_password);
 			continue;
@@ -753,15 +747,13 @@ od_config_reader_database(od_config_reader_t *reader)
 
 	/* name or default */
 	if (od_config_reader_is(reader, OD_PARSER_STRING)) {
-		if (! od_config_reader_string(reader, &db_name))
+		if (! od_config_reader_string(reader, &db_name, reader->mcxt))
 			return -1;
 	} else {
 		if (! od_config_reader_keyword(reader, &od_config_keywords[OD_LDEFAULT]))
 			return -1;
 		db_is_default = 1;
-		db_name = strdup("default");
-		if (db_name == NULL)
-			return -1;
+		db_name = default_name;
 	}
 	db_name_len = strlen(db_name);
 
@@ -783,7 +775,6 @@ od_config_reader_database(od_config_reader_t *reader)
 		case OD_PARSER_SYMBOL:
 			/* } */
 			if (token.value.num == '}') {
-				free(db_name);
 				return 0;
 			}
 			/* fall through */
@@ -800,26 +791,29 @@ od_config_reader_database(od_config_reader_t *reader)
 		switch (keyword->id) {
 		/* user */
 		case OD_LUSER:
+		{
 			rc = od_config_reader_route(reader, db_name, db_name_len, db_is_default);
+
 			if (rc == -1)
 				goto error;
 			continue;
+		}
 		default:
 			od_config_reader_error(reader, &token, "unexpected parameter");
 			goto error;
 		}
 	}
-	/* unreach */
-	return -1;
+
 error:
-	free(db_name);
 	return -1;
 }
 
 static int
 od_config_reader_parse(od_config_reader_t *reader)
 {
-	od_config_t *config = reader->config;
+	od_config_t	   *config = reader->config;
+	mcxt_context_t	old;
+
 	for (;;)
 	{
 		od_token_t token;
@@ -845,10 +839,12 @@ od_config_reader_parse(od_config_reader_t *reader)
 		case OD_LINCLUDE:
 		{
 			char *config_file = NULL;
-			if (! od_config_reader_string(reader, &config_file))
+			if (! od_config_reader_string(reader, &config_file, reader->mcxt))
 				return -1;
-			rc = od_config_reader_import(reader->config, reader->rules, reader->error, config_file);
-			free(config_file);
+			rc = od_config_reader_import(reader->config, reader->rules,
+				reader->error, config_file, reader->mcxt);
+
+			mcxt_free(config_file);
 			if (rc == -1)
 				return -1;
 			continue;
@@ -865,17 +861,17 @@ od_config_reader_parse(od_config_reader_t *reader)
 			continue;
 		/* pid_file */
 		case OD_LPID_FILE:
-			if (! od_config_reader_string(reader, &config->pid_file))
+			if (! od_config_reader_string(reader, &config->pid_file, config->mcxt))
 				return -1;
 			continue;
 		/* unix_socket_dir */
 		case OD_LUNIX_SOCKET_DIR:
-			if (! od_config_reader_string(reader, &config->unix_socket_dir))
+			if (! od_config_reader_string(reader, &config->unix_socket_dir, config->mcxt))
 				return -1;
 			continue;
 		/* unix_socket_mode */
 		case OD_LUNIX_SOCKET_MODE:
-			if (! od_config_reader_string(reader, &config->unix_socket_mode))
+			if (! od_config_reader_string(reader, &config->unix_socket_mode, config->mcxt))
 				return -1;
 			continue;
 		/* log_debug */
@@ -910,12 +906,12 @@ od_config_reader_parse(od_config_reader_t *reader)
 			continue;
 		/* log_format */
 		case OD_LLOG_FORMAT:
-			if (! od_config_reader_string(reader, &config->log_format))
+			if (! od_config_reader_string(reader, &config->log_format, config->mcxt))
 				return -1;
 			continue;
 		/* log_file */
 		case OD_LLOG_FILE:
-			if (! od_config_reader_string(reader, &config->log_file))
+			if (! od_config_reader_string(reader, &config->log_file, config->mcxt))
 				return -1;
 			continue;
 		/* log_syslog */
@@ -925,12 +921,12 @@ od_config_reader_parse(od_config_reader_t *reader)
 			continue;
 		/* log_syslog_ident */
 		case OD_LLOG_SYSLOG_IDENT:
-			if (! od_config_reader_string(reader, &config->log_syslog_ident))
+			if (! od_config_reader_string(reader, &config->log_syslog_ident, config->mcxt))
 				return -1;
 			continue;
 		/* log_syslog_facility */
 		case OD_LLOG_SYSLOG_FACILITY:
-			if (! od_config_reader_string(reader, &config->log_syslog_facility))
+			if (! od_config_reader_string(reader, &config->log_syslog_facility, config->mcxt))
 				return -1;
 			continue;
 		/* stats_interval */
@@ -1002,12 +998,16 @@ od_config_reader_parse(od_config_reader_t *reader)
 		/* listen */
 		case OD_LLISTEN:
 			rc = od_config_reader_listen(reader);
+
 			if (rc == -1)
 				return -1;
 			continue;
 		/* storage */
 		case OD_LSTORAGE:
+			old = mcxt_switch_to(reader->rules->mcxt);
 			rc = od_config_reader_storage(reader);
+			mcxt_switch_to(old);
+
 			if (rc == -1)
 				return -1;
 			continue;
@@ -1028,18 +1028,25 @@ od_config_reader_parse(od_config_reader_t *reader)
 
 int
 od_config_reader_import(od_config_t *config, od_rules_t *rules, od_error_t *error,
-                        char *config_file)
+                        char *config_file, mcxt_context_t mcxt)
 {
+	mcxt_context_t	old;
+
 	od_config_reader_t reader;
 	memset(&reader, 0, sizeof(reader));
 	reader.error   = error;
 	reader.config  = config;
 	reader.rules   = rules;
-	int rc;
-	rc = od_config_reader_open(&reader, config_file);
+	reader.mcxt    = mcxt_new(mcxt);
+
+	old = mcxt_switch_to(reader.mcxt);
+	int rc = od_config_reader_open(&reader, config_file);
 	if (rc == -1)
 		return -1;
+
 	rc = od_config_reader_parse(&reader);
-	od_config_reader_close(&reader);
+	mcxt_switch_to(old);
+	mcxt_delete(reader.mcxt);
+
 	return rc;
 }

--- a/sources/config_reader.h
+++ b/sources/config_reader.h
@@ -7,6 +7,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-int od_config_reader_import(od_config_t*, od_rules_t*, od_error_t*, char*);
+int od_config_reader_import(od_config_t*, od_rules_t*, od_error_t*, char*, mcxt_context_t);
 
 #endif /* ODYSSEY_CONFIG_READER_H */

--- a/sources/console.c
+++ b/sources/console.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 enum
@@ -816,7 +805,7 @@ od_console_query(od_client_t *client, machine_msg_t *stream,
 		return 0;
 	}
 
-	if (instance->config.log_query)
+	if (instance->config->log_query)
 		od_debug(&instance->logger, "console", client, NULL,
 		         "%.*s", query_len, query);
 

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static int
@@ -102,7 +91,7 @@ od_cron_stat(od_cron_t *cron)
 	od_instance_t *instance = cron->global->instance;
 	od_worker_pool_t *worker_pool = cron->global->worker_pool;
 
-	if (instance->config.log_stats)
+	if (instance->config->log_stats)
 	{
 		/* system worker stats */
 		uint64_t count_coroutine = 0;
@@ -144,7 +133,7 @@ od_cron_stat(od_cron_t *cron)
 	/* update stats per route and print info */
 	od_route_pool_stat_cb_t stat_cb;
 	stat_cb = od_cron_stat_cb;
-	if (! instance->config.log_stats)
+	if (! instance->config->log_stats)
 		stat_cb = NULL;
 	void *argv[] = { instance };
 	od_router_stat(router, cron->stat_time_us, 1, stat_cb, argv);
@@ -175,7 +164,7 @@ od_cron_expire(od_cron_t *cron)
 			         "closing idle server connection (%d secs)",
 			         server->idle_time);
 			server->route = NULL;
-			if (! od_config_is_multi_workers(&instance->config))
+			if (! od_config_is_multi_workers(instance->config))
 				od_io_attach(&server->io);
 			od_backend_close_connection(server);
 			od_backend_close(server);
@@ -201,7 +190,7 @@ od_cron(void *arg)
 		od_cron_expire(cron);
 
 		/* update statistics */
-		if (++stats_tick >= instance->config.stats_interval) {
+		if (++stats_tick >= instance->config->stats_interval) {
 			od_cron_stat(cron);
 			stats_tick = 0;
 		}

--- a/sources/daemon.c
+++ b/sources/daemon.c
@@ -5,22 +5,13 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
 
+#include "c.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 int

--- a/sources/deploy.c
+++ b/sources/deploy.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 int od_deploy(od_client_t *client, char *context)

--- a/sources/dns.c
+++ b/sources/dns.c
@@ -5,20 +5,10 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
+#include <c.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static int

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static inline void
@@ -141,7 +130,7 @@ od_frontend_attach(od_client_t *client, char *context, kiwi_params_t *route_para
 
 	for (;;)
 	{
-		status = od_router_attach(router, &instance->config, client);
+		status = od_router_attach(router, instance->config, client);
 		if (status != OD_ROUTER_OK)
 		{
 			if (status == OD_ROUTER_ERROR_TIMEDOUT)
@@ -322,7 +311,7 @@ od_frontend_setup(od_client_t *client)
 	if (rc == -1)
 		return OD_ECLIENT_WRITE;
 
-	if (instance->config.log_session) {
+	if (instance->config->log_session) {
 		client->time_setup = machine_time_us();
 		od_log(&instance->logger, "setup", client, NULL,
 		       "login time: %d microseconds",
@@ -452,7 +441,7 @@ od_frontend_remote_server(od_relay_t *relay, char *data, int size)
 	od_instance_t *instance = client->global->instance;
 
 	kiwi_be_type_t type = *data;
-	if (instance->config.log_debug)
+	if (instance->config->log_debug)
 		od_debug(&instance->logger, "main", client, server, "%s",
 		         kiwi_be_type_to_string(type));
 
@@ -486,7 +475,7 @@ od_frontend_remote_server(od_relay_t *relay, char *data, int size)
 		od_stat_query_end(&route->stats, &server->stats_state,
 		                  server->is_transaction,
 		                  &query_time);
-		if (instance->config.log_debug && query_time > 0) {
+		if (instance->config->log_debug && query_time > 0) {
 			od_debug(&instance->logger, "main", server->client, server,
 			         "query time: %d microseconds",
 			          query_time);
@@ -532,7 +521,7 @@ od_frontend_remote_client(od_relay_t *relay, char *data, int size)
 	od_server_t *server = client->server;
 	assert(server != NULL);
 
-	if (instance->config.log_debug)
+	if (instance->config->log_debug)
 		od_debug(&instance->logger, "main", client, server, "%s",
 		         kiwi_fe_type_to_string(type));
 
@@ -672,7 +661,7 @@ od_frontend_remote(od_client_t *client)
 			/* push server connection back to route pool */
 			od_router_t *router = client->global->router;
 			od_instance_t *instance = client->global->instance;
-			od_router_detach(router, &instance->config, client);
+			od_router_detach(router, instance->config, client);
 			server = NULL;
 		} else
 		if (status != OD_OK) {
@@ -714,7 +703,7 @@ od_frontend_cleanup(od_client_t *client, char *context,
 	case OD_STOP:
 	case OD_OK:
 		/* graceful disconnect or kill */
-		if (instance->config.log_session) {
+		if (instance->config->log_session) {
 			od_log(&instance->logger, context, client, server,
 			       "client disconnected");
 		}
@@ -728,7 +717,7 @@ od_frontend_cleanup(od_client_t *client, char *context,
 			break;
 		}
 		/* push server to router server pool */
-		od_router_detach(router, &instance->config, client);
+		od_router_detach(router, instance->config, client);
 		break;
 
 	case OD_EOOM:
@@ -761,7 +750,7 @@ od_frontend_cleanup(od_client_t *client, char *context,
 			break;
 		}
 		/* push server to router server pool */
-		od_router_detach(router, &instance->config, client);
+		od_router_detach(router, instance->config, client);
 		break;
 
 	case OD_ESERVER_CONNECT:
@@ -808,7 +797,7 @@ od_frontend(void *arg)
 	od_router_t *router = client->global->router;
 
 	/* log client connection */
-	if (instance->config.log_session) {
+	if (instance->config->log_session) {
 		char peer[128];
 		od_getpeername(client->io.io, peer, sizeof(peer), 1, 1);
 		od_log(&instance->logger, "startup", client, NULL,
@@ -874,7 +863,7 @@ od_frontend(void *arg)
 
 	/* route client */
 	od_router_status_t router_status;
-	router_status = od_router_route(router, &instance->config, client);
+	router_status = od_router_route(router, instance->config, client);
 	switch (router_status) {
 	case OD_ROUTER_ERROR:
 		od_error(&instance->logger, "startup", client, NULL,
@@ -904,7 +893,7 @@ od_frontend(void *arg)
 	case OD_ROUTER_OK:
 	{
 		od_route_t *route = client->route;
-		if (instance->config.log_session) {
+		if (instance->config->log_session) {
 			od_log(&instance->logger, "startup", client, NULL,
 			       "route '%s.%s' to '%s.%s'",
 			       client->startup.database.value,

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -5,22 +5,12 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
+#include <c.h>
 #include <signal.h>
 #include <errno.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 void
@@ -28,7 +18,9 @@ od_instance_init(od_instance_t *instance)
 {
 	od_pid_init(&instance->pid);
 	od_logger_init(&instance->logger, &instance->pid);
-	od_config_init(&instance->config);
+
+	instance->top_mcxt = mcxt_new(NULL);
+	instance->config = od_config_allocate(instance->top_mcxt);
 	instance->config_file = NULL;
 
 	sigset_t mask;
@@ -43,10 +35,11 @@ od_instance_init(od_instance_t *instance)
 void
 od_instance_free(od_instance_t *instance)
 {
-	if (instance->config.pid_file)
-		od_pid_unlink(&instance->pid, instance->config.pid_file);
-	od_config_free(&instance->config);
+	if (instance->config->pid_file)
+		od_pid_unlink(&instance->pid, instance->config->pid_file);
+	od_config_free(instance->config);
 	od_logger_close(&instance->logger);
+	mcxt_delete(instance->top_mcxt);
 	machinarium_free();
 }
 
@@ -72,7 +65,7 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	od_global_t      global;
 
 	od_system_init(&system);
-	od_router_init(&router);
+	od_router_init(instance->top_mcxt, &router);
 	od_cron_init(&cron);
 	od_worker_pool_init(&worker_pool);
 	od_global_init(&global, instance, &system, &router, &cron, &worker_pool);
@@ -93,7 +86,9 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	od_error_t error;
 	od_error_init(&error);
 	int rc;
-	rc = od_config_reader_import(&instance->config, &router.rules, &error, instance->config_file);
+	rc = od_config_reader_import(instance->config, &router.rules, &error,
+		instance->config_file, instance->top_mcxt);
+
 	if (rc == -1) {
 		od_error(&instance->logger, "config", NULL, NULL,
 		         "%s", error.error);
@@ -101,22 +96,22 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	}
 
 	/* validate configuration */
-	rc = od_config_validate(&instance->config, &instance->logger);
+	rc = od_config_validate(instance->config, &instance->logger);
 	if (rc == -1)
 		return -1;
 
 	/* validate rules */
-	rc = od_rules_validate(&router.rules, &instance->config, &instance->logger);
+	rc = od_rules_validate(&router.rules, instance->config, &instance->logger);
 	if (rc == -1)
 		return -1;
 
 	/* configure logger */
-	od_logger_set_format(&instance->logger, instance->config.log_format);
-	od_logger_set_debug(&instance->logger, instance->config.log_debug);
-	od_logger_set_stdout(&instance->logger, instance->config.log_to_stdout);
+	od_logger_set_format(&instance->logger, instance->config->log_format);
+	od_logger_set_debug(&instance->logger, instance->config->log_debug);
+	od_logger_set_stdout(&instance->logger, instance->config->log_to_stdout);
 
 	/* run as daemon */
-	if (instance->config.daemonize) {
+	if (instance->config->daemonize) {
 		rc = od_daemonize();
 		if (rc == -1)
 			return -1;
@@ -125,21 +120,21 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	}
 
 	/* reopen log file after config parsing */
-	if (instance->config.log_file) {
-		rc = od_logger_open(&instance->logger, instance->config.log_file);
+	if (instance->config->log_file) {
+		rc = od_logger_open(&instance->logger, instance->config->log_file);
 		if (rc == -1) {
 			od_error(&instance->logger, "init", NULL, NULL,
 			         "failed to open log file '%s'",
-			         instance->config.log_file);
+			         instance->config->log_file);
 			return -1;
 		}
 	}
 
 	/* syslog */
-	if (instance->config.log_syslog) {
+	if (instance->config->log_syslog) {
 		od_logger_open_syslog(&instance->logger,
-		                      instance->config.log_syslog_ident,
-		                      instance->config.log_syslog_facility);
+		                      instance->config->log_syslog_ident,
+		                      instance->config->log_syslog_facility);
 	}
 	od_log(&instance->logger, "init", NULL, NULL, "odyssey (git: %s %s)",
 	       OD_VERSION_GIT,
@@ -151,15 +146,15 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	       instance->config_file);
 	od_log(&instance->logger, "init", NULL, NULL, "");
 
-	if (instance->config.log_config) {
-		od_config_print(&instance->config, &instance->logger);
+	if (instance->config->log_config) {
+		od_config_print(instance->config, &instance->logger);
 		od_rules_print(&router.rules, &instance->logger);
 	}
 
 	/* set process priority */
-	if (instance->config.priority != 0) {
+	if (instance->config->priority != 0) {
 		int rc;
-		rc = setpriority(PRIO_PROCESS, 0, instance->config.priority);
+		rc = setpriority(PRIO_PROCESS, 0, instance->config->priority);
 		if (rc == -1) {
 			od_error(&instance->logger, "init", NULL, NULL,
 			         "failed to set process priority: %s", strerror(errno));
@@ -167,10 +162,10 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	}
 
 	/* initialize machinarium */
-	machinarium_set_stack_size(instance->config.coroutine_stack_size);
-	machinarium_set_pool_size(instance->config.resolvers);
-	machinarium_set_coroutine_cache_size(instance->config.cache_coroutine);
-	machinarium_set_msg_cache_gc_size(instance->config.cache_msg_gc_size);
+	machinarium_set_stack_size(instance->config->coroutine_stack_size);
+	machinarium_set_pool_size(instance->config->resolvers);
+	machinarium_set_coroutine_cache_size(instance->config->cache_coroutine);
+	machinarium_set_msg_cache_gc_size(instance->config->cache_msg_gc_size);
 	rc = machinarium_init();
 	if (rc == -1) {
 		od_error(&instance->logger, "init", NULL, NULL,
@@ -179,8 +174,8 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 	}
 
 	/* create pid file */
-	if (instance->config.pid_file)
-		od_pid_create(&instance->pid, instance->config.pid_file);
+	if (instance->config->pid_file)
+		od_pid_create(&instance->pid, instance->config->pid_file);
 
 	/* start system machine thread */
 	rc = od_system_start(&system, &global);
@@ -188,5 +183,6 @@ od_instance_main(od_instance_t *instance, int argc, char **argv)
 		return -1;
 
 	machine_wait(system.machine);
+
 	return 0;
 }

--- a/sources/instance.h
+++ b/sources/instance.h
@@ -14,7 +14,9 @@ struct od_instance
 	od_pid_t     pid;
 	od_logger_t  logger;
 	char        *config_file;
-	od_config_t  config;
+	od_config_t	*config;
+
+	mcxt_context_t	top_mcxt;
 };
 
 void od_instance_init(od_instance_t*);

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -5,15 +5,7 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
+#include <c.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -22,8 +14,6 @@
 #include <time.h>
 #include <syslog.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 typedef struct

--- a/sources/main.c
+++ b/sources/main.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 int main(int argc, char *argv[])

--- a/sources/odyssey.h
+++ b/sources/odyssey.h
@@ -7,6 +7,13 @@
  * Scalable PostgreSQL connection pooler.
 */
 
+#include <c.h>
+
+// common
+#include <memcontext.h>
+#include <machinarium.h>
+#include <kiwi.h>
+
 #include "sources/macro.h"
 #include "sources/version.h"
 #include "sources/atomic.h"

--- a/sources/pid.c
+++ b/sources/pid.c
@@ -5,23 +5,14 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
 
+#include <c.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 void

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 int

--- a/sources/route.h
+++ b/sources/route.h
@@ -11,6 +11,7 @@ typedef struct od_route od_route_t;
 
 struct od_route
 {
+	mcxt_context_t		mcxt;
 	od_rule_t          *rule;
 	od_route_id_t       id;
 	od_stat_t           stats;
@@ -43,23 +44,26 @@ od_route_init(od_route_t *route)
 static inline void
 od_route_free(od_route_t *route)
 {
-	od_route_id_free(&route->id);
 	od_server_pool_free(&route->server_pool);
 	kiwi_params_lock_free(&route->params);
 	if (route->wait_bus)
 		machine_channel_free(route->wait_bus);
 	pthread_mutex_destroy(&route->lock);
-	free(route);
+	mcxt_delete(route->mcxt);
 }
 
 static inline od_route_t*
-od_route_allocate(int is_shared)
+od_route_allocate(mcxt_context_t mcxt, int is_shared)
 {
-	od_route_t *route = malloc(sizeof(*route));
+	mcxt_context_t route_mcxt = mcxt_new(mcxt);
+	od_route_t *route = mcxt_alloc_mem(route_mcxt, sizeof(*route), true);
 	if (route == NULL)
 		return NULL;
+
 	od_route_init(route);
 	route->wait_bus = machine_channel_create(is_shared);
+	route->mcxt = route_mcxt;
+
 	if (route->wait_bus == NULL) {
 		od_route_free(route);
 		return NULL;

--- a/sources/route_id.h
+++ b/sources/route_id.h
@@ -28,31 +28,22 @@ od_route_id_init(od_route_id_t *id)
 	id->physical_rep = false;
 }
 
-static inline void
-od_route_id_free(od_route_id_t *id)
-{
-	if (id->database)
-		free(id->database);
-	if (id->user)
-		free(id->user);
-}
-
 static inline int
 od_route_id_copy(od_route_id_t *dest, od_route_id_t *id)
 {
-	dest->database = malloc(id->database_len);
+	dest->database_len = id->database_len;
+	dest->database = mcxt_strdup(id->database);
 	if (dest->database == NULL)
 		return -1;
-	memcpy(dest->database, id->database, id->database_len);
-	dest->database_len = id->database_len;
-	dest->user = malloc(id->user_len);
+
+	dest->user_len = id->user_len;
+	dest->user = mcxt_strdup(id->user);
+
 	if (dest->user == NULL) {
-		free(dest->database);
+		mcxt_free(dest->database);
 		dest->database = NULL;
 		return -1;
 	}
-	memcpy(dest->user, id->user, id->user_len);
-	dest->user_len = id->user_len;
 	dest->physical_rep = id->physical_rep;
 	return 0;
 }

--- a/sources/router.h
+++ b/sources/router.h
@@ -21,6 +21,7 @@ typedef enum
 
 struct od_router
 {
+	mcxt_context_t	mcxt;
 	pthread_mutex_t lock;
 	od_rules_t      rules;
 	od_route_pool_t route_pool;
@@ -39,7 +40,7 @@ od_router_unlock(od_router_t *router)
 	pthread_mutex_unlock(&router->lock);
 }
 
-void od_router_init(od_router_t*);
+void od_router_init(mcxt_context_t, od_router_t*);
 void od_router_free(od_router_t*);
 int  od_router_reconfigure(od_router_t*, od_rules_t*);
 int  od_router_expire(od_router_t*, od_list_t*);

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -47,6 +47,7 @@ typedef enum
 
 struct od_rule_storage
 {
+	mcxt_context_t			mcxt;
 	char                   *name;
 	char                   *type;
 	od_rule_storage_type_t  storage_type;
@@ -69,6 +70,8 @@ struct od_rule_auth
 
 struct od_rule
 {
+	mcxt_context_t			mcxt;
+
 	/* versioning */
 	int                     mark;
 	int                     obsolete;
@@ -119,11 +122,13 @@ struct od_rule
 
 struct od_rules
 {
+	mcxt_context_t	mcxt;
+
 	od_list_t storages;
 	od_list_t rules;
 };
 
-void od_rules_init(od_rules_t*);
+void od_rules_init(mcxt_context_t mcxt, od_rules_t*);
 void od_rules_free(od_rules_t*);
 int  od_rules_validate(od_rules_t*, od_config_t*, od_logger_t*);
 int  od_rules_merge(od_rules_t*, od_rules_t*);
@@ -150,14 +155,12 @@ od_rule_storage_t*
 od_rules_storage_match(od_rules_t*, char*);
 
 od_rule_storage_t*
-od_rules_storage_copy(od_rule_storage_t*);
+od_rules_storage_copy(mcxt_context_t, od_rule_storage_t*);
 
 void od_rules_storage_free(od_rule_storage_t*);
 
 /* auth */
 od_rule_auth_t*
 od_rules_auth_add(od_rule_t*);
-
-void od_rules_auth_free(od_rule_auth_t*);
 
 #endif /* ODYSSEY_RULES_H */

--- a/sources/tls.c
+++ b/sources/tls.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 machine_tls_t*

--- a/sources/worker.c
+++ b/sources/worker.c
@@ -5,17 +5,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <inttypes.h>
-#include <assert.h>
-
-#include <machinarium.h>
-#include <kiwi.h>
 #include <odyssey.h>
 
 static inline void
@@ -107,7 +96,7 @@ od_worker_start(od_worker_t *worker)
 	od_instance_t *instance = worker->global->instance;
 
 	int is_shared;
-	is_shared = od_config_is_multi_workers(&instance->config);
+	is_shared = od_config_is_multi_workers(instance->config);
 
 	worker->task_channel = machine_channel_create(is_shared);
 	if (worker->task_channel == NULL) {

--- a/third_party/memcontext/.gitignore
+++ b/third_party/memcontext/.gitignore
@@ -1,0 +1,1 @@
+src/memconsts.h

--- a/third_party/memcontext/CMakeLists.txt
+++ b/third_party/memcontext/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.5)
+project(libmemcontext VERSION 1.0.0 LANGUAGES C)
+
+# main library
+set(src
+	src/memcontext.c
+)
+
+add_library(memcontext ${src})
+target_compile_options(memcontext PRIVATE -Werror -Wall -Wextra)
+target_compile_features(memcontext PRIVATE c_std_11)
+option(MCXT_CHECK "add additinal checking fields and valgrind support" OFF)
+option(MCXT_TESTS "add additinal checking fields and valgrind support" ON)
+
+if (MCXT_CHECK)
+	find_package(PkgConfig)
+	pkg_check_modules(VALGRIND valgrind)
+endif()
+
+include(CheckTypeSize)
+check_type_size("void*" SIZEOF_VOID_P)
+configure_file(src/memconsts.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/memconsts.h)
+
+find_package (Threads)
+target_link_libraries(memcontext Threads::Threads)
+
+
+target_include_directories(memcontext
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+		${VALGRIND_INCLUDEDIR}
+)
+
+if (MCXT_CHECK)
+	message(STATUS "Memory contexts check mode: ON")
+else()
+	message(STATUS "Memory contexts check mode: OFF")
+endif()
+
+if (MCXT_TESTS)
+	message(STATUS "Memory contexts build tests: ON")
+	find_package(cmocka 1.1.3)
+
+	list(APPEND tests_names "test_memcontext")
+	list(APPEND tests_options "-Wall -Werror -Wextra")
+	list(APPEND tests_link "-Wl,--wrap,free")
+
+	# declare all tests targets
+	list(LENGTH tests_names count)
+	math(EXPR count "${count} - 1")
+	foreach(i RANGE ${count})
+		list(GET tests_names ${i} test_name)
+		list(GET tests_options ${i} test_options)
+		list(GET tests_link ${i} test_link)
+		add_executable(${test_name} src/${test_name}.c)
+		target_include_directories(${test_name}
+			PUBLIC
+				$<INSTALL_INTERFACE:include>
+				$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+			PRIVATE
+				${CMAKE_CURRENT_SOURCE_DIR}/src
+				${VALGRIND_INCLUDEDIR}
+		)
+		target_link_libraries(
+			${test_name}
+			cmocka
+			-fprofile-arcs
+			memcontext
+			${test_link}
+		)
+		target_compile_features(${test_name}
+			PRIVATE c_std_11
+		)
+		add_test(${test_name} ${test_name})
+	endforeach()
+	enable_testing()
+endif()

--- a/third_party/memcontext/include/memcontext.h
+++ b/third_party/memcontext/include/memcontext.h
@@ -1,0 +1,81 @@
+#ifndef MEMCONTEXT_H
+#define MEMCONTEXT_H
+
+#include <stdbool.h>
+
+typedef struct mcxt_memory_chunk		*mcxt_chunk_t;
+typedef struct mcxt_context_data		*mcxt_context_t;
+typedef struct mcxt_context_callback	 mcxt_context_callback_t;
+
+typedef void (*mcxt_callback_function) (void *arg);
+struct mcxt_context_callback
+{
+	mcxt_callback_function func;		/* function to call */
+	void	   *arg;					/* argument to pass it */
+	mcxt_context_callback_t *next;		/* next in list of callbacks */
+};
+
+struct mcxt_context_data
+{
+	uint32_t		lock;
+	mcxt_context_t	parent;
+	mcxt_context_t	firstchild;			/* link to first child */
+	mcxt_context_t	prevchild;			/* prev parent's child */
+	mcxt_context_t	nextchild;			/* next parent's child */
+	mcxt_chunk_t	lastchunk;			/* list of allocated chunks */
+	mcxt_context_callback_t *reset_cbs;	/* list of reset/delete callbacks */
+#ifdef MCXT_CHECK
+	pthread_t		ptid;				/* id of owner thread */
+#endif
+};
+
+extern __thread mcxt_context_t current_mcxt;
+
+mcxt_context_t mcxt_new(mcxt_context_t parent);
+mcxt_context_t mcxt_switch_to(mcxt_context_t to);
+
+void mcxt_reset(mcxt_context_t context, bool recursive);
+void mcxt_delete(mcxt_context_t context);
+void *mcxt_alloc_mem(mcxt_context_t context, size_t size, bool zero);
+void *mcxt_realloc(void *ptr, size_t size);
+void mcxt_free_mem(mcxt_context_t context, void *p);
+void mcxt_clean_reset_callbacks(mcxt_context_t context);
+void mcxt_add_reset_callback(mcxt_context_t context, mcxt_callback_function func, void *arg);
+
+int mcxt_chunks_count(mcxt_context_t context);
+char *mcxt_strdup_in(mcxt_context_t context, const char *string);
+
+static inline void *mcxt_alloc(size_t size)
+{
+	assert(current_mcxt != NULL);
+	return mcxt_alloc_mem(current_mcxt, size, false);
+}
+
+static inline void *mcxt_alloc0(size_t size)
+{
+	assert(current_mcxt != NULL);
+	return mcxt_alloc_mem(current_mcxt, size, true);
+}
+
+static inline void mcxt_free(void *p)
+{
+	mcxt_context_t context = *((mcxt_context_t *) ((char *) p - sizeof(void *)));
+	mcxt_free_mem(context, p);
+}
+
+static inline char *mcxt_strdup(const char *string)
+{
+	assert(current_mcxt != NULL);
+	return mcxt_strdup_in(current_mcxt, string);
+}
+
+#ifdef MCXT_CHECK
+void mcxt_incr_refcount(void *ptr);
+void mcxt_decr_refcount(void *ptr);
+void mcxt_check(void *ptr, void *context, int refcount);
+#else
+#define mcxt_incr_refcount(ptr)
+#define mcxt_decr_refcount(ptr)
+#endif
+
+#endif

--- a/third_party/memcontext/src/memconsts.h.in
+++ b/third_party/memcontext/src/memconsts.h.in
@@ -1,0 +1,8 @@
+#ifndef MEMCONSTS_IN
+#define MEMCONSTS_IN
+
+/* The size of `size_t', as computed by sizeof. */
+#cmakedefine SIZEOF_VOID_P		${SIZEOF_VOID_P}
+#cmakedefine VALGRIND_VERSION	${VALGRIND_VERSION}
+
+#endif

--- a/third_party/memcontext/src/memcontext.c
+++ b/third_party/memcontext/src/memcontext.c
@@ -1,0 +1,306 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "sleep_lock.h"
+#include "memconsts.h"
+#include "memcontext.h"
+#include "memutils.h"
+
+__thread mcxt_context_t current_mcxt = NULL;
+
+/* Append chunk at the end of list of chunks */
+static inline void
+mcxt_append_chunk(mcxt_context_t context, mcxt_chunk_t chunk)
+{
+	mcxt_chunk_t		lastchunk;
+
+	lastchunk = context->lastchunk;
+	if (lastchunk)
+		lastchunk->next = chunk;
+
+	context->lastchunk = chunk;
+	chunk->prev = lastchunk;
+	chunk->next = NULL;
+}
+
+/* Link child context to parent context */
+static void mcxt_link_context(mcxt_context_t parent, mcxt_context_t new)
+{
+	mm_sleeplock_lock(&parent->lock);
+	if (parent->firstchild == NULL)
+		parent->firstchild = new;
+	else
+	{
+		mcxt_context_t	child;
+
+		/* find latest child */
+		for (child = parent->firstchild; child->nextchild != NULL;
+				child = child->nextchild);
+
+		child->nextchild = new;
+		new->prevchild = child;
+	}
+	mm_sleeplock_unlock(&parent->lock);
+}
+
+/* New memory context */
+mcxt_context_t mcxt_new(mcxt_context_t parent)
+{
+	mcxt_chunk_t chunk = calloc(MEMORY_CHUNK_SIZE +
+		sizeof(struct mcxt_context_data), 1);
+	mcxt_context_t new = ChunkDataOffset(chunk);
+	memset(chunk, 0, sizeof(struct mcxt_context_data) + MEMORY_CHUNK_SIZE);
+
+	if (new == NULL)
+		return NULL;
+
+	new->parent = parent;
+
+#ifdef MCXT_CHECK
+	new->ptid = pthread_self();
+	chunk->chunk_type = mct_context;
+#endif
+
+	/* append to parent's children */
+	if (parent)
+		mcxt_link_context(parent, new);
+
+	return new;
+}
+
+/* Change current memory context */
+mcxt_context_t mcxt_switch_to(mcxt_context_t to)
+{
+	mcxt_context_t	old = current_mcxt;
+	current_mcxt = to;
+	return old;
+}
+
+/* Free all memory in memory context */
+void mcxt_reset(mcxt_context_t context, bool recursive)
+{
+	mcxt_context_callback_t	*cb = context->reset_cbs;
+	mcxt_chunk_t		chunk = context->lastchunk;
+
+	if (recursive)
+	{
+		/* reset children if recursive */
+		mcxt_context_t	child;
+		for (child = context->firstchild; child != NULL; child = child->nextchild)
+		{
+			mcxt_reset(child, true);
+		}
+	}
+
+	/* call reset callbacks */
+	while (cb != NULL)
+	{
+		cb->func(cb->arg);
+		cb = cb->next;
+	}
+
+	while (chunk != NULL)
+	{
+		mcxt_chunk_t prev = chunk->prev;
+		free(chunk);
+		chunk = prev;
+	}
+	context->lastchunk = NULL;
+}
+
+int mcxt_chunks_count(mcxt_context_t context)
+{
+	int			count = 0;
+	mcxt_chunk_t chunk = context->lastchunk;
+	while (chunk != NULL)
+	{
+		count++;
+		chunk = chunk->prev;
+	}
+	return count;
+}
+
+static void mcxt_unlink_context(mcxt_context_t context)
+{
+	if (context->parent == NULL)
+	{
+		assert(context->prevchild == NULL);
+		assert(context->nextchild == NULL);
+		return;
+	}
+
+	mm_sleeplock_lock(&context->parent->lock);
+
+	if (context->prevchild)
+		context->prevchild->nextchild = context->nextchild;
+	else
+		context->parent->firstchild = context->nextchild;
+
+	if (context->nextchild)
+		context->nextchild->prevchild = context->prevchild;
+
+	mm_sleeplock_unlock(&context->parent->lock);
+}
+
+/* Delete memory context, all its chunks and childs */
+void mcxt_delete(mcxt_context_t context)
+{
+	mcxt_context_t	child;
+
+	assert(current_mcxt != context);
+#ifdef MCXT_CHECK
+	assert(GetMemoryChunk(context)->chunk_type == mct_context);
+#endif
+
+	mcxt_unlink_context(context);
+
+	for (child = context->firstchild; child != NULL; child = child->nextchild)
+	{
+		mcxt_delete(child);
+	}
+
+	mcxt_reset(context, false);
+	mcxt_clean_reset_callbacks(context);
+	free(GetMemoryChunk(context));
+}
+
+/*
+ * Allocate memory in specified memory context,
+ * we don't have locks here since we assume that threads should not use same
+ * memory contexts for allocations.
+ */
+void *mcxt_alloc_mem(mcxt_context_t context, size_t size, bool zero)
+{
+	mcxt_chunk_t		chunk;
+
+	assert(context);
+	chunk = malloc(MEMORY_CHUNK_SIZE + size);
+	if (chunk == NULL)
+		return NULL;
+
+	if (zero)
+		memset(chunk, 0, MEMORY_CHUNK_SIZE + size);
+
+#ifdef MCXT_CHECK
+	assert(context->ptid == pthread_self());
+	chunk->chunk_type = mct_alloc;
+	chunk->refcount = 0;
+#endif
+
+	chunk->prev = chunk->next = NULL;
+	chunk->context = context;
+	mcxt_append_chunk(context, chunk);
+
+	VALGRIND_MAKE_MEM_DEFINED(chunk, MEMORY_CHUNK_SIZE);
+	return ChunkDataOffset(chunk);
+}
+
+void *mcxt_realloc(void *ptr, size_t size)
+{
+	mcxt_chunk_t chunk = GetMemoryChunk(ptr);
+	assert(size > MEMORY_CHUNK_SIZE);
+	return realloc(chunk, size);
+}
+
+/* Free memory in specified memory context */
+void mcxt_free_mem(mcxt_context_t context, void *p)
+{
+	VALGRIND_CHECK_VALUE_IS_DEFINED(context);
+	VALGRIND_CHECK_VALUE_IS_DEFINED(p);
+
+	mcxt_chunk_t chunk = GetMemoryChunk(p);
+
+	assert(p != NULL);
+	assert(p == (void *) MAXALIGN(p));
+#ifdef MCXT_CHECK
+	assert(chunk->chunk_type == mct_alloc);
+	assert(chunk->refcount == 0);
+#endif
+
+	/* first, deattach from chunks in context */
+	if (chunk->next)
+		chunk->next->prev = chunk->prev;
+	if (chunk->prev)
+		chunk->prev->next = chunk->next;
+	if (chunk == context->lastchunk)
+		context->lastchunk = chunk->prev;
+
+	free(chunk);
+}
+
+char *mcxt_strdup_in(mcxt_context_t context, const char *string)
+{
+	char	   *nstr;
+	size_t		len = strlen(string) + 1;
+
+	nstr = (char *) mcxt_alloc_mem(context, len, false);
+	memcpy(nstr, string, len);
+	return nstr;
+}
+
+/* Add callback for mcxt_reset call on the memory context */
+void mcxt_add_reset_callback(mcxt_context_t context,
+		mcxt_callback_function func, void *arg)
+{
+	mcxt_context_callback_t	*cb,
+							*new;
+
+	new = malloc(sizeof(mcxt_context_callback_t));
+	new->func = func;
+	new->arg = arg;
+	new->next = NULL;
+	mm_sleeplock_lock(&context->lock);
+
+	if (context->reset_cbs == NULL)
+		context->reset_cbs = new;
+	else
+	{
+		/* find end of chain */
+		for (cb = context->reset_cbs; cb->next != NULL;)
+			cb = cb->next;
+
+		cb->next = new;
+	}
+	mm_sleeplock_unlock(&context->lock);
+}
+
+/* Reset all `mcxt_reset` callbacks on the memory context */
+void mcxt_clean_reset_callbacks(mcxt_context_t context)
+{
+	mcxt_context_callback_t *cb;
+
+	mm_sleeplock_lock(&context->lock);
+	cb = context->reset_cbs;
+	context->reset_cbs = NULL;
+
+	while (cb != NULL)
+	{
+		mcxt_context_callback_t *next = cb->next;
+		free(cb);
+		cb = next;
+	}
+	mm_sleeplock_unlock(&context->lock);
+}
+
+#ifdef MCXT_CHECK
+void mcxt_incr_refcount(void *ptr)
+{
+	GetMemoryChunk(ptr)->refcount++;
+}
+
+void mcxt_decr_refcount(void *ptr)
+{
+	GetMemoryChunk(ptr)->refcount--;
+}
+void mcxt_check(void *ptr, void *context, int refcount)
+{
+	assert(GetMemoryChunk(ptr)->context == context);
+	assert(GetMemoryChunk(ptr)->refcount == refcount);
+}
+#endif

--- a/third_party/memcontext/src/memutils.h
+++ b/third_party/memcontext/src/memutils.h
@@ -1,0 +1,47 @@
+#ifndef MEMUTILS_H
+#define MEMUTILS_H
+
+#ifdef MCXT_CHECK
+#include "memcheck.h"
+#else
+#define VALGRIND_MAKE_MEM_DEFINED(ptr,size)
+#define VALGRIND_CHECK_VALUE_IS_DEFINED(ptr)
+#endif
+
+#define MAXIMUM_ALIGNOF 8
+#define TYPEALIGN(ALIGNVAL,LEN)  \
+	(((uintptr_t) (LEN) + ((ALIGNVAL) - 1)) & ~((uintptr_t) ((ALIGNVAL) - 1)))
+
+#define MAXALIGN(LEN)	TYPEALIGN(MAXIMUM_ALIGNOF, (LEN))
+
+typedef enum __attribute__ ((__packed__)) {
+	mct_alloc		= 0x01,
+	mct_context		= 0x02
+} mcxt_chunk_type;
+
+static_assert(sizeof(mcxt_chunk_type) == 1, "enum size should be 1");
+
+struct mcxt_memory_chunk
+{
+	mcxt_chunk_t		prev;
+	mcxt_chunk_t		next;
+#ifdef MCXT_CHECK
+	uint16_t			refcount;
+	mcxt_chunk_type		chunk_type;
+#define ALLOCCHUNK_RAWSIZE  (1 + SIZEOF_VOID_P * 2 + 2)
+#else
+#define ALLOCCHUNK_RAWSIZE  (SIZEOF_VOID_P * 2)
+#endif
+
+	/* ensure proper alignment by adding padding if needed */
+#if (ALLOCCHUNK_RAWSIZE % MAXIMUM_ALIGNOF) != 0
+	char	padding[MAXIMUM_ALIGNOF - ALLOCCHUNK_RAWSIZE % MAXIMUM_ALIGNOF];
+#endif
+	mcxt_context_t		context;
+};
+
+#define MEMORY_CHUNK_SIZE (MAXALIGN(sizeof(struct mcxt_memory_chunk)))
+#define GetMemoryChunk(p) ((mcxt_chunk_t)((char *)(p) - MEMORY_CHUNK_SIZE))
+#define ChunkDataOffset(c) ((void *)((char *)(c) + MEMORY_CHUNK_SIZE))
+
+#endif

--- a/third_party/memcontext/src/sleep_lock.h
+++ b/third_party/memcontext/src/sleep_lock.h
@@ -1,0 +1,45 @@
+#ifndef MM_SLEEP_LOCK_H
+#define MM_SLEEP_LOCK_H
+
+/*
+ * machinarium.
+ *
+ * cooperative multitasking engine.
+*/
+
+typedef unsigned int mm_sleeplock_t;
+
+#if defined(__x86_64__) || defined(__i386) || defined(_X86_)
+#  define MM_SLEEPLOCK_BACKOFF __asm__ ("pause")
+#else
+#  define MM_SLEEPLOCK_BACKOFF
+#endif
+
+static inline void
+mm_sleeplock_init(mm_sleeplock_t *lock)
+{
+	*lock = 0;
+}
+
+static inline void
+mm_sleeplock_lock(mm_sleeplock_t *lock)
+{
+	if (__sync_lock_test_and_set(lock, 1) != 0) {
+		unsigned int spin_count = 0U;
+		for (;;) {
+			MM_SLEEPLOCK_BACKOFF;
+			if (*lock == 0U && __sync_lock_test_and_set(lock, 1) == 0)
+				break;
+			if (++spin_count > 30U)
+				usleep(1);
+		}
+	}
+}
+
+static inline void
+mm_sleeplock_unlock(mm_sleeplock_t *lock)
+{
+	__sync_lock_release(lock);
+}
+
+#endif /* MM_SLEEP_LOCK_H */

--- a/third_party/memcontext/src/test_memcontext.c
+++ b/third_party/memcontext/src/test_memcontext.c
@@ -1,0 +1,335 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <cmocka.h>
+#include <pthread.h>
+#include <malloc.h>
+
+#include "sleep_lock.h"
+#include "memcontext.h"
+#include "memutils.h"
+
+static volatile int free_called = 0;
+
+void __real_free(void *ptr);
+void __wrap_free(void *ptr)
+{
+	free_called += (int) mock();
+	__real_free(ptr);
+}
+
+static void test_consistency(void **state) {
+	mcxt_context_t	top = mcxt_new(NULL),
+					old,
+					child1 = mcxt_new(top),
+					child2 = mcxt_new(top);
+
+	assert_ptr_equal(current_mcxt, NULL);
+	old = mcxt_switch_to(top);
+	assert_ptr_equal(old, NULL);
+	assert_ptr_equal(current_mcxt, top);
+
+	/* top */
+	assert_ptr_equal(top->firstchild, child1);
+	assert_ptr_equal(top->nextchild, NULL);
+	assert_ptr_equal(top->prevchild, NULL);
+
+	/* child */
+	assert_ptr_equal(child1->parent, top);
+	assert_ptr_equal(child1->firstchild, NULL);
+	assert_ptr_equal(child1->nextchild, child2);
+	assert_ptr_equal(child1->prevchild, NULL);
+	assert_ptr_equal(child1->lastchunk, NULL);
+
+	/* child2 */
+	assert_ptr_equal(child2->parent, top);
+	assert_ptr_equal(child2->firstchild, NULL);
+	assert_ptr_equal(child2->nextchild, NULL);
+	assert_ptr_equal(child2->prevchild, child1);
+	assert_ptr_equal(child2->lastchunk, NULL);
+
+	old = mcxt_switch_to(old);
+	assert_ptr_equal(old, top);
+	assert_ptr_equal(current_mcxt, NULL);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+static void test_allocation(void **state) {
+	mcxt_chunk_t		chunk,
+					chunk2,
+					chunk3;
+	mcxt_context_t	top = mcxt_new(NULL);
+	char		   *block3;
+
+	chunk = GetMemoryChunk(mcxt_alloc_mem(top, 100, false));
+#ifdef MCXT_PROTECTION_CHECK
+	assert_true(chunk->chunk_type == mct_alloc);
+#endif
+	assert_true(chunk->context == top);
+	assert_true(malloc_usable_size(chunk) >= MEMORY_CHUNK_SIZE + 100);
+	assert_ptr_equal(top->lastchunk, chunk);
+
+	chunk2 = GetMemoryChunk(mcxt_alloc_mem(top, 130, false));
+	assert_ptr_equal(top->lastchunk, chunk2);
+	assert_ptr_equal(chunk2->prev, chunk);
+	assert_ptr_equal(chunk2->next, NULL);
+	assert_true(malloc_usable_size(chunk2) >= MEMORY_CHUNK_SIZE + 130);
+
+	assert_ptr_equal(chunk->next, chunk2);
+	assert_ptr_equal(chunk->prev, NULL);
+
+	block3 = mcxt_alloc_mem(top, 10, true);
+	chunk3 = GetMemoryChunk(block3);
+	assert_ptr_equal(top->lastchunk, chunk3);
+	assert_ptr_equal(chunk3->prev, chunk2);
+	assert_ptr_equal(chunk3->next, NULL);
+	assert_ptr_equal(chunk2->next, chunk3);
+	assert_ptr_equal(chunk2->prev, chunk);
+
+	for (int i = 0; i < 10; i++)
+		assert_true(block3[i] == '\0');
+
+	will_return_always(__wrap_free, 1);
+	free_called = 0;
+
+	mcxt_reset(top, false);
+	assert_ptr_equal(top->lastchunk, NULL);
+	assert_int_equal(free_called, 3);
+
+	mcxt_delete(top);
+	assert_int_equal(free_called, 4);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+static void test_tree_deletion(void **state) {
+	mcxt_context_t	top = mcxt_new(NULL),
+					child1 = mcxt_new(top),
+					child2 = mcxt_new(top);
+
+	mcxt_new(child1);
+	mcxt_new(child1);
+	mcxt_new(child2);
+
+	will_return_always(__wrap_free, 1);
+	free_called = 0;
+	mcxt_delete(top);
+	assert_int_equal(free_called, 6);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+static void test_part_tree_deletion(void **state) {
+	mcxt_context_t	top = mcxt_new(NULL),
+					child1,
+					child1_1,
+					child2,
+					child2_1,
+					child2_2,
+					child2_3,
+					child2_1_1,
+					child2_1_2,
+					child3;
+
+	will_return_always(__wrap_free, 1);
+
+	assert_ptr_equal(top->firstchild, NULL);
+	assert_ptr_equal(top->nextchild, NULL);
+	assert_ptr_equal(top->prevchild, NULL);
+	assert_ptr_equal(top->parent, NULL);
+
+	child1 = mcxt_new(top);
+	assert_ptr_equal(top->firstchild, child1);
+	assert_ptr_equal(child1->firstchild, NULL);
+	assert_ptr_equal(child1->nextchild, NULL);
+	assert_ptr_equal(child1->prevchild, NULL);
+	assert_ptr_equal(child1->parent, top);
+
+	child1_1 = mcxt_new(child1);
+	assert_ptr_equal(child1->firstchild, child1_1);
+	assert_ptr_equal(child1->nextchild, NULL);
+	assert_ptr_equal(child1->prevchild, NULL);
+	assert_ptr_equal(child1->parent, top);
+
+	assert_ptr_equal(child1_1->firstchild, NULL);
+	assert_ptr_equal(child1_1->nextchild, NULL);
+	assert_ptr_equal(child1_1->prevchild, NULL);
+	assert_ptr_equal(child1_1->parent, child1);
+
+	child2 = mcxt_new(top);
+	assert_ptr_equal(top->firstchild, child1);
+	assert_ptr_equal(child2->firstchild, NULL);
+	assert_ptr_equal(child2->nextchild, NULL);
+	assert_ptr_equal(child2->prevchild, child1);
+	assert_ptr_equal(child2->parent, top);
+
+	assert_ptr_equal(child1->nextchild, child2);
+	assert_ptr_equal(child1->prevchild, NULL);
+	assert_ptr_equal(child1->parent, top);
+
+	free_called = 0;
+	mcxt_delete(child1_1);
+	assert_int_equal(free_called, 1);
+	assert_ptr_equal(child1->firstchild, NULL);
+
+	child2_1 = mcxt_new(child2);
+	child2_2 = mcxt_new(child2);
+	child2_3 = mcxt_new(child2);
+	child2_1_1 = mcxt_new(child2_1);
+	child2_1_2 = mcxt_new(child2_1);
+
+	child3 = mcxt_new(top);
+
+	assert_ptr_equal(child2_1->prevchild, NULL);
+	assert_ptr_equal(child2_1->nextchild, child2_2);
+	assert_ptr_equal(child2_2->prevchild, child2_1);
+	assert_ptr_equal(child2_2->nextchild, child2_3);
+	assert_ptr_equal(child2_3->prevchild, child2_2);
+	assert_ptr_equal(child2_3->nextchild, NULL);
+	assert_ptr_equal(child2_1->firstchild, child2_1_1);
+	assert_ptr_equal(child2_1_1->nextchild, child2_1_2);
+	assert_ptr_equal(child2_1_2->prevchild, child2_1_1);
+
+	free_called = 0;
+	mcxt_delete(child2);
+
+	assert_ptr_equal(top->firstchild, child1);
+	assert_ptr_equal(child1->nextchild, child3);
+	assert_ptr_equal(child1->prevchild, NULL);
+
+	assert_ptr_equal(child3->prevchild, child1);
+	assert_ptr_equal(child3->nextchild, NULL);
+
+	assert_int_equal(free_called, 6);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+static void test_reset(void **state) {
+	mcxt_context_t	top = mcxt_new(NULL),
+					child1 = mcxt_new(top),
+					child2 = mcxt_new(top),
+					old;
+
+	free_called = 0;
+	will_return_always(__wrap_free, 1);
+
+	old = mcxt_switch_to(top);
+	mcxt_alloc(10);
+	mcxt_alloc(10);
+	mcxt_alloc(10);
+	mcxt_switch_to(old);
+
+	old = mcxt_switch_to(child1);
+	mcxt_alloc(10);
+	mcxt_alloc(10);
+	mcxt_switch_to(old);
+
+	old = mcxt_switch_to(child2);
+	mcxt_alloc(10);
+	mcxt_switch_to(old);
+
+	assert_int_equal(mcxt_chunks_count(top), 3);
+	assert_int_equal(mcxt_chunks_count(child1), 2);
+	assert_int_equal(mcxt_chunks_count(child2), 1);
+
+	mcxt_reset(top, false);
+	assert_int_equal(mcxt_chunks_count(top), 0);
+	assert_int_equal(mcxt_chunks_count(child1), 2);
+	assert_int_equal(mcxt_chunks_count(child2), 1);
+
+	mcxt_reset(top, true);
+	assert_int_equal(mcxt_chunks_count(top), 0);
+	assert_int_equal(mcxt_chunks_count(child1), 0);
+	assert_int_equal(mcxt_chunks_count(child2), 0);
+	assert_int_equal(free_called, 6);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+static void test_helpers(void **state) {
+	mcxt_context_t	top = mcxt_new(NULL),
+					child1 = mcxt_new(top),
+					old;
+	mcxt_chunk_t		chunk1,
+					chunk2;
+
+	will_return_always(__wrap_free, 1);
+
+	mcxt_switch_to(top);
+	chunk1 = GetMemoryChunk(mcxt_alloc(10));
+	assert_ptr_equal(chunk1->context, top);
+
+	old = mcxt_switch_to(child1);
+	assert_ptr_equal(old, top);
+	chunk2 = GetMemoryChunk(mcxt_alloc0(10));
+	assert_ptr_equal(chunk2->context, child1);
+	old = mcxt_switch_to(old);
+	assert_ptr_equal(old, child1);
+
+	assert_int_equal(mcxt_chunks_count(top), 1);
+	assert_int_equal(mcxt_chunks_count(child1), 1);
+
+	free_called = 0;
+	mcxt_free(ChunkDataOffset(chunk1));
+	mcxt_free(ChunkDataOffset(chunk2));
+
+	assert_int_equal(free_called, 2);
+	assert_int_equal(mcxt_chunks_count(top), 0);
+	assert_int_equal(mcxt_chunks_count(child1), 0);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+void callback1(void *arg)
+{
+	int	*counter = arg;
+	(*counter)++;
+}
+
+void callback2(void *arg)
+{
+	int	*counter = arg;
+	(*counter)++;
+}
+
+static void test_callbacks(void **state) {
+	int counter1 = 0,
+		counter2 = 0;
+
+	will_return_always(__wrap_free, 1);
+	free_called = 0;
+
+	mcxt_context_t	top = mcxt_new(NULL);
+	mcxt_add_reset_callback(top, callback1, (void *) &counter1);
+	mcxt_add_reset_callback(top, callback2, (void *) &counter2);
+	mcxt_reset(top, true);
+	assert_int_equal(counter1, 1);
+	assert_int_equal(counter2, 1);
+	mcxt_clean_reset_callbacks(top);
+	assert_int_equal(free_called, 2);
+
+	mcxt_reset(top, true);
+	assert_int_equal(counter1, 1);
+	assert_int_equal(counter2, 1);
+
+	(void) state;	/* keep compiler quiet */
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_consistency),
+        cmocka_unit_test(test_helpers),
+        cmocka_unit_test(test_allocation),
+        cmocka_unit_test(test_tree_deletion),
+		cmocka_unit_test(test_part_tree_deletion),
+		cmocka_unit_test(test_reset),
+		cmocka_unit_test(test_helpers),
+		cmocka_unit_test(test_callbacks)
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This pull request adds support of memory contexts for allocated objects. This is first revision of it, and I have moved to memory contexts only od_ objects for now, but it will have meaning for `kiwi` and `machinarium` objects too.

The idea is simple, when we have some scope (client, instance, config, route) it will have associated memory context with it, and all related objects will be allocated in it (including base object). And when we clean for example some `route`, we just remove its memory context and clean all allocated objects in this memory context.

I will be glad to hear some opinions about this pull request.