### PR TITLE
* Corrected SEGFAULT in case of non-existent user in auth_query

### DIFF
--- a/sources/auth.c
+++ b/sources/auth.c
@@ -76,9 +76,11 @@ od_auth_frontend_cleartext(od_client_t *client)
 	kiwi_password_init(&client_password);
 
 	if (client->rule->auth_query) {
+		char peer[128];
+		od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
 		rc = od_auth_query(client->global,
 		                   client->rule,
-		                   client->io.io,
+		                   peer,
 		                   &client->startup.user,
 		                   &client_password);
 		if (rc == -1) {
@@ -92,8 +94,6 @@ od_auth_frontend_cleartext(od_client_t *client)
 			return -1;
 		}
 		if(client_password.password == NULL){
-			char peer[128];
-			od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
 			od_log(&instance->logger, "auth", client, NULL,
 			   "user '%s.%s' incorrect user from %s",
 			   client->startup.database.value,
@@ -189,9 +189,11 @@ od_auth_frontend_md5(od_client_t *client)
 	kiwi_password_init(&query_password);
 
 	if (client->rule->auth_query) {
+		char peer[128];
+		od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
 		rc = od_auth_query(client->global,
 		                   client->rule,
-		                   client->io.io,
+		                   peer,
 		                   &client->startup.user,
 		                   &query_password);
 		if (rc == -1) {
@@ -205,8 +207,6 @@ od_auth_frontend_md5(od_client_t *client)
 			return -1;
 		}
 		if(query_password.password == NULL){
-			char peer[128];
-			od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
 			od_log(&instance->logger, "auth", client, NULL,
 			   "user '%s.%s' incorrect user from %s",
 			   client->startup.database.value,

--- a/sources/auth.c
+++ b/sources/auth.c
@@ -78,7 +78,7 @@ od_auth_frontend_cleartext(od_client_t *client)
 	if (client->rule->auth_query) {
 		rc = od_auth_query(client->global,
 		                   client->rule,
-						   client->io.io,
+		                   client->io.io,
 		                   &client->startup.user,
 		                   &client_password);
 		if (rc == -1) {
@@ -91,17 +91,17 @@ od_auth_frontend_cleartext(od_client_t *client)
 			machine_msg_free(msg);
 			return -1;
 		}
-        if(client_password.password == NULL){
-            char peer[128];
- 		    od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
-            od_log(&instance->logger, "auth", client, NULL,
-               "user '%s.%s' incorrect user from %s",
-               client->startup.database.value,
-               client->startup.user.value,peer);
-            od_frontend_error(client, KIWI_INVALID_PASSWORD,
-                          "incorrect user");
-            return -1;
-        }
+		if(client_password.password == NULL){
+			char peer[128];
+			od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
+			od_log(&instance->logger, "auth", client, NULL,
+			   "user '%s.%s' incorrect user from %s",
+			   client->startup.database.value,
+			   client->startup.user.value,peer);
+			od_frontend_error(client, KIWI_INVALID_PASSWORD,
+			              "incorrect user");
+			return -1;
+		}
 	} else {
 		client_password.password_len = client->rule->password_len + 1;
 		client_password.password     = client->rule->password;
@@ -191,7 +191,7 @@ od_auth_frontend_md5(od_client_t *client)
 	if (client->rule->auth_query) {
 		rc = od_auth_query(client->global,
 		                   client->rule,
-						   client->io.io,
+		                   client->io.io,
 		                   &client->startup.user,
 		                   &query_password);
 		if (rc == -1) {
@@ -204,17 +204,17 @@ od_auth_frontend_md5(od_client_t *client)
 			machine_msg_free(msg);
 			return -1;
 		}
-        if(query_password.password == NULL){
-            char peer[128];
-            od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
-            od_log(&instance->logger, "auth", client, NULL,
-               "user '%s.%s' incorrect user from %s",
-               client->startup.database.value,
-               client->startup.user.value,peer);
-            od_frontend_error(client, KIWI_INVALID_PASSWORD,
-                          "incorrect user");
-            return -1;
-        }
+		if(query_password.password == NULL){
+			char peer[128];
+			od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
+			od_log(&instance->logger, "auth", client, NULL,
+			   "user '%s.%s' incorrect user from %s",
+			   client->startup.database.value,
+			   client->startup.user.value,peer);
+			od_frontend_error(client, KIWI_INVALID_PASSWORD,
+			              "incorrect user");
+			return -1;
+		}
 		query_password.password_len--;
 	} else {
 		query_password.password_len = client->rule->password_len;

--- a/sources/auth.c
+++ b/sources/auth.c
@@ -78,6 +78,7 @@ od_auth_frontend_cleartext(od_client_t *client)
 	if (client->rule->auth_query) {
 		rc = od_auth_query(client->global,
 		                   client->rule,
+						   client->io.io,
 		                   &client->startup.user,
 		                   &client_password);
 		if (rc == -1) {
@@ -90,6 +91,17 @@ od_auth_frontend_cleartext(od_client_t *client)
 			machine_msg_free(msg);
 			return -1;
 		}
+        if(client_password.password == NULL){
+            char peer[128];
+ 		    od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
+            od_log(&instance->logger, "auth", client, NULL,
+               "user '%s.%s' incorrect user from %s",
+               client->startup.database.value,
+               client->startup.user.value,peer);
+            od_frontend_error(client, KIWI_INVALID_PASSWORD,
+                          "incorrect user");
+            return -1;
+        }
 	} else {
 		client_password.password_len = client->rule->password_len + 1;
 		client_password.password     = client->rule->password;
@@ -179,6 +191,7 @@ od_auth_frontend_md5(od_client_t *client)
 	if (client->rule->auth_query) {
 		rc = od_auth_query(client->global,
 		                   client->rule,
+						   client->io.io,
 		                   &client->startup.user,
 		                   &query_password);
 		if (rc == -1) {
@@ -191,6 +204,17 @@ od_auth_frontend_md5(od_client_t *client)
 			machine_msg_free(msg);
 			return -1;
 		}
+        if(query_password.password == NULL){
+            char peer[128];
+            od_getpeername(client->io.io, peer, sizeof(peer), 1, 0);
+            od_log(&instance->logger, "auth", client, NULL,
+               "user '%s.%s' incorrect user from %s",
+               client->startup.database.value,
+               client->startup.user.value,peer);
+            od_frontend_error(client, KIWI_INVALID_PASSWORD,
+                          "incorrect user");
+            return -1;
+        }
 		query_password.password_len--;
 	} else {
 		query_password.password_len = client->rule->password_len;

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -141,7 +141,7 @@ error:
 
 __attribute__((hot)) static inline int
 od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
-                     machine_io_t *io,char *output, int output_len)
+                     char *peer,char *output, int output_len)
 {
 	char *dst_pos = output;
 	char *dst_end = output + output_len;
@@ -160,8 +160,6 @@ od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
 				dst_pos += len;
 			} else if (*format_pos == 'h') {
 				int len;
-				char peer[128];
-				od_getpeername(io, peer, sizeof(peer), 1, 0);
 				len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
 				                    peer);
 				dst_pos += len;			} else {
@@ -189,7 +187,7 @@ od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
 
 int
 od_auth_query(od_global_t *global, od_rule_t *rule,
-              machine_io_t *io, kiwi_var_t *user,
+              char *peer, kiwi_var_t *user,
               kiwi_password_t *password)
 {
 	od_instance_t *instance = global->instance;
@@ -250,7 +248,7 @@ od_auth_query(od_global_t *global, od_rule_t *rule,
 	/* preformat and execute query */
 	char query[512];
 	int  query_len;
-	query_len = od_auth_query_format(rule, user, io, query, sizeof(query));
+	query_len = od_auth_query_format(rule, user, peer, query, sizeof(query));
 
 	rc = od_auth_query_do(server, query, query_len, password);
 	if (rc == -1) {

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -158,13 +158,13 @@ od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
 				len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
 				                  user->value);
 				dst_pos += len;
-            } else if (*format_pos == 'h') {
-                int len;
-                char peer[128];
-                od_getpeername(io, peer, sizeof(peer), 1, 0);
-                len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
-                                    peer);
-                dst_pos += len;			} else {
+			} else if (*format_pos == 'h') {
+				int len;
+				char peer[128];
+				od_getpeername(io, peer, sizeof(peer), 1, 0);
+				len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
+				                    peer);
+				dst_pos += len;			} else {
 				if (od_unlikely((dst_end - dst_pos) < 2))
 					break;
 				dst_pos[0] = '%';

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -141,7 +141,7 @@ error:
 
 __attribute__((hot)) static inline int
 od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
-                     char *output, int output_len)
+                     machine_io_t *io,char *output, int output_len)
 {
 	char *dst_pos = output;
 	char *dst_end = output + output_len;
@@ -158,7 +158,13 @@ od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
 				len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
 				                  user->value);
 				dst_pos += len;
-			} else {
+            } else if (*format_pos == 'h') {
+                int len;
+                char peer[128];
+                od_getpeername(io, peer, sizeof(peer), 1, 0);
+                len = od_snprintf(dst_pos, dst_end - dst_pos, "%s",
+                                    peer);
+                dst_pos += len;			} else {
 				if (od_unlikely((dst_end - dst_pos) < 2))
 					break;
 				dst_pos[0] = '%';
@@ -183,7 +189,7 @@ od_auth_query_format(od_rule_t *rule, kiwi_var_t *user,
 
 int
 od_auth_query(od_global_t *global, od_rule_t *rule,
-              kiwi_var_t *user,
+              machine_io_t *io, kiwi_var_t *user,
               kiwi_password_t *password)
 {
 	od_instance_t *instance = global->instance;
@@ -244,7 +250,7 @@ od_auth_query(od_global_t *global, od_rule_t *rule,
 	/* preformat and execute query */
 	char query[512];
 	int  query_len;
-	query_len = od_auth_query_format(rule, user, query, sizeof(query));
+	query_len = od_auth_query_format(rule, user, io, query, sizeof(query));
 
 	rc = od_auth_query_do(server, query, query_len, password);
 	if (rc == -1) {

--- a/sources/auth_query.h
+++ b/sources/auth_query.h
@@ -7,6 +7,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-int od_auth_query(od_global_t*, od_rule_t*, machine_io_t*, kiwi_var_t*, kiwi_password_t*);
+int od_auth_query(od_global_t*, od_rule_t*, char*, kiwi_var_t*, kiwi_password_t*);
 
 #endif /* ODYSSEY_AUTH_QUERY_H */

--- a/sources/auth_query.h
+++ b/sources/auth_query.h
@@ -7,6 +7,6 @@
  * Scalable PostgreSQL connection pooler.
 */
 
-int od_auth_query(od_global_t*, od_rule_t*, kiwi_var_t*, kiwi_password_t*);
+int od_auth_query(od_global_t*, od_rule_t*, machine_io_t*, kiwi_var_t*, kiwi_password_t*);
 
 #endif /* ODYSSEY_AUTH_QUERY_H */


### PR DESCRIPTION
+ Added ability for host-based authentification a-la pg_hba:
  e.g.
  auth_query "SELECT usename, passwd FROM pg_shadow,pg_hba_net WHERE usename='%u' AND ((pg_shadow.usename=pg_hba_net.username and network >> '%h') OR (SELECT COUNT(*) FROM pg_hba_net WHERE username='%u'))