### PR TITLE
Implement client_max_routing

### DIFF
--- a/odyssey.conf
+++ b/odyssey.conf
@@ -238,6 +238,16 @@ keepalive 7200
 #
 # client_max 100
 
+#
+# Global limit of client connections concurrently being routed.
+# Client connection is being routed after it is accepted and until it's startup
+# message is read and connection is assigned route to the database. Most of the
+# routing time is occupied with TLS handshake.
+#
+# Unset or zero 'client_max_routing' will set it's value equal to 4 * workers
+#
+# client_max_routing 32
+
 ###
 ### LISTEN
 ###

--- a/sources/config.c
+++ b/sources/config.c
@@ -45,10 +45,18 @@ od_config_init(od_config_t *config)
 	config->resolvers            = 1;
 	config->client_max_set       = 0;
 	config->client_max           = 0;
+	config->client_max_routing   = 0;
 	config->cache_coroutine      = 0;
 	config->cache_msg_gc_size    = 0;
 	config->coroutine_stack_size = 4;
 	od_list_init(&config->listen);
+}
+
+void
+od_config_reload(od_config_t *current_config, od_config_t *new_config)
+{
+	current_config->client_max = new_config->client_max;
+	current_config->client_max_routing = new_config->client_max_routing;
 }
 
 static void
@@ -257,6 +265,8 @@ od_config_print(od_config_t *config, od_logger_t *logger)
 	if (config->client_max_set)
 		od_log(logger, "config", NULL, NULL,
 		       "client_max           %d", config->client_max);
+	od_log(logger, "config", NULL, NULL,
+	       "client_max_routing   %d", config->client_max_routing);
 	od_log(logger, "config", NULL, NULL,
 	       "cache_msg_gc_size    %d", config->cache_msg_gc_size);
 	od_log(logger, "config", NULL, NULL,

--- a/sources/config.h
+++ b/sources/config.h
@@ -59,6 +59,7 @@ struct od_config
 	int        resolvers;
 	int        client_max_set;
 	int        client_max;
+	int        client_max_routing;
 	int        cache_coroutine;
 	int        cache_msg_gc_size;
 	int        coroutine_stack_size;
@@ -73,6 +74,7 @@ od_config_is_multi_workers(od_config_t *config)
 
 void od_config_init(od_config_t*);
 void od_config_free(od_config_t*);
+void od_config_reload(od_config_t*, od_config_t*);
 int  od_config_validate(od_config_t*, od_logger_t*);
 void od_config_print(od_config_t*, od_logger_t*);
 

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -64,6 +64,7 @@ enum
 	OD_LCACHE_COROUTINE,
 	OD_LCOROUTINE_STACK_SIZE,
 	OD_LCLIENT_MAX,
+	OD_LCLIENT_MAX_ROUTING,
 	OD_LCLIENT_FWD_ERROR,
 	OD_LTLS,
 	OD_LTLS_CA_FILE,
@@ -148,6 +149,7 @@ od_config_keywords[] =
 	od_keyword("cache_coroutine",      OD_LCACHE_COROUTINE),
 	od_keyword("coroutine_stack_size", OD_LCOROUTINE_STACK_SIZE),
 	od_keyword("client_max",           OD_LCLIENT_MAX),
+	od_keyword("client_max_routing",           OD_LCLIENT_MAX_ROUTING),
 	od_keyword("client_fwd_error",     OD_LCLIENT_FWD_ERROR),
 	od_keyword("tls",                  OD_LTLS),
 	od_keyword("tls_ca_file",          OD_LTLS_CA_FILE),
@@ -951,6 +953,11 @@ od_config_reader_parse(od_config_reader_t *reader)
 				return -1;
 			config->client_max_set = 1;
 			continue;
+		/* client_max_routing */
+		case OD_LCLIENT_MAX_ROUTING:
+			if (! od_config_reader_number(reader, &config->client_max_routing))
+				return -1;
+			continue;
 		/* readahead */
 		case OD_LREADAHEAD:
 			if (! od_config_reader_number(reader, &config->readahead))
@@ -1048,5 +1055,8 @@ od_config_reader_import(od_config_t *config, od_rules_t *rules, od_error_t *erro
 		return -1;
 	rc = od_config_reader_parse(&reader);
 	od_config_reader_close(&reader);
+
+	if (!config->client_max_routing)
+		config->client_max_routing = config->workers * 4;
 	return rc;
 }

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -865,6 +865,7 @@ od_frontend(void *arg)
 		od_io_close(&client->io);
 		machine_close(client->notify_io);
 		od_client_free(client);
+		od_atomic_u32_dec(&router->clients_routing);
 		return;
 	}
 
@@ -875,6 +876,7 @@ od_frontend(void *arg)
 		od_io_close(&client->io);
 		machine_close(client->notify_io);
 		od_client_free(client);
+		od_atomic_u32_dec(&router->clients_routing);
 		return;
 	}
 
@@ -884,6 +886,7 @@ od_frontend(void *arg)
 		od_frontend_error(client, KIWI_TOO_MANY_CONNECTIONS,
 		                  "too many connections");
 		od_frontend_close(client);
+		od_atomic_u32_dec(&router->clients_routing);
 		return;
 	}
 
@@ -891,6 +894,7 @@ od_frontend(void *arg)
 	rc = od_frontend_startup(client);
 	if (rc == -1) {
 		od_frontend_close(client);
+		od_atomic_u32_dec(&router->clients_routing);
 		return;
 	}
 
@@ -907,6 +911,7 @@ od_frontend(void *arg)
 			od_router_cancel_free(&cancel);
 		}
 		od_frontend_close(client);
+		od_atomic_u32_dec(&router->clients_routing);
 		return;
 	}
 
@@ -924,6 +929,10 @@ od_frontend(void *arg)
 	/* route client */
 	od_router_status_t router_status;
 	router_status = od_router_route(router, &instance->config, client);
+
+	/* routing is over */
+	od_atomic_u32_dec(&router->clients_routing);
+
 	switch (router_status) {
 	case OD_ROUTER_ERROR:
 		od_error(&instance->logger, "startup", client, NULL,

--- a/sources/router.c
+++ b/sources/router.c
@@ -25,6 +25,7 @@ od_router_init(od_router_t *router)
 	od_rules_init(&router->rules);
 	od_route_pool_init(&router->route_pool);
 	router->clients = 0;
+	router->clients_routing = 0;
 }
 
 void

--- a/sources/router.h
+++ b/sources/router.h
@@ -25,6 +25,7 @@ struct od_router
 	od_rules_t      rules;
 	od_route_pool_t route_pool;
 	od_atomic_u32_t clients;
+	od_atomic_u32_t clients_routing;
 };
 
 static inline void

--- a/sources/system.c
+++ b/sources/system.c
@@ -28,6 +28,7 @@ od_system_server(void *arg)
 {
 	od_system_server_t *server = arg;
 	od_instance_t *instance = server->global->instance;
+	od_router_t *router = server->global->router;
 
 	for (;;)
 	{
@@ -105,7 +106,12 @@ od_system_server(void *arg)
 		memcpy(machine_msg_data(msg), &client, sizeof(od_client_t*));
 
 		od_worker_pool_t *worker_pool = server->global->worker_pool;
+		od_atomic_u32_inc(&router->clients_routing);
 		od_worker_pool_feed(worker_pool, msg);
+		while (od_atomic_u32_of(&router->clients_routing)
+				> (uint32_t) instance->config.client_max_routing) {
+			machine_sleep(1);
+		}
 	}
 }
 
@@ -344,6 +350,7 @@ od_system_config_reload(od_system_t *system)
 	}
 
 	rc = od_rules_validate(&rules, &config, &instance->logger);
+	od_config_reload(&instance->config, &config);
 	od_config_free(&config);
 	if (rc == -1) {
 		od_rules_free(&rules);


### PR DESCRIPTION
To handle the incoming wave of TLS connections we need to accept them gradually. This PR introduces a new setting client_max_routing. Odyssey will not accept more than client_max_routing connections in routing simultaneously.
By default, this setting is 4 * workers. This should be enough to satiate workers.