### PR TITLE
Modifications to build on PG12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,18 @@ if (BUILD_DEBIAN)
 endif()
 
 # postgresql
+option(PG_VERSION_NUM "PostgreSQL version" 100000)
 find_package(PostgreSQL REQUIRED)
-set(od_libraries ${od_libraries} ${POSTGRESQL_LIBRARY} ${PQ_LIBRARY})
+execute_process (
+    COMMAND pg_config --libdir
+    OUTPUT_VARIABLE PG_LIBDIR
+)
+execute_process (
+    COMMAND pg_config --includedir-server
+    OUTPUT_VARIABLE PG_INCLUDE_SERVER
+)
+set(POSTGRESQL_INCLUDE_DIR ${PG_INCLUDE_SERVER})
+set(od_libraries ${od_libraries} ${POSTGRESQL_LIBRARY} ${POSTGRESQL_LIBPGPORT} ${PQ_LIBRARY})
 include_directories(${POSTGRESQL_INCLUDE_DIR})
 
 # use BoringSSL or OpenSSL
@@ -86,6 +96,8 @@ message(STATUS "CMAKE_BUILD_TYPE:       ${CMAKE_BUILD_TYPE}")
 message(STATUS "BUILD_DEBIAN:           ${BUILD_DEBIAN}")
 message(STATUS "POSTGRESQL_INCLUDE_DIR: ${POSTGRESQL_INCLUDE_DIR}")
 message(STATUS "POSTGRESQL_LIBRARY:     ${POSTGRESQL_LIBRARY}")
+message(STATUS "POSTGRESQL_LIBPGPORT:   ${POSTGRESQL_LIBPGPORT}")
+message(STATUS "PG_VERSION_NUM:         ${PG_VERSION_NUM}")
 message(STATUS "PQ_LIBRARY:             ${PQ_LIBRARY}")
 message(STATUS "USE_BORINGSSL:          ${USE_BORINGSSL}")
 message(STATUS "BORINGSSL_ROOT_DIR:     ${BORINGSSL_ROOT_DIR}")

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -8,13 +8,19 @@
 find_path(
     POSTGRESQL_INCLUDE_DIR
     NAMES common/base64.h common/saslprep.h common/scram-common.h common/sha2.h
-    PATH_SUFFIXES postgresql/10/server
+    PATH_SUFFIXES PG_INCLUDE_SERVER
 )
 
 find_library(
     POSTGRESQL_LIBRARY
     NAMES pgcommon
-    HINTS "/usr/lib/postgresql/10/lib/"
+    HINTS PG_LIBDIR
+)
+
+find_library(
+    POSTGRESQL_LIBPGPORT
+    NAMES libpgport.a
+    HINTS PG_LIBDIR
 )
 
 find_library(

--- a/sources/build.h.cmake
+++ b/sources/build.h.cmake
@@ -13,5 +13,6 @@
 #cmakedefine OD_VERSION_BUILD "@OD_VERSION_BUILD@"
 
 #cmakedefine PAM_FOUND 1
+#cmakedefine PG_VERSION_NUM @PG_VERSION_NUM@
 
 #endif /* ODYSSEY_BUILD_H */

--- a/sources/scram.c
+++ b/sources/scram.c
@@ -437,7 +437,8 @@ od_scram_create_client_final_message(od_scram_state_t *scram_state,
 	if (rc == -1)
 		return NULL;
 
-	char result[512];
+	const int SCRAM_FINAL_MAX_SIZE = 512;
+	char result[SCRAM_FINAL_MAX_SIZE];
 
 	od_snprintf(result, sizeof(result), "c=biws,r=%s", server_nonce);
 
@@ -461,7 +462,7 @@ od_scram_create_client_final_message(od_scram_state_t *scram_state,
 	result[size++] = 'p';
 	result[size++] = '=';
 
-	size += od_b64_encode((char*)client_proof, SCRAM_KEY_LEN, result + size, 512 - size);
+	size += od_b64_encode((char*)client_proof, SCRAM_KEY_LEN, result + size, SCRAM_FINAL_MAX_SIZE - size);
 	result[size] = '\0';
 
 	machine_msg_t *msg = kiwi_fe_write_authentication_scram_final(NULL, result, size);

--- a/sources/scram.h
+++ b/sources/scram.h
@@ -1,6 +1,14 @@
 #ifndef ODYSSEY_SCRAM_H
 #define ODYSSEY_SCRAM_H
 
+#if PG_VERSION_NUM >= 120000
+#define od_b64_encode(src, src_len, dst, dst_len) pg_b64_encode(src, src_len, dst, dst_len);
+#define od_b64_decode(src, src_len, dst, dst_len) pg_b64_decode(src, src_len, dst, dst_len);
+#else
+#define od_b64_encode(src, src_len, dst, dst_len) pg_b64_encode(src, src_len, dst);
+#define od_b64_decode(src, src_len, dst, dst_len) pg_b64_decode(src, src_len, dst);
+#endif
+
 /*
  * Odyssey.
  *


### PR DESCRIPTION
Hi,

Thanks for the project! While trying to build it with PostgreSQL 12, I've
stumbled upon couple of issues, namely:

* Incompatibility after [[1]]
* Required presence of libpgport (to expose pg_sprintf for scram implementation)

My first reaction was to introduce the following naive changes (including also
use pg_config to recognise lib/include dir). Without them odyssey, compiled
against v10, was crashing sometimes while connecting to v12. Does something
like that makes sense, or there is a better way to achive compatibility?

[1]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=cfc40d384ae51ea2886d599d2008ae57b529e6ea