### PR TITLE
Use more hints to find PG libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,17 +39,8 @@ if (BUILD_DEBIAN)
 endif()
 
 # postgresql
-option(PG_VERSION_NUM "PostgreSQL version" 100000)
 find_package(PostgreSQL REQUIRED)
-execute_process (
-    COMMAND pg_config --libdir
-    OUTPUT_VARIABLE PG_LIBDIR
-)
-execute_process (
-    COMMAND pg_config --includedir-server
-    OUTPUT_VARIABLE PG_INCLUDE_SERVER
-)
-set(POSTGRESQL_INCLUDE_DIR ${PG_INCLUDE_SERVER})
+
 set(od_libraries ${od_libraries} ${POSTGRESQL_LIBRARY} ${POSTGRESQL_LIBPGPORT} ${PQ_LIBRARY})
 include_directories(${POSTGRESQL_INCLUDE_DIR})
 

--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -11,16 +11,35 @@ find_path(
     PATH_SUFFIXES PG_INCLUDE_SERVER
 )
 
+option(PG_VERSION_NUM "PostgreSQL version" 100000)
+
+execute_process (
+        COMMAND pg_config --libdir
+        OUTPUT_VARIABLE PG_LIBDIR
+)
+
+execute_process (
+        COMMAND pg_config --pkglibdir
+        OUTPUT_VARIABLE PG_PKGLIBDIR
+)
+
+execute_process (
+        COMMAND pg_config --includedir-server
+        OUTPUT_VARIABLE PG_INCLUDE_SERVER
+)
+
+set(POSTGRESQL_INCLUDE_DIR ${PG_INCLUDE_SERVER})
+
 find_library(
     POSTGRESQL_LIBRARY
     NAMES pgcommon
-    HINTS PG_LIBDIR
+    HINTS ${PG_LIBDIR} ${PG_PKGLIBDIR} /usr/lib/postgresql/10/lib
 )
 
 find_library(
     POSTGRESQL_LIBPGPORT
-    NAMES libpgport.a
-    HINTS PG_LIBDIR
+    NAMES pgport
+    HINTS ${PG_LIBDIR}  ${PG_PKGLIBDIR} /usr/lib/postgresql/10/lib
 )
 
 find_library(


### PR DESCRIPTION
@erthalion please take a look
Hints from pg_config seem to be not working on Ubuntu installations. Even if variable points to the same path as literal.
I've added literal hint and it helps. But it seems to me we are doing something wrong here.