### PR TITLE
Fix clients computation during enforcing route max_clients

### DIFF
--- a/sources/router.c
+++ b/sources/router.c
@@ -277,7 +277,6 @@ od_router_route(od_router_t *router, od_config_t *config, od_client_t *client)
 	    od_client_pool_total(&route->client_pool) >= rule->client_max) {
 		od_route_unlock(route);
 		od_router_lock(router);
-		router->clients--;
 		od_rules_unref(rule);
 		od_router_unlock(router);
 		return OD_ROUTER_ERROR_LIMIT_ROUTE;


### PR DESCRIPTION
All router->clients interactions must be atomic.
Furthermore, all decrements must go through od_frontend_close.

The bug manifests in when both global max_clients and route max_clients are set and continuously pressured.