### PR TITLE
Quantiles for transactions and queries

### DIFF
--- a/odyssey.conf
+++ b/odyssey.conf
@@ -500,7 +500,7 @@ database default {
 #
 		log_debug no
 
-#       Compute quantiles of query and transaction times
+#		Compute quantiles of query and transaction times
 		quantiles "0.99,0.95,0.5"
 	}
 }

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -499,6 +499,9 @@ database default {
 #		Enable verbose mode for a specific route only.
 #
 		log_debug no
+
+#       Compute percentiles of query and transaction times
+		percentiles "0.99,0.95,0.5"
 	}
 }
 

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -500,8 +500,8 @@ database default {
 #
 		log_debug no
 
-#       Compute percentiles of query and transaction times
-		percentiles "0.99,0.95,0.5"
+#       Compute quantiles of query and transaction times
+		quantiles "0.99,0.95,0.5"
 	}
 }
 

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -23,6 +23,7 @@ set(od_src
     frontend.c
     backend.c
     instance.c
+    hgram.c
     main.c
 )
 

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -93,7 +93,8 @@ enum
 	OD_LAUTH_PAM_SERVICE,
 	OD_LAUTH_QUERY,
 	OD_LAUTH_QUERY_DB,
-	OD_LAUTH_QUERY_USER
+	OD_LAUTH_QUERY_USER,
+    OD_LPERCENTILES,
 };
 
 typedef struct
@@ -182,6 +183,7 @@ od_config_keywords[] =
 	od_keyword("auth_query_db",        OD_LAUTH_QUERY_DB),
 	od_keyword("auth_query_user",      OD_LAUTH_QUERY_USER),
 	od_keyword("auth_pam_service",     OD_LAUTH_PAM_SERVICE),
+    od_keyword("percentiles",          OD_LPERCENTILES),
 	{ 0, 0, 0 }
 };
 
@@ -292,6 +294,36 @@ error:
 	od_parser_push(&reader->parser, &token);
 	od_config_reader_error(reader, &token, "expected '%c'", symbol);
 	return false;
+}
+
+static bool
+od_config_reader_percentiles(od_config_reader_t *reader, char *value, double **percentiles, int *count)
+{
+    int comma_cnt = 1;
+    char *c = value;
+    while (*c){
+        if (*c == ',')
+            comma_cnt++;
+        c++;
+    }
+    *percentiles = malloc(sizeof(double) * comma_cnt);
+    double *array = *percentiles;
+    *count = 0;
+    c = value;
+    while (*c) {
+        int length = sscanf(c, "%lf", array + *count);
+        if (length !=1 || array[*count] > 1 ||array[*count] < 0) {
+            od_config_reader_error(reader, NULL, "incorrect percentile value");
+            free(*percentiles);
+            return false;
+        }
+        *count += 1;
+        while (*c != ',') {
+            c++;
+        }
+        c++;
+    }
+    return true;
 }
 
 static bool
@@ -692,6 +724,17 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 		case OD_LCLIENT_FWD_ERROR:
 			if (! od_config_reader_yes_no(reader, &route->client_fwd_error))
 				return -1;
+			continue;
+		/* percentiles */
+		case OD_LPERCENTILES:
+        {
+            char *percentiles_str = NULL;
+			if (! od_config_reader_string(reader, &percentiles_str))
+				return -1;
+            if (! od_config_reader_percentiles(reader, percentiles_str, &route->percentiles, &route->percentiles_count))
+                return -1;
+
+		}
 			continue;
 		/* pool */
 		case OD_LPOOL:

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -727,13 +727,12 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 			continue;
 		/* quantiles */
 		case OD_LQUANTILES:
-        {
-            char *quantiles_str = NULL;
+		{
+			char *quantiles_str = NULL;
 			if (! od_config_reader_string(reader, &quantiles_str))
 				return -1;
-            if (!od_config_reader_quantiles(reader, quantiles_str, &route->quantiles, &route->quantiles_count))
-                return -1;
-
+			if (!od_config_reader_quantiles(reader, quantiles_str, &route->quantiles, &route->quantiles_count))
+				return -1;
 		}
 			continue;
 		/* pool */

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -94,7 +94,7 @@ enum
 	OD_LAUTH_QUERY,
 	OD_LAUTH_QUERY_DB,
 	OD_LAUTH_QUERY_USER,
-    OD_LPERCENTILES,
+	OD_LQUANTILES,
 };
 
 typedef struct
@@ -183,7 +183,7 @@ od_config_keywords[] =
 	od_keyword("auth_query_db",        OD_LAUTH_QUERY_DB),
 	od_keyword("auth_query_user",      OD_LAUTH_QUERY_USER),
 	od_keyword("auth_pam_service",     OD_LAUTH_PAM_SERVICE),
-    od_keyword("percentiles",          OD_LPERCENTILES),
+	od_keyword("quantiles", OD_LQUANTILES),
 	{ 0, 0, 0 }
 };
 
@@ -297,24 +297,24 @@ error:
 }
 
 static bool
-od_config_reader_percentiles(od_config_reader_t *reader, char *value, double **percentiles, int *count)
+od_config_reader_quantiles(od_config_reader_t *reader, char *value, double **quantiles, int *count)
 {
     int comma_cnt = 1;
     char *c = value;
-    while (*c){
+    while (*c) {
         if (*c == ',')
             comma_cnt++;
         c++;
     }
-    *percentiles = malloc(sizeof(double) * comma_cnt);
-    double *array = *percentiles;
+    *quantiles = malloc(sizeof(double) * comma_cnt);
+    double *array = *quantiles;
     *count = 0;
     c = value;
     while (*c) {
         int length = sscanf(c, "%lf", array + *count);
-        if (length !=1 || array[*count] > 1 ||array[*count] < 0) {
-            od_config_reader_error(reader, NULL, "incorrect percentile value");
-            free(*percentiles);
+        if (length != 1 || array[*count] > 1 || array[*count] < 0) {
+            od_config_reader_error(reader, NULL, "incorrect quantile value");
+            free(*quantiles);
             return false;
         }
         *count += 1;
@@ -725,13 +725,13 @@ od_config_reader_route(od_config_reader_t *reader, char *db_name, int db_name_le
 			if (! od_config_reader_yes_no(reader, &route->client_fwd_error))
 				return -1;
 			continue;
-		/* percentiles */
-		case OD_LPERCENTILES:
+		/* quantiles */
+		case OD_LQUANTILES:
         {
-            char *percentiles_str = NULL;
-			if (! od_config_reader_string(reader, &percentiles_str))
+            char *quantiles_str = NULL;
+			if (! od_config_reader_string(reader, &quantiles_str))
 				return -1;
-            if (! od_config_reader_percentiles(reader, percentiles_str, &route->percentiles, &route->percentiles_count))
+            if (!od_config_reader_quantiles(reader, quantiles_str, &route->quantiles, &route->quantiles_count))
                 return -1;
 
 		}

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -92,19 +92,19 @@ od_cron_stat_cb(od_route_t *route, od_stat_t *current, od_stat_t *avg,
 	       info.avg_recv_client,
 	       info.avg_recv_server);
 
-	for (int i = 0; i < route->rule->percentiles_count; i++) {
-        double perc = route->rule->percentiles[i];
-        uint64_t qp = 0;
-        uint64_t tp = 0;
+	for (int i = 0; i < route->rule->quantiles_count; i++) {
+        double quantile = route->rule->quantiles[i];
+        uint64_t query_quantile = 0;
+        uint64_t transaction_quantile = 0;
 
 	    if (avg->query_hgram)
-            qp = od_hgram_percentile(avg->query_hgram, perc);
+			query_quantile = od_hgram_quantile(avg->query_hgram, quantile);
 	    if (avg->transaction_hgram)
-            tp = od_hgram_percentile(avg->transaction_hgram, perc);
+			transaction_quantile = od_hgram_quantile(avg->transaction_hgram, quantile);
 
         od_log(&instance->logger, "stats", NULL, NULL,
-               "percentile %lf for queries %" PRIu64 " usec, for transactions %" PRIu64" usec",
-               perc, qp, tp);
+               "quantile %lf for queries %" PRIu64 " usec, for transactions %" PRIu64" usec",
+			   quantile, query_quantile, transaction_quantile);
 	}
 
 	return 0;

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -93,18 +93,18 @@ od_cron_stat_cb(od_route_t *route, od_stat_t *current, od_stat_t *avg,
 	       info.avg_recv_server);
 
 	for (int i = 0; i < route->rule->quantiles_count; i++) {
-        double quantile = route->rule->quantiles[i];
-        uint64_t query_quantile = 0;
-        uint64_t transaction_quantile = 0;
+		double quantile = route->rule->quantiles[i];
+		uint64_t query_quantile = 0;
+		uint64_t transaction_quantile = 0;
 
-	    if (avg->query_hgram)
+		if (avg->query_hgram)
 			query_quantile = od_hgram_quantile(avg->query_hgram, quantile);
-	    if (avg->transaction_hgram)
+		if (avg->transaction_hgram)
 			transaction_quantile = od_hgram_quantile(avg->transaction_hgram, quantile);
 
-        od_log(&instance->logger, "stats", NULL, NULL,
-               "quantile %lf for queries %" PRIu64 " usec, for transactions %" PRIu64" usec",
-			   quantile, query_quantile, transaction_quantile);
+		od_log(&instance->logger, "stats", NULL, NULL,
+			"quantile %lf for queries %" PRIu64 " usec, for transactions %" PRIu64" usec",
+				quantile, query_quantile, transaction_quantile);
 	}
 
 	return 0;

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -92,6 +92,21 @@ od_cron_stat_cb(od_route_t *route, od_stat_t *current, od_stat_t *avg,
 	       info.avg_recv_client,
 	       info.avg_recv_server);
 
+	for (int i = 0; i < route->rule->percentiles_count; i++) {
+        double perc = route->rule->percentiles[i];
+        uint64_t qp = 0;
+        uint64_t tp = 0;
+
+	    if (avg->query_hgram)
+            qp = od_hgram_percentile(avg->query_hgram, perc);
+	    if (avg->transaction_hgram)
+            tp = od_hgram_percentile(avg->transaction_hgram, perc);
+
+        od_log(&instance->logger, "stats", NULL, NULL,
+               "percentile %lf for queries %" PRIu64 " usec, for transactions %" PRIu64" usec",
+               perc, qp, tp);
+	}
+
 	return 0;
 }
 

--- a/sources/hgram.c
+++ b/sources/hgram.c
@@ -24,19 +24,19 @@ void od_hgram_init(od_hgram_t *hgram) {
 	memset(hgram, 0, sizeof(*hgram));
 }
 
-// Probablisticaly add data point, return true is point was actually added to data set
-bool od_hgram_add_data_point(od_hgram_t *hgram, uint64_t point) {
+// Probablisticaly add data point, return 1 is point was actually added to data set, 0 otherwise
+int od_hgram_add_data_point(od_hgram_t *hgram, uint64_t point) {
 	uint64_t next_position = __sync_fetch_and_add(&hgram->estimated_size, 1);
 	if (next_position < OD_HGRAM_DATA_POINTS) {
 		hgram->data[next_position] = point;
-		return true;
+		return 1;
 	}
 	next_position = machine_lrand48() % next_position;
 	if (next_position < OD_HGRAM_DATA_POINTS){
 		hgram->data[next_position] = point;
-		return true;
+		return 1;
 	}
-	return false;
+	return 0;
 }
 
 static int cmpfunc_ui32(const void *a, const void *b) {

--- a/sources/hgram.c
+++ b/sources/hgram.c
@@ -3,6 +3,8 @@
  * Odyssey.
  *
  * Scalable PostgreSQL connection pooler.
+ *
+ * Implementation of reservoir sampling algorithm
 */
 
 #include <stdlib.h>
@@ -18,25 +20,26 @@
 #include <kiwi.h>
 #include <odyssey.h>
 
-void od_hgram_init(od_hgram_t *hgram)
-{
+void od_hgram_init(od_hgram_t *hgram) {
 	memset(hgram, 0, sizeof(*hgram));
 }
 
-void od_hgram_add_data_point(od_hgram_t *hgram, uint64_t point)
-{
+// Probablisticaly add data point, return true is point was actually added to data set
+bool od_hgram_add_data_point(od_hgram_t *hgram, uint64_t point) {
 	uint64_t next_position = __sync_fetch_and_add(&hgram->estimated_size, 1);
 	if (next_position < OD_HGRAM_DATA_POINTS) {
 		hgram->data[next_position] = point;
-		return;
+		return true;
 	}
 	next_position = machine_lrand48() % next_position;
-	if (next_position < OD_HGRAM_DATA_POINTS)
+	if (next_position < OD_HGRAM_DATA_POINTS){
 		hgram->data[next_position] = point;
+		return true;
+	}
+	return false;
 }
 
-static int cmpfunc_ui32(const void *a, const void *b)
-{
+static int cmpfunc_ui32(const void *a, const void *b) {
 	if (*(uint32_t *) a < *(uint32_t *) b)
 		return 1;
 	if (*(uint32_t *) a > *(uint32_t *) b)
@@ -44,23 +47,23 @@ static int cmpfunc_ui32(const void *a, const void *b)
 	return 0;
 }
 
-void od_hgram_freeze(od_hgram_t *hgram, od_hgram_frozen_t *hgram_tmp)
-{
+// Create static copy of reservoir for analysis
+void od_hgram_freeze(od_hgram_t *hgram, od_hgram_frozen_t *hgram_tmp) {
 	memcpy(hgram_tmp, hgram, sizeof(*hgram));
+	hgram->estimated_size = 0;
+
 	qsort(&hgram_tmp->data, OD_HGRAM_DATA_POINTS, sizeof(uint32_t), cmpfunc_ui32);
 
-	if (hgram->estimated_size > OD_HGRAM_DATA_POINTS * 2) {
-		hgram->estimated_size = hgram->estimated_size / 2;
-		hgram_tmp->estimated_size = OD_HGRAM_DATA_POINTS;
-	} else if (hgram->estimated_size > OD_HGRAM_DATA_POINTS) {
-		hgram->estimated_size = OD_HGRAM_DATA_POINTS;
+	if (hgram_tmp->estimated_size > OD_HGRAM_DATA_POINTS) {
 		hgram_tmp->estimated_size = OD_HGRAM_DATA_POINTS;
 	}
 }
 
-uint64_t od_hgram_percentile(od_hgram_frozen_t *frozen, double percentile)
-{
-	assert(percentile > 0);
-	assert(percentile <= 1);
-	return frozen->data[(size_t)(frozen->estimated_size * (1 - percentile))];
+// Compute quantile withing static copy of reservoir
+uint64_t od_hgram_quantile(od_hgram_frozen_t *frozen, double quantile) {
+	assert(quantile > 0);
+	assert(quantile <= 1);
+	if (frozen->estimated_size == 0)
+		return 0;
+	return frozen->data[(size_t) (frozen->estimated_size * (1 - quantile))];
 }

--- a/sources/hgram.c
+++ b/sources/hgram.c
@@ -1,0 +1,66 @@
+
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+*/
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include <machinarium.h>
+#include <kiwi.h>
+#include <odyssey.h>
+
+void od_hgram_init(od_hgram_t *hgram)
+{
+	memset(hgram, 0, sizeof(*hgram));
+}
+
+void od_hgram_add_data_point(od_hgram_t *hgram, uint64_t point)
+{
+	uint64_t next_position = __sync_fetch_and_add(&hgram->estimated_size, 1);
+	if (next_position < OD_HGRAM_DATA_POINTS) {
+		hgram->data[next_position] = point;
+		return;
+	}
+	next_position = machine_lrand48() % next_position;
+	if (next_position < OD_HGRAM_DATA_POINTS)
+		hgram->data[next_position] = point;
+}
+
+static int cmpfunc_ui32(const void *a, const void *b)
+{
+	if (*(uint32_t *) a < *(uint32_t *) b)
+		return 1;
+	if (*(uint32_t *) a > *(uint32_t *) b)
+		return -1;
+	return 0;
+}
+
+void od_hgram_freeze(od_hgram_t *hgram, od_hgram_frozen_t *hgram_tmp)
+{
+	memcpy(hgram_tmp, hgram, sizeof(*hgram));
+	qsort(&hgram_tmp->data, OD_HGRAM_DATA_POINTS, sizeof(uint32_t), cmpfunc_ui32);
+
+	if (hgram->estimated_size > OD_HGRAM_DATA_POINTS * 2) {
+		hgram->estimated_size = hgram->estimated_size / 2;
+		hgram_tmp->estimated_size = OD_HGRAM_DATA_POINTS;
+	} else if (hgram->estimated_size > OD_HGRAM_DATA_POINTS) {
+		hgram->estimated_size = OD_HGRAM_DATA_POINTS;
+		hgram_tmp->estimated_size = OD_HGRAM_DATA_POINTS;
+	}
+}
+
+uint64_t od_hgram_percentile(od_hgram_frozen_t *frozen, double percentile)
+{
+	assert(percentile > 0);
+	assert(percentile <= 1);
+	return frozen->data[(size_t)(frozen->estimated_size * (1 - percentile))];
+}

--- a/sources/hgram.h
+++ b/sources/hgram.h
@@ -1,0 +1,28 @@
+#ifndef ODYSSEY_HGRAM_H
+#define ODYSSEY_HGRAM_H
+
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+*/
+
+typedef struct od_hgram od_hgram_t;
+typedef struct od_hgram od_hgram_frozen_t;
+
+#define OD_HGRAM_DATA_POINTS 256
+
+struct od_hgram {
+	uint32_t data[OD_HGRAM_DATA_POINTS];
+	uint64_t estimated_size;
+};
+
+void od_hgram_init(od_hgram_t *);
+
+void od_hgram_add_data_point(od_hgram_t *, uint64_t);
+
+void od_hgram_freeze(od_hgram_t *, od_hgram_frozen_t *);
+
+uint64_t od_hgram_percentile(od_hgram_frozen_t *, double);
+
+#endif //ODYSSEY_HGRAM_H

--- a/sources/hgram.h
+++ b/sources/hgram.h
@@ -19,7 +19,7 @@ struct od_hgram {
 
 void od_hgram_init(od_hgram_t *);
 
-bool od_hgram_add_data_point(od_hgram_t *, uint64_t);
+int od_hgram_add_data_point(od_hgram_t *, uint64_t);
 
 void od_hgram_freeze(od_hgram_t *, od_hgram_frozen_t *);
 

--- a/sources/hgram.h
+++ b/sources/hgram.h
@@ -19,10 +19,10 @@ struct od_hgram {
 
 void od_hgram_init(od_hgram_t *);
 
-void od_hgram_add_data_point(od_hgram_t *, uint64_t);
+bool od_hgram_add_data_point(od_hgram_t *, uint64_t);
 
 void od_hgram_freeze(od_hgram_t *, od_hgram_frozen_t *);
 
-uint64_t od_hgram_percentile(od_hgram_frozen_t *, double);
+uint64_t od_hgram_quantile(od_hgram_frozen_t *, double);
 
 #endif //ODYSSEY_HGRAM_H

--- a/sources/odyssey.h
+++ b/sources/odyssey.h
@@ -60,4 +60,6 @@
 #include "sources/frontend.h"
 #include "sources/backend.h"
 
+#include "sources/hgram.h"
+
 #endif /* ODYSSEY_H */

--- a/sources/route.h
+++ b/sources/route.h
@@ -48,6 +48,10 @@ od_route_free(od_route_t *route)
 	kiwi_params_lock_free(&route->params);
 	if (route->wait_bus)
 		machine_channel_free(route->wait_bus);
+	if (route->stats.transaction_hgram)
+	    free(route->stats.transaction_hgram);
+	if (route->stats.query_hgram)
+	    free(route->stats.query_hgram);
 	pthread_mutex_destroy(&route->lock);
 	free(route);
 }

--- a/sources/route_pool.h
+++ b/sources/route_pool.h
@@ -60,7 +60,7 @@ od_route_pool_new(od_route_pool_t *pool, int is_shared, od_route_id_t *id,
 		return NULL;
 	}
 	route->rule = rule;
-	if (rule->percentiles_count) {
+	if (rule->quantiles_count) {
 		route->stats.transaction_hgram = malloc(sizeof(od_hgram_t));
 		od_hgram_init(route->stats.transaction_hgram);
 		route->stats.query_hgram = malloc(sizeof(od_hgram_t));

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -116,6 +116,8 @@ struct od_rule
 	int                     client_max_set;
 	int                     client_max;
 	int                     log_debug;
+	double 				   *percentiles;
+	int 				    percentiles_count;
 	od_list_t               link;
 };
 

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -116,8 +116,8 @@ struct od_rule
 	int                     client_max_set;
 	int                     client_max;
 	int                     log_debug;
-	double 				   *percentiles;
-	int 				    percentiles_count;
+	double                 *quantiles;
+	int                     quantiles_count;
 	od_list_t               link;
 };
 

--- a/sources/stat.h
+++ b/sources/stat.h
@@ -26,8 +26,8 @@ struct od_stat
 	od_atomic_u64_t tx_time;
 	od_atomic_u64_t recv_server;
 	od_atomic_u64_t recv_client;
-	od_hgram_t*      transaction_hgram;
-	od_hgram_t*      query_hgram;
+	od_hgram_t     *transaction_hgram;
+	od_hgram_t     *query_hgram;
 };
 
 static inline void
@@ -79,7 +79,7 @@ od_stat_query_end(od_stat_t *stat, od_stat_state_t *state,
 			od_atomic_u64_add(&stat->tx_time, diff);
 			od_atomic_u64_inc(&stat->count_tx);
 			if (stat->transaction_hgram)
-                od_hgram_add_data_point(stat->transaction_hgram, diff);
+				od_hgram_add_data_point(stat->transaction_hgram, diff);
 		}
 		state->tx_time_start = 0;
 	}

--- a/sources/stat.h
+++ b/sources/stat.h
@@ -1,6 +1,8 @@
 #ifndef ODYSSEY_STAT_H
 #define ODYSSEY_STAT_H
 
+#include "hgram.h"
+
 /*
  * Odyssey.
  *
@@ -24,6 +26,8 @@ struct od_stat
 	od_atomic_u64_t tx_time;
 	od_atomic_u64_t recv_server;
 	od_atomic_u64_t recv_client;
+	od_hgram_t*      transaction_hgram;
+	od_hgram_t*      query_hgram;
 };
 
 static inline void
@@ -60,6 +64,8 @@ od_stat_query_end(od_stat_t *stat, od_stat_state_t *state,
 			*query_time = diff;
 			od_atomic_u64_add(&stat->query_time, diff);
 			od_atomic_u64_inc(&stat->count_query);
+			if (stat->query_hgram)
+			    od_hgram_add_data_point(stat->query_hgram, diff);
 		}
 		state->query_time_start = 0;
 	}
@@ -72,6 +78,8 @@ od_stat_query_end(od_stat_t *stat, od_stat_state_t *state,
 		if (diff > 0) {
 			od_atomic_u64_add(&stat->tx_time, diff);
 			od_atomic_u64_inc(&stat->count_tx);
+            if (stat->transaction_hgram)
+                od_hgram_add_data_point(stat->transaction_hgram, diff);
 		}
 		state->tx_time_start = 0;
 	}

--- a/sources/stat.h
+++ b/sources/stat.h
@@ -78,7 +78,7 @@ od_stat_query_end(od_stat_t *stat, od_stat_state_t *state,
 		if (diff > 0) {
 			od_atomic_u64_add(&stat->tx_time, diff);
 			od_atomic_u64_inc(&stat->count_tx);
-            if (stat->transaction_hgram)
+			if (stat->transaction_hgram)
                 od_hgram_add_data_point(stat->transaction_hgram, diff);
 		}
 		state->tx_time_start = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,8 @@ set(od_test_src
     machinarium/test_tls_read_10mb2.c
     machinarium/test_tls_read_multithread.c
     machinarium/test_tls_read_var.c
+    ../sources/hgram.c
+    odyssey/test_hgram.c
    )
 
 file(COPY machinarium/ca.crt DESTINATION machinarium)
@@ -76,6 +78,7 @@ file(COPY odyssey/test_scram_backend.sh DESTINATION odyssey)
 file(COPY odyssey/test_scram_frontend.sh DESTINATION odyssey)
 
 include_directories("${PROJECT_SOURCE_DIR}/")
+include_directories("${PROJECT_SOURCE_DIR}/sources/")
 include_directories("${PROJECT_BINARY_DIR}/")
 include_directories("${PROJECT_SOURCE_DIR}/test")
 include_directories("${PROJECT_BINARY_DIR}/test")

--- a/test/odyssey/test_hgram.c
+++ b/test/odyssey/test_hgram.c
@@ -10,9 +10,10 @@ void hgram_backward_test();
 
 int hgram_random_test();
 
+// Currently we are linking without lm
 static int myround(double x)
 {
-	return x+0.5;
+	return x + 0.5;
 }
 
 void
@@ -47,11 +48,11 @@ int hgram_random_test()
 	od_hgram_freeze(&hgram, &f);
 
 	int result = 0;
-	if(myround(od_hgram_percentile(&f, 0.8) / 2000.0) != 4)
+	if(myround(od_hgram_quantile(&f, 0.8) / 2000.0) != 4)
 		result++;
-	if(myround(od_hgram_percentile(&f, 0.6) / 2000.0) != 3)
+	if(myround(od_hgram_quantile(&f, 0.6) / 2000.0) != 3)
 		result++;
-	if(myround(od_hgram_percentile(&f, 0.4) / 2000.0) != 2)
+	if(myround(od_hgram_quantile(&f, 0.4) / 2000.0) != 2)
 		result++;
 
 	return result;
@@ -69,9 +70,9 @@ void hgram_backward_test()
 
 	od_hgram_freeze(&hgram, &f);
 
-	assert(od_hgram_percentile(&f, 0.7) == 70);
-	assert(od_hgram_percentile(&f, 0.5) == 50);
-	assert(od_hgram_percentile(&f, 0.3) == 30);
+	assert(od_hgram_quantile(&f, 0.7) == 70);
+	assert(od_hgram_quantile(&f, 0.5) == 50);
+	assert(od_hgram_quantile(&f, 0.3) == 30);
 }
 
 void hgram_forward_test()
@@ -85,7 +86,7 @@ void hgram_forward_test()
 	}
 	od_hgram_freeze(&hgram, &f);
 
-	assert(od_hgram_percentile(&f, 0.7) == 70);
-	assert(od_hgram_percentile(&f, 0.5) == 50);
-	assert(od_hgram_percentile(&f, 0.3) == 30);
+	assert(od_hgram_quantile(&f, 0.7) == 70);
+	assert(od_hgram_quantile(&f, 0.5) == 50);
+	assert(od_hgram_quantile(&f, 0.3) == 30);
 }

--- a/test/odyssey/test_hgram.c
+++ b/test/odyssey/test_hgram.c
@@ -1,0 +1,91 @@
+#include <machinarium.h>
+#include <odyssey_test.h>
+#include <assert.h>
+#include <lrand48.h>
+#include "sources/hgram.h"
+
+void hgram_forward_test();
+
+void hgram_backward_test();
+
+int hgram_random_test();
+
+static int myround(double x)
+{
+	return x+0.5;
+}
+
+void
+machinarium_test_hgram(void)
+{
+	machinarium_init();
+	mm_lrand48_seed();
+
+	hgram_forward_test();
+	hgram_backward_test();
+
+	int fails = 0;
+	for (int i=0;i<20;i++)
+		fails += hgram_random_test();
+
+	// fails approx 1/1000, so suppress flaps to impossible
+	assert(fails <= 3);
+
+	machinarium_free();
+}
+
+int hgram_random_test()
+{
+	od_hgram_t hgram;
+	od_hgram_frozen_t f;
+	od_hgram_init(&hgram);
+
+	for (int i = 0; i < 100000; i++) {
+		od_hgram_add_data_point(&hgram, machine_lrand48() % 10000);
+	}
+
+	od_hgram_freeze(&hgram, &f);
+
+	int result = 0;
+	if(myround(od_hgram_percentile(&f, 0.8) / 2000.0) != 4)
+		result++;
+	if(myround(od_hgram_percentile(&f, 0.6) / 2000.0) != 3)
+		result++;
+	if(myround(od_hgram_percentile(&f, 0.4) / 2000.0) != 2)
+		result++;
+
+	return result;
+}
+
+void hgram_backward_test()
+{
+	od_hgram_t hgram;
+	od_hgram_frozen_t f;
+	od_hgram_init(&hgram);
+
+	for (int i = 0; i < 100; i++) {
+		od_hgram_add_data_point(&hgram, 100 - i);
+	}
+
+	od_hgram_freeze(&hgram, &f);
+
+	assert(od_hgram_percentile(&f, 0.7) == 70);
+	assert(od_hgram_percentile(&f, 0.5) == 50);
+	assert(od_hgram_percentile(&f, 0.3) == 30);
+}
+
+void hgram_forward_test()
+{
+	od_hgram_t hgram;
+	od_hgram_frozen_t f;
+	od_hgram_init(&hgram);
+
+	for (int i = 1; i <= 100; i++) {
+		od_hgram_add_data_point(&hgram, i);
+	}
+	od_hgram_freeze(&hgram, &f);
+
+	assert(od_hgram_percentile(&f, 0.7) == 70);
+	assert(od_hgram_percentile(&f, 0.5) == 50);
+	assert(od_hgram_percentile(&f, 0.3) == 30);
+}

--- a/test/odyssey_test.c
+++ b/test/odyssey_test.c
@@ -74,6 +74,7 @@ extern void machinarium_test_tls_read_10mb1(void);
 extern void machinarium_test_tls_read_10mb2(void);
 extern void machinarium_test_tls_read_multithread(void);
 extern void machinarium_test_tls_read_var(void);
+extern void machinarium_test_hgram(void);
 
 int main(int argc, char *argv[])
 {
@@ -138,6 +139,7 @@ int main(int argc, char *argv[])
 	odyssey_test(machinarium_test_tls_read_10mb2);
 	odyssey_test(machinarium_test_tls_read_multithread);
 	odyssey_test(machinarium_test_tls_read_var);
+	odyssey_test(machinarium_test_hgram);
 
 	odyssey_shell_test("odyssey/setup");
 	odyssey_shell_test("odyssey/test_scram_backend");


### PR DESCRIPTION
This is a draft for percentile computation.
Usually, the average query time is not very useful, while 99 percentile can give more insights about slow queries.
In this PR I use sampling for query times, this is not a very efficient algorithm like T-digest.
I think in future we will implement something more precise.