### PR TITLE
Remove useless logging of startup errors

### DIFF
--- a/sources/cron.c
+++ b/sources/cron.c
@@ -111,6 +111,8 @@ od_cron_stat(od_cron_t *cron)
 		uint64_t msg_cache_count = 0;
 		uint64_t msg_cache_gc_count = 0;
 		uint64_t msg_cache_size = 0;
+		od_atomic_u64_t startup_errors = od_atomic_u64_of(&cron->startup_errors);
+		cron->startup_errors = 0;
 		machine_stat(&count_coroutine,
 		             &count_coroutine_cache,
 		             &msg_allocated,
@@ -119,13 +121,14 @@ od_cron_stat(od_cron_t *cron)
 		             &msg_cache_size);
 		od_log(&instance->logger, "stats", NULL, NULL,
 		       "system worker: msg (%" PRIu64 " allocated, %" PRIu64 " cached, %" PRIu64 " freed, %" PRIu64 " cache_size), "
-		       "coroutines (%" PRIu64 " active, %"PRIu64 " cached)",
+		       "coroutines (%" PRIu64 " active, %"PRIu64 " cached) startup errors %" PRIu64,
 		       msg_allocated,
 		       msg_cache_count,
 		       msg_cache_gc_count,
 		       msg_cache_size,
 		       count_coroutine,
-		       count_coroutine_cache);
+		       count_coroutine_cache,
+			   startup_errors);
 
 		/* request stats per worker */
 		int i;
@@ -216,6 +219,7 @@ od_cron_init(od_cron_t *cron)
 {
 	cron->stat_time_us = 0;
 	cron->global = NULL;
+	cron->startup_errors = 0;
 }
 
 int

--- a/sources/cron.h
+++ b/sources/cron.h
@@ -13,6 +13,7 @@ struct od_cron
 {
 	uint64_t     stat_time_us;
 	od_global_t *global;
+	od_atomic_u64_t startup_errors;
 };
 
 void od_cron_init(od_cron_t*);

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -163,8 +163,10 @@ od_frontend_startup(od_client_t *client)
 	return 0;
 
 error:
-	od_error(&instance->logger, "startup", client, NULL,
+	od_debug(&instance->logger, "startup", client, NULL,
 	         "startup packet read error");
+	od_cron_t *cron = client->global->cron;
+	od_atomic_u64_inc(&cron->startup_errors);
 	return -1;
 }
 


### PR DESCRIPTION
Currently, logs are flooded with messages like ```msg=startup packet read error``` from pings of monitoring and HA tools.
This commit removes those lines.