### PR TITLE
Add server_login_retry timeout and server_max_routing restriction

### DIFF
--- a/odyssey.conf
+++ b/odyssey.conf
@@ -296,6 +296,10 @@ listen {
 #   client_login_timeout
 #   Prevent client stall during routing for more that client_login_timeout milliseconds.
 #   Defaults to 15000.
+
+#   server_login_retry
+#   If server responds with "Too many clients" client will wait for server_login_retry milliseconds.
+#   Defaults to 1.
 }
 
 ###

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -248,6 +248,15 @@ keepalive 7200
 #
 # client_max_routing 32
 
+#
+# Global limit of server connections concurrently being routed.
+# We are opening no more than server_max_routing server connections concurrently.
+# In future, this setting will be moved to storage section.
+#
+# Unset or zero 'server_max_routing' will set it's value equal to 2 * workers
+#
+# server_max_routing 4
+
 ###
 ### LISTEN
 ###

--- a/sources/config.c
+++ b/sources/config.c
@@ -46,6 +46,7 @@ od_config_init(od_config_t *config)
 	config->client_max_set       = 0;
 	config->client_max           = 0;
 	config->client_max_routing   = 0;
+	config->server_login_retry   = 1;
 	config->cache_coroutine      = 0;
 	config->cache_msg_gc_size    = 0;
 	config->coroutine_stack_size = 4;
@@ -57,6 +58,7 @@ od_config_reload(od_config_t *current_config, od_config_t *new_config)
 {
 	current_config->client_max = new_config->client_max;
 	current_config->client_max_routing = new_config->client_max_routing;
+	current_config->server_login_retry = new_config->server_login_retry;
 }
 
 static void
@@ -268,6 +270,8 @@ od_config_print(od_config_t *config, od_logger_t *logger)
 		       "client_max           %d", config->client_max);
 	od_log(logger, "config", NULL, NULL,
 	       "client_max_routing   %d", config->client_max_routing);
+	od_log(logger, "config", NULL, NULL,
+	       "server_login_retry   %d", config->server_login_retry);
 	od_log(logger, "config", NULL, NULL,
 	       "cache_msg_gc_size    %d", config->cache_msg_gc_size);
 	od_log(logger, "config", NULL, NULL,

--- a/sources/config.c
+++ b/sources/config.c
@@ -46,6 +46,7 @@ od_config_init(od_config_t *config)
 	config->client_max_set       = 0;
 	config->client_max           = 0;
 	config->client_max_routing   = 0;
+	config->server_max_routing   = 0;
 	config->server_login_retry   = 1;
 	config->cache_coroutine      = 0;
 	config->cache_msg_gc_size    = 0;
@@ -58,6 +59,7 @@ od_config_reload(od_config_t *current_config, od_config_t *new_config)
 {
 	current_config->client_max = new_config->client_max;
 	current_config->client_max_routing = new_config->client_max_routing;
+	current_config->server_max_routing = new_config->server_max_routing;
 	current_config->server_login_retry = new_config->server_login_retry;
 }
 
@@ -270,6 +272,8 @@ od_config_print(od_config_t *config, od_logger_t *logger)
 		       "client_max           %d", config->client_max);
 	od_log(logger, "config", NULL, NULL,
 	       "client_max_routing   %d", config->client_max_routing);
+	od_log(logger, "config", NULL, NULL,
+	       "server_max_routing   %d", config->server_max_routing);
 	od_log(logger, "config", NULL, NULL,
 	       "server_login_retry   %d", config->server_login_retry);
 	od_log(logger, "config", NULL, NULL,

--- a/sources/config.h
+++ b/sources/config.h
@@ -61,6 +61,7 @@ struct od_config
 	int        client_max_set;
 	int        client_max;
 	int        client_max_routing;
+	int        server_max_routing;
 	int        server_login_retry;
 	int        cache_coroutine;
 	int        cache_msg_gc_size;

--- a/sources/config.h
+++ b/sources/config.h
@@ -61,6 +61,7 @@ struct od_config
 	int        client_max_set;
 	int        client_max;
 	int        client_max_routing;
+	int        server_login_retry;
 	int        cache_coroutine;
 	int        cache_msg_gc_size;
 	int        coroutine_stack_size;

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -65,6 +65,7 @@ enum
 	OD_LCOROUTINE_STACK_SIZE,
 	OD_LCLIENT_MAX,
 	OD_LCLIENT_MAX_ROUTING,
+	OD_LSERVERS_MAX_ROUTING,
 	OD_LSERVER_LOGIN_RETRY,
 	OD_LCLIENT_LOGIN_TIMEOUT,
 	OD_LCLIENT_FWD_ERROR,
@@ -152,9 +153,10 @@ od_config_keywords[] =
 	od_keyword("cache_coroutine",      OD_LCACHE_COROUTINE),
 	od_keyword("coroutine_stack_size", OD_LCOROUTINE_STACK_SIZE),
 	od_keyword("client_max",           OD_LCLIENT_MAX),
-	od_keyword("client_max_routing",           OD_LCLIENT_MAX_ROUTING),
-	od_keyword("server_login_retry",           OD_LSERVER_LOGIN_RETRY),
-	od_keyword("client_login_timeout",       OD_LCLIENT_LOGIN_TIMEOUT),
+	od_keyword("client_max_routing",   OD_LCLIENT_MAX_ROUTING),
+	od_keyword("server_max_routing",  OD_LSERVERS_MAX_ROUTING),
+	od_keyword("server_login_retry",   OD_LSERVER_LOGIN_RETRY),
+	od_keyword("client_login_timeout", OD_LCLIENT_LOGIN_TIMEOUT),
 	od_keyword("client_fwd_error",     OD_LCLIENT_FWD_ERROR),
 	od_keyword("application_name_add_host",     OD_LAPPLICATION_NAME_ADD_HOST),
 	od_keyword("tls",                  OD_LTLS),
@@ -974,6 +976,11 @@ od_config_reader_parse(od_config_reader_t *reader)
 			if (! od_config_reader_number(reader, &config->client_max_routing))
 				return -1;
 			continue;
+		/* server_max_routing */
+		case OD_LSERVERS_MAX_ROUTING:
+			if (! od_config_reader_number(reader, &config->server_max_routing))
+				return -1;
+			continue;
 		/* server_login_retry */
 		case OD_LSERVER_LOGIN_RETRY:
 			if (! od_config_reader_number(reader, &config->server_login_retry))
@@ -1079,5 +1086,7 @@ od_config_reader_import(od_config_t *config, od_rules_t *rules, od_error_t *erro
 
 	if (!config->client_max_routing)
 		config->client_max_routing = config->workers * 16;
+	if (!config->server_max_routing)
+		config->server_max_routing = config->workers * 2;
 	return rc;
 }

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -65,6 +65,7 @@ enum
 	OD_LCOROUTINE_STACK_SIZE,
 	OD_LCLIENT_MAX,
 	OD_LCLIENT_MAX_ROUTING,
+	OD_LSERVER_LOGIN_RETRY,
 	OD_LCLIENT_LOGIN_TIMEOUT,
 	OD_LCLIENT_FWD_ERROR,
 	OD_LAPPLICATION_NAME_ADD_HOST,
@@ -152,6 +153,7 @@ od_config_keywords[] =
 	od_keyword("coroutine_stack_size", OD_LCOROUTINE_STACK_SIZE),
 	od_keyword("client_max",           OD_LCLIENT_MAX),
 	od_keyword("client_max_routing",           OD_LCLIENT_MAX_ROUTING),
+	od_keyword("server_login_retry",           OD_LSERVER_LOGIN_RETRY),
 	od_keyword("client_login_timeout",       OD_LCLIENT_LOGIN_TIMEOUT),
 	od_keyword("client_fwd_error",     OD_LCLIENT_FWD_ERROR),
 	od_keyword("application_name_add_host",     OD_LAPPLICATION_NAME_ADD_HOST),
@@ -970,6 +972,11 @@ od_config_reader_parse(od_config_reader_t *reader)
 		/* client_max_routing */
 		case OD_LCLIENT_MAX_ROUTING:
 			if (! od_config_reader_number(reader, &config->client_max_routing))
+				return -1;
+			continue;
+		/* server_login_retry */
+		case OD_LSERVER_LOGIN_RETRY:
+			if (! od_config_reader_number(reader, &config->server_login_retry))
 				return -1;
 			continue;
 		/* readahead */

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -209,7 +209,9 @@ od_frontend_attach(od_client_t *client, char *context, kiwi_params_t *route_para
 			return OD_OK;
 
 		int rc;
+		od_atomic_u32_inc(&router->servers_routing);
 		rc = od_backend_connect(server, context, route_params);
+		od_atomic_u32_dec(&router->servers_routing);
 		if (rc == -1)
 		{
 			/* In case of 'too many connections' error, retry attach attempt by

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -219,6 +219,8 @@ od_frontend_attach(od_client_t *client, char *context, kiwi_params_t *route_para
 			                od_frontend_error_is_too_many_connections(client);
 			if (wait_for_idle) {
 				od_router_close(router, client);
+				if (instance->config.server_login_retry)
+					machine_sleep(instance->config.server_login_retry);
 				continue;
 			}
 			return OD_ESERVER_CONNECT;

--- a/sources/router.h
+++ b/sources/router.h
@@ -26,6 +26,7 @@ struct od_router
 	od_route_pool_t route_pool;
 	od_atomic_u32_t clients;
 	od_atomic_u32_t clients_routing;
+	od_atomic_u32_t servers_routing;
 };
 
 static inline void


### PR DESCRIPTION
When the server is full we do not limit reconnects from the user, this can result in a lot of useless retries.
This behaviour is resemblant to pgbouncer's server_login_retry https://github.com/pgbouncer/pgbouncer/blob/master/etc/pgbouncer.ini#L246