### PR TITLE
Add psql apt repository to bionic apt repository in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,15 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    gnupg \
+    lsb-release
+
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     gcc \


### PR DESCRIPTION
In this Dockerfile, the base image is ubuntu bionic.
I think bionic cannot install `postgresql-server-dev-11` via bionic's standard apt repository(see: [here](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=postgresql-server-dev&searchon=names)).
And actually, docker build was failed in my local environment because of not locating `postgresql-server-dev-11`.
So, it's need to add psql apt repository in this way.

(cf: https://wiki.postgresql.org/wiki/Apt)