### PR TITLE
Try to stop TLS handshakes on shutdown

### DIFF
--- a/sources/system.c
+++ b/sources/system.c
@@ -412,12 +412,17 @@ od_system_signal_handler(void *arg)
 		case SIGTERM:
 			od_log(&instance->logger, "system", NULL, NULL,
 			       "SIGTERM received, shutting down");
+			od_worker_pool_stop(system->global->worker_pool);
+			/* No time for caution */
 			od_system_cleanup(system);
 			exit(0);
 			break;
 		case SIGINT:
 			od_log(&instance->logger, "system", NULL, NULL,
 			       "SIGINT received, shutting down");
+			od_worker_pool_stop(system->global->worker_pool);
+			/* Prevent OpenSSL usage during deinitialization */
+			od_worker_pool_wait(system->global->worker_pool);
 			od_system_cleanup(system);
 			exit(0);
 			break;

--- a/sources/worker_pool.h
+++ b/sources/worker_pool.h
@@ -44,6 +44,41 @@ od_worker_pool_start(od_worker_pool_t *pool, od_global_t *global, int count)
 }
 
 static inline void
+od_worker_pool_stop(od_worker_pool_t *pool)
+{
+	od_instance_t *instance = pool->pool->global->instance;
+	int is_shared;
+	is_shared = od_config_is_multi_workers(&instance->config);
+	if (!is_shared)
+		return;
+
+	for (int i = 0; i < pool->count; i++) {
+		od_worker_t *worker = &pool->pool[i];
+		machine_stop(worker->machine);
+	}
+}
+
+static inline void
+od_worker_pool_wait(od_worker_pool_t *pool)
+{
+	od_instance_t *instance = pool->pool->global->instance;
+	int is_shared;
+	is_shared = od_config_is_multi_workers(&instance->config);
+	if (!is_shared)
+		return;
+
+	// In fact we cannot wait anything here - machines may be in epoll waiting
+	// No new TLS handshakes should be initiated, so, just wait a bit.
+	machine_sleep(1);
+	/*
+	for (int i = 0; i < pool->count; i++) {
+		od_worker_t *worker = &pool->pool[i];
+		machine_wait(worker->machine);
+	}
+	*/
+}
+
+static inline void
 od_worker_pool_feed(od_worker_pool_t *pool, machine_msg_t *msg)
 {
 	int next = pool->round_robin;

--- a/test/machinarium/test_condition0.c
+++ b/test/machinarium/test_condition0.c
@@ -9,7 +9,7 @@ test_condition_coroutine(void *arg)
 {
 	(void)arg;
 	machine_cond_signal(condition);
-	machine_stop();
+	machine_stop_current();
 }
 
 static void
@@ -28,7 +28,7 @@ test_waiter(void *arg)
 	rc = machine_cond_wait(condition, UINT32_MAX);
 	test(rc == 0);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_connect.c
+++ b/test/machinarium/test_connect.c
@@ -40,7 +40,7 @@ test_waiter(void *arg)
 	rc = machine_join(id);
 	test(rc == 0);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_connect_cancel1.c
+++ b/test/machinarium/test_connect_cancel1.c
@@ -39,7 +39,7 @@ test_waiter(void *arg)
 	rc = machine_join(id);
 	test(rc == -1);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_context_switch.c
+++ b/test/machinarium/test_context_switch.c
@@ -26,7 +26,7 @@ csw_runner(void *arg)
 	test(rc != -1);
 	test(csw == 100000);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_create0.c
+++ b/test/machinarium/test_create0.c
@@ -9,7 +9,7 @@ coroutine(void *arg)
 {
 	(void)arg;
 	coroutine_call++;
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_eventfd.c
+++ b/test/machinarium/test_eventfd.c
@@ -46,7 +46,7 @@ test_waiter(void *arg)
 
 	machine_cond_free(cond);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_join.c
+++ b/test/machinarium/test_join.c
@@ -35,7 +35,7 @@ test_waiter(void *arg)
 	rc = machine_join(b);
 	test(rc == 0);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_sleep.c
+++ b/test/machinarium/test_sleep.c
@@ -7,7 +7,7 @@ coroutine(void *arg)
 {
 	(void)arg;
 	machine_sleep(100);
-	machine_stop();
+	machine_stop_current();
 }
 
 void
@@ -32,7 +32,7 @@ coroutine_random_sleep(void *arg)
 	(void)arg;
 	long int duration = machine_lrand48();
 	machine_sleep(duration & 0xFF);
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_sleep_cancel0.c
+++ b/test/machinarium/test_sleep_cancel0.c
@@ -27,7 +27,7 @@ test_sleep_cancel0_parent(void *arg)
 	rc = machine_join(id);
 	test(rc == 0);
 
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/test/machinarium/test_sleep_yield.c
+++ b/test/machinarium/test_sleep_yield.c
@@ -7,7 +7,7 @@ coroutine(void *arg)
 {
 	(void)arg;
 	machine_sleep(0);
-	machine_stop();
+	machine_stop_current();
 }
 
 void

--- a/third_party/machinarium/sources/machinarium.h
+++ b/third_party/machinarium/sources/machinarium.h
@@ -67,7 +67,7 @@ MACHINE_API int64_t
 machine_create(char *name, machine_coroutine_t, void *arg);
 
 MACHINE_API void
-machine_stop(void);
+machine_stop_current(void);
 
 MACHINE_API int
 machine_active(void);
@@ -77,6 +77,9 @@ machine_self(void);
 
 MACHINE_API int
 machine_wait(uint64_t machine_id);
+
+MACHINE_API int
+machine_stop(uint64_t machine_id);
 
 MACHINE_API uint64_t
 machine_time_ms(void);

--- a/third_party/machinarium/sources/machine.c
+++ b/third_party/machinarium/sources/machine.c
@@ -53,7 +53,7 @@ machine_main(void *arg)
 	/* run main loop */
 	machine->online = 1;
 	for (;;) {
-		if (! mm_scheduler_online(&machine->scheduler))
+		if (! (mm_scheduler_online(&machine->scheduler) && machine->online))
 			break;
 		mm_loop_step(&machine->loop);
 	}
@@ -148,6 +148,17 @@ machine_wait(uint64_t machine_id)
 }
 
 MACHINE_API int
+machine_stop(uint64_t machine_id)
+{
+	mm_machine_t *machine;
+	machine = mm_machinemgr_delete_by_id(&machinarium.machine_mgr, machine_id);
+	if (machine == NULL)
+		return -1;
+	machine->online = 0;
+	return 0;
+}
+
+MACHINE_API int
 machine_active(void)
 {
 	return mm_self->online;
@@ -160,7 +171,7 @@ machine_self(void)
 }
 
 MACHINE_API void
-machine_stop(void)
+machine_stop_current(void)
 {
 	mm_self->online = 0;
 }

--- a/third_party/machinarium/sources/machine.h
+++ b/third_party/machinarium/sources/machine.h
@@ -11,7 +11,7 @@ typedef struct mm_machine mm_machine_t;
 
 struct mm_machine
 {
-	int                  online;
+	volatile int         online;
 	uint64_t             id;
 	char                *name;
 	machine_coroutine_t  main;

--- a/third_party/machinarium/sources/machine_mgr.c
+++ b/third_party/machinarium/sources/machine_mgr.c
@@ -65,3 +65,20 @@ mm_machinemgr_delete_by_id(mm_machinemgr_t *mgr, uint64_t id)
 	pthread_spin_unlock(&mgr->lock);
 	return NULL;
 }
+
+mm_machine_t*
+mm_machinemgr_find_by_id(mm_machinemgr_t *mgr, uint64_t id)
+{
+	pthread_spin_lock(&mgr->lock);
+	mm_list_t *i;
+	mm_list_foreach(&mgr->list, i) {
+		mm_machine_t *machine;
+		machine = mm_container_of(i, mm_machine_t, link);
+		if (machine->id == id) {
+			pthread_spin_unlock(&mgr->lock);
+			return machine;
+		}
+	}
+	pthread_spin_unlock(&mgr->lock);
+	return NULL;
+}

--- a/third_party/machinarium/sources/machine_mgr.h
+++ b/third_party/machinarium/sources/machine_mgr.h
@@ -24,5 +24,7 @@ void mm_machinemgr_add(mm_machinemgr_t*, mm_machine_t*);
 void mm_machinemgr_delete(mm_machinemgr_t*, mm_machine_t*);
 mm_machine_t*
 mm_machinemgr_delete_by_id(mm_machinemgr_t*, uint64_t);
+mm_machine_t*
+mm_machinemgr_find_by_id(mm_machinemgr_t*, uint64_t);
 
 #endif /* MM_MACHINE_MGR_H */


### PR DESCRIPTION
This should fix problem with termination of heavily loaded instances

`
Thread 4 (Thread 0x7f5dc759f780 (LWP 373439)):
#0  0x00007f5dc6d6365b in pthread_join (threadid=140040753280768, thread_return=0x0) at pthread_join.c:92
#1  0x000000000046f94b in machine_wait ()
#2  0x000000000046efe6 in od_instance_main ()
#3  0x0000000000451088 in main ()

Thread 3 (Thread 0x7f5dc75ab700 (LWP 373440)):
#0  0x00007f5dc6a8f6d3 in epoll_wait () at ../sysdeps/unix/syscall-template.S:81
---Type <return> to continue, or q <return> to quit---
#1  0x0000000000475181 in mm_epoll_step ()
#2  0x0000000000474892 in mm_loop_step ()
#3  0x000000000046faf0 in machine_main ()
#4  0x00007f5dc6d62184 in start_thread (arg=0x7f5dc75ab700) at pthread_create.c:312
#5  0x00007f5dc6a8f03d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111

Thread 2 (Thread 0x7f5dc75a7700 (LWP 373441)):
#0  0x00000000006171c0 in engine_list_cleanup ()
#1  0x00000000004fc3c6 in engine_cleanup_cb_free ()
#2  0x000000000056b7f3 in OPENSSL_sk_pop_free ()
#3  0x00000000004fc6ec in engine_cleanup_int ()
#4  0x000000000051a73a in OPENSSL_cleanup ()
#5  0x00007f5dc69cd1a9 in __run_exit_handlers (status=0, listp=0x7f5dc6d536c8 <__exit_funcs>, 
    run_list_atexit=run_list_atexit@entry=true) at exit.c:82
#6  0x00007f5dc69cd1f5 in __GI_exit (status=<optimized out>) at exit.c:104
#7  0x000000000045bbaa in od_system_signal_handler ()
#8  0x00000000004759d0 in mm_scheduler_main ()
#9  0x0000000000476883 in mm_context_runner ()
#10 0x0000000000000000 in ?? ()

Thread 1 (Thread 0x7f5dc7516700 (LWP 373456)):
#0  pthread_rwlock_wrlock () at ../nptl/sysdeps/unix/sysv/linux/x86_64/pthread_rwlock_wrlock.S:41
#1  0x000000000056c179 in CRYPTO_THREAD_write_lock ()
#2  0x000000000053b747 in RAND_get_rand_method ()
#3  0x000000000053ba42 in RAND_bytes ()
#4  0x000000000049463b in def_generate_session_id ()
#5  0x0000000000494974 in ssl_generate_session_id ()
#6  0x00000000004afc5f in tls_construct_new_session_ticket ()
#7  0x00000000004a184f in state_machine.part ()
#8  0x000000000048d5c4 in SSL_do_handshake ()
#9  0x0000000000470e1d in mm_tls_handshake_cb ()
#10 0x00000000004751d6 in mm_epoll_step ()
#11 0x0000000000474892 in mm_loop_step ()
#12 0x000000000046faf0 in machine_main ()
---Type <return> to continue, or q <return> to quit---
#13 0x00007f5dc6d62184 in start_thread (arg=0x7f5dc7516700) at pthread_create.c:312
#14 0x00007f5dc6a8f03d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
`