### PR TITLE
fix usage of od_b64_decode

### DIFF
--- a/sources/scram.c
+++ b/sources/scram.c
@@ -668,11 +668,15 @@ od_scram_read_client_final_message(od_scram_state_t *scram_state,
 			goto error;
 	} while (attribute != 'p');
 
-	proof = malloc(pg_b64_dec_len(base64_proof_size));
+	int proof_size = pg_b64_dec_len(base64_proof_size);
+	proof          = malloc(proof_size);
 	if (proof == NULL)
 		goto error;
 
-	od_b64_decode(base64_proof, base64_proof_size, proof, base64_proof_len);
+	int proof_len =
+	  od_b64_decode(base64_proof, base64_proof_size, proof, proof_size);
+	if (proof_len < 0)
+		goto error;
 
 	if (auth_data_size)
 		goto error;


### PR DESCRIPTION
fixed issues:
* return value was unchecked
* src buffer length was passed instead of dst buffer length as 4th parameter

first issue was detected by coverty:
https://scan8.coverity.com/reports.htm#v40721/p12618/fileInstanceId=32935028&defectInstanceId=10694020&mergedDefectId=286529&eventId=10694020-15