### PR TITLE
adjust odyssey_test dependencies

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories("${PROJECT_SOURCE_DIR}/test")
 include_directories("${PROJECT_BINARY_DIR}/test")
 
 add_executable(${od_test_binary} ${od_test_src})
-add_dependencies(${od_test_binary} build_libs)
+add_dependencies(${od_test_binary} build_libs odyssey)
 
 if(THREADS_HAVE_PTHREAD_ARG)
     set_property(TARGET ${od_test_binary} PROPERTY COMPILE_OPTIONS "-pthread")


### PR DESCRIPTION
If odyssey_test target was built selectively then run would fail because of missing odyssey binary.
So top-level cmake dependency to odyssey was required.