### PR TITLE
Protection from broken sync during packet pipelining

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -971,6 +971,7 @@ od_frontend_cleanup(od_client_t *client,
 		case OD_SKIP:
 		case OD_ATTACH:
 		case OD_DETACH:
+		case OD_ESYNC_BROKEN:
 			od_error(&instance->logger,
 			         context,
 			         client,

--- a/sources/relay.h
+++ b/sources/relay.h
@@ -212,8 +212,11 @@ od_relay_process(od_relay_t *relay, int *progress, char *data, int size)
 		if (size < (int)sizeof(kiwi_header_t))
 			return OD_UNDEF;
 
-		int body;
-		body = kiwi_read_size(data, sizeof(kiwi_header_t));
+		uint32_t body;
+		rc = kiwi_validate_header(data, sizeof(kiwi_header_t), &body);
+		if (rc != 0)
+			return OD_ESYNC_BROKEN;
+
 		body -= sizeof(uint32_t);
 
 		int total = sizeof(kiwi_header_t) + body;

--- a/sources/status.h
+++ b/sources/status.h
@@ -23,6 +23,7 @@ typedef enum
 	OD_ESERVER_WRITE,
 	OD_ECLIENT_READ,
 	OD_ECLIENT_WRITE,
+	OD_ESYNC_BROKEN,
 } od_frontend_status_t;
 
 static inline char *
@@ -57,6 +58,8 @@ od_frontend_status_to_str(od_frontend_status_t status)
 			return "OD_ECLIENT_READ";
 		case OD_ECLIENT_WRITE:
 			return "OD_ECLIENT_WRITE";
+		case OD_ESYNC_BROKEN:
+			return "OD_ESYNC_BROKEN";
 	}
 	return "unkonown";
 }
@@ -69,6 +72,7 @@ static const od_frontend_status_t od_frontend_status_errs[] = {
 	OD_ESERVER_READ,
 	OD_ESERVER_WRITE,
 	OD_ECLIENT_WRITE,
+	OD_ESYNC_BROKEN,
 };
 
 #define OD_FRONTEND_STATUS_ERRORS_TYPES_COUNT                                  \


### PR DESCRIPTION
Segfault can be reproduced by this go code

```
package main

import (
        "fmt"
        "github.com/jackc/pgproto3"
)
import "os"
import "context"
import pgx "github.com/jackc/pgx"

func main() {
        ctx := context.Background()
        conn, err := pgx.Connect(ctx, "host=::1 port=6432 user=x4mmm database=postgres")
        if err != nil {
                fmt.Fprintf(os.Stderr, "Unable to connection to database: %v\n", err)
                os.Exit(1)
        }
        pgConn := conn.PgConn().Conn()
        buf := make([]byte,8192)
        buf = (&pgproto3.Query{String: "select 1"}).Encode(buf)
        buf[0] = 0x80
        buf[1] = 0x80
        buf[2] = 0x80
        buf[3] = 0x80
        pgConn.Write(buf)
}

```