### PR TITLE
use iso 8601 format in datetime

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -66,7 +66,8 @@ Supported flags:
 
 ```
 %n = unixtime
-%t = timestamp with date
+%t = timestamp with date in iso 8601 format
+%e = millisEcond
 %p = process ID
 %i = client ID
 %s = server ID
@@ -80,7 +81,7 @@ Supported flags:
 %h = client host
 ```
 
-`log_format "%p %t %l [%i %s] (%c) %m\n"`
+`log_format "%p %t %e %l [%i %s] (%c) %m\n"`
 
 #### log\_to\_stdout *yes|no*
 

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -209,11 +209,16 @@ od_logger_format(od_logger_t *logger,
 				case 't': {
 					struct timeval tv;
 					gettimeofday(&tv, NULL);
-					len = strftime(dst_pos,
-					               dst_end - dst_pos,
-					               "%d %b %H:%M:%S.",
-					               localtime(&tv.tv_sec));
+					len = strftime(
+					  dst_pos, dst_end - dst_pos, "%FT%TZ", gmtime(&tv.tv_sec));
 					dst_pos += len;
+
+					break;
+				}
+				/* millis */
+				case 'e': {
+					struct timeval tv;
+					gettimeofday(&tv, NULL);
 					len = od_snprintf(dst_pos,
 					                  dst_end - dst_pos,
 					                  "%03d",


### PR DESCRIPTION
tskv datetime=2020-07-29T10:53:50Z ms=639 pid=14993 unixtime=1596020030 level=info cid=none sid=none db=none user=none ctx=server cluster=mdb3vv65vfp2ed6332gkhostname=iva-z9a11y5kjani1u97.db.yandex.net origin=odyssey msg=listening on [::]:6432