### PR TITLE
Fix calculation of latencies

### DIFF
--- a/sources/deploy.c
+++ b/sources/deploy.c
@@ -42,9 +42,12 @@ int od_deploy(od_client_t *client, char *context)
 			return -1;
 
 		query_count++;
+		client->server->synced_settings = false;
 
 		od_debug(&instance->logger, context, client, server,
 			 "deploy: %s", query);
+	} else {
+		client->server->synced_settings = true;
 	}
 
 	return query_count;

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -727,8 +727,6 @@ static od_frontend_status_t od_frontend_remote_server(od_relay_t *relay,
 				 query_time);
 		}
 
-
-
 		break;
 	}
 	default:

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -710,6 +710,13 @@ static od_frontend_status_t od_frontend_remote_server(od_relay_t *relay,
 		is_ready_for_query = 1;
 		od_backend_ready(server, data, size);
 
+		if (is_deploy)
+			server->deploy_sync--;
+
+		if (!server->synced_settings) {
+			server->synced_settings = true;
+			break;
+		}
 		/* update server stats */
 		int64_t query_time = 0;
 		od_stat_query_end(&route->stats, &server->stats_state,
@@ -720,8 +727,7 @@ static od_frontend_status_t od_frontend_remote_server(od_relay_t *relay,
 				 query_time);
 		}
 
-		if (is_deploy)
-			server->deploy_sync--;
+
 
 		break;
 	}

--- a/sources/server.h
+++ b/sources/server.h
@@ -42,6 +42,7 @@ struct od_server {
 	int offline;
 	uint64_t init_time_us;
 	od_list_t link;
+	bool synced_settings;
 };
 
 static inline void od_server_init(od_server_t *server)


### PR DESCRIPTION
What was the problem?
- Calculation of latencies with pool_mode=transaction and pool_discard=yes returned strange little values.

Why did it happen?
1. Due to pool_mode=transaction after every transaction, a connection was detached from PG connection.
2. Due to pool_discard=yes every pg_connection dropped all settings after a transaction.
3. As a result when we got a new query, the session started with setting application_name before the real query.
4. Latency is calculated after getting the ReadyForQuery message, but there was a "set application_query" before the real and we got the ReadyForQuery message for it first.

What is the idea of the fix?
- Calculate latencies only after be sure that client and server settings are synced.