### PR TITLE
fix bench compile errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test/odyssey_test
 test/odyssey/data
 third_party/machinarium/sources/build.h
 third_party/machinarium/benchmark/benchmark_csw
+third_party/machinarium/benchmark/benchmark_csw2
 third_party/machinarium/benchmark/benchmark_channel
 third_party/machinarium/benchmark/benchmark_channel_shared
 build/

--- a/third_party/machinarium/benchmark/Makefile
+++ b/third_party/machinarium/benchmark/Makefile
@@ -3,10 +3,12 @@ RM         = rm
 CFLAGS     = -I. -Wall -g -O3 -I../sources
 LFLAGS_LIB = ../sources/libmachinarium.a -pthread -lssl -lcrypto
 LFLAGS     = $(LFLAGS_LIB)
-EXAMPLES   = benchmark_csw benchmark_channel benchmark_channel_shared
+EXAMPLES   = benchmark_csw benchmark_csw2 benchmark_channel benchmark_channel_shared
 all: clean $(EXAMPLES)
 benchmark_csw:
 	$(CC) $(CFLAGS) benchmark_csw.c $(LFLAGS) -o benchmark_csw
+benchmark_csw2:
+	$(CC) $(CFLAGS) benchmark_csw2.c $(LFLAGS) -o benchmark_csw2
 benchmark_channel:
 	$(CC) $(CFLAGS) benchmark_channel.c $(LFLAGS) -o benchmark_channel
 benchmark_channel_shared:

--- a/third_party/machinarium/benchmark/benchmark_channel.c
+++ b/third_party/machinarium/benchmark/benchmark_channel.c
@@ -26,7 +26,7 @@ static void benchmark_writer(void *arg)
 	machine_channel_t *channel = arg;
 	while (machine_active()) {
 		machine_msg_t *msg;
-		msg = machine_msg_create(0, 0);
+		msg = machine_msg_create(0);
 		machine_channel_write(channel, msg);
 		ops++;
 		machine_sleep(0);
@@ -44,7 +44,7 @@ static void benchmark_runner(void *arg)
 	int w = machine_coroutine_create(benchmark_writer, channel);
 
 	machine_sleep(1000);
-	machine_stop();
+	machine_stop_current();
 	machine_cancel(r);
 	machine_join(r);
 	machine_join(w);

--- a/third_party/machinarium/benchmark/benchmark_channel_shared.c
+++ b/third_party/machinarium/benchmark/benchmark_channel_shared.c
@@ -44,7 +44,7 @@ static void benchmark_runner(void *arg)
 	int w = machine_coroutine_create(benchmark_writer, q);
 
 	machine_sleep(1000);
-	machine_stop();
+	machine_stop_current();
 	machine_cancel(r);
 	machine_join(r);
 	machine_join(w);

--- a/third_party/machinarium/benchmark/benchmark_csw.c
+++ b/third_party/machinarium/benchmark/benchmark_csw.c
@@ -31,7 +31,7 @@ static void benchmark_runner(void *arg)
 	machine_sleep(1000);
 	printf("done.\n");
 	printf("context switches %d in 1 sec.\n", csw);
-	machine_stop();
+	machine_stop_current();
 }
 
 int main(int argc, char *argv[])

--- a/third_party/machinarium/benchmark/benchmark_csw2.c
+++ b/third_party/machinarium/benchmark/benchmark_csw2.c
@@ -1,0 +1,57 @@
+
+/*
+ * machinarium.
+ *
+ * Cooperative multitasking engine.
+ */
+
+/*
+ * This example shows coroutine context switch (yield)
+ * performance done in one second.
+ */
+
+#include <machinarium.h>
+
+#define MAX_COROUTINES 1000
+
+int csws[MAX_COROUTINES];
+
+static void benchmark_worker(void *arg)
+{
+	int id = arg;
+	//	printf("worker started.\n");
+	while (machine_active()) {
+		csws[id]++;
+		machine_sleep(0);
+	}
+	//	printf("worker done.\n");
+}
+
+static void benchmark_runner(void *arg)
+{
+	printf("benchmark started.\n");
+	for (int i = 0; i < MAX_COROUTINES; ++i) {
+		machine_coroutine_create(benchmark_worker, i);
+	}
+	machine_sleep(1000);
+	printf("done.\n");
+
+	int csw = 0;
+	for (int i = 0; i < MAX_COROUTINES; ++i) {
+		csw += csws[i];
+	}
+	fflush(stdout);
+	printf("_______________________________\n");
+	printf("context switches %d in 1 sec.\n", csw);
+	machine_stop_current();
+}
+
+int main(int argc, char *argv[])
+{
+	machinarium_init();
+	int id = machine_create("benchmark_csw", benchmark_runner, NULL);
+	int rc = machine_wait(id);
+	printf("retcode from machine wait %d.\n", rc);
+	machinarium_free();
+	return 0;
+}


### PR DESCRIPTION
➜ ./benchmark_csw           
benchmark started.
worker started.
done.
context switches 2025400 in 1 sec.
worker done.
retcode from machine wait 0.

➜ ./benchmark_channel_shared
benchmark started.
done.
channel operations 1782334 in 1 sec.


➜ ./benchmark_channel 
benchmark started.
done.
channel operations 1796785 in 1 sec.
