### PR TITLE
Fix default_user ldap auth for default user configuration

### DIFF
--- a/docker/ldap/odyssey.conf
+++ b/docker/ldap/odyssey.conf
@@ -54,6 +54,28 @@ database "ldap_db" {
 		quantiles "0.99,0.95,0.5"
                 client_max 107
 	}
+	user default {
+		authentication "clear_text"
+		storage "postgres_server"
+		storage_password "1"
+		pool "session"
+		pool_size 10
+		ldap_pool_size 10
+		ldap_pool_timeout 0
+        pool_timeout 0
+		pool_ttl 60
+		pool_discard no
+		pool_cancel yes
+		pool_rollback yes
+		client_fwd_error yes
+		application_name_add_host yes
+		reserve_session_server_connection no
+		server_lifetime 3600
+		log_debug no
+		ldap_endpoint_name "ldap1"
+		quantiles "0.99,0.95,0.5"
+		client_max 10
+	}
 }
 
 unix_socket_dir "/tmp"

--- a/docker/ldap/test_ldap.sh
+++ b/docker/ldap/test_ldap.sh
@@ -3,6 +3,9 @@
 ldapadd -x -H ldap://192.168.233.16 -D "cn=admin,dc=example,dc=org" -wadmin -f /ldap/usr1.ldif
 # wait for ldap server to do smt
 sleep 1
+ldapadd -x -H ldap://192.168.233.16 -D "cn=admin,dc=example,dc=org" -wadmin -f /ldap/usr3.ldif
+# wait for ldap server to do smt
+sleep 1
 
 /usr/bin/odyssey /ldap/odyssey.conf
 
@@ -15,6 +18,20 @@ PGPASSWORD=lolol psql -h localhost -p 6432 -U user1 -c "select 1" ldap_db > /dev
 
 PGPASSWORD=notlolol psql -h localhost -p 6432 -U user1 -c "select 1" ldap_db > /dev/null 2>&1 && {
     echo "error:  successfully auth with incorrect password"
+    ody-stop
+    cat /var/log/odyssey.log
+    exit 1
+}
+
+PGPASSWORD=default psql -h localhost -p 6432 -U user3 -c "select 1" ldap_db > /dev/null 2>&1 && {
+    echo "error: failed to successfully auth with correct password as default user"
+    ody-stop
+    cat /var/log/odyssey.log
+    exit 1
+}
+
+PGPASSWORD=notdefault psql -h localhost -p 6432 -U user3 -c "select 1" ldap_db > /dev/null 2>&1 && {
+    echo "error:  successfully auth with incorrect password as default user"
     ody-stop
     cat /var/log/odyssey.log
     exit 1

--- a/docker/ldap/usr3.ldif
+++ b/docker/ldap/usr3.ldif
@@ -1,0 +1,18 @@
+dn: uid=user3,dc=example,dc=org
+objectClass: top
+objectClass: account
+objectClass: posixAccount
+objectClass: shadowAccount
+cn: user3
+uid: user3
+uidNumber: 16859
+gidNumber: 100
+homeDirectory: /home/user3
+loginShell: /bin/bash
+gecos: user3
+userPassword: default
+shadowLastChange: 0
+shadowMax: 0
+shadowWarning: 0
+
+

--- a/sources/ldap.c
+++ b/sources/ldap.c
@@ -217,7 +217,7 @@ od_ldap_server_t *od_ldap_server_allocate()
 static inline od_retcode_t od_ldap_server_init(od_logger_t *logger,
 					       od_ldap_server_t *server,
 					       od_route_t *route,
-						   od_client_t *client)
+					       od_client_t *client)
 {
 	od_id_generate(&server->id, "ls");
 	od_list_init(&server->link);
@@ -329,7 +329,8 @@ static inline od_ldap_server_t *od_ldap_server_attach(od_route_t *route,
 		/* create new server object */
 		server = od_ldap_server_allocate();
 
-		int ldap_rc = od_ldap_server_init(logger, server, route, client);
+		int ldap_rc =
+			od_ldap_server_init(logger, server, route, client);
 
 		od_route_lock(route);
 		od_ldap_server_pool_set(&route->ldap_pool, server,

--- a/sources/ldap.c
+++ b/sources/ldap.c
@@ -106,7 +106,7 @@ od_retcode_t od_ldap_endpoint_prepare(od_ldap_endpoint_t *le)
 
 static inline od_retcode_t od_ldap_server_prepare(od_logger_t *logger,
 						  od_ldap_server_t *serv,
-						  od_route_t *route)
+						  od_client_t *client)
 {
 	od_retcode_t rc;
 	char *auth_user = NULL;
@@ -142,10 +142,10 @@ static inline od_retcode_t od_ldap_server_prepare(od_logger_t *logger,
 		} else if (serv->endpoint->ldapsearchattribute) {
 			od_asprintf(&filter, "(%s=%s)",
 				    serv->endpoint->ldapsearchattribute,
-				    route->rule->user_name);
+				    client->startup.user.value);
 		} else {
 			od_asprintf(&filter, "(uid=%s)",
-				    route->rule->user_name);
+				    client->startup.user.value);
 		}
 
 		rc = ldap_search_s(serv->conn, serv->endpoint->ldapbasedn,
@@ -193,7 +193,7 @@ static inline od_retcode_t od_ldap_server_prepare(od_logger_t *logger,
 			    serv->endpoint->ldapprefix ?
 				    serv->endpoint->ldapprefix :
 				    "",
-			    route->rule->user_name,
+			    client->startup.user.value,
 			    serv->endpoint->ldapsuffix ?
 				    serv->endpoint->ldapsuffix :
 				    "");
@@ -216,7 +216,8 @@ od_ldap_server_t *od_ldap_server_allocate()
 
 static inline od_retcode_t od_ldap_server_init(od_logger_t *logger,
 					       od_ldap_server_t *server,
-					       od_route_t *route)
+					       od_route_t *route,
+						   od_client_t *client)
 {
 	od_id_generate(&server->id, "ls");
 	od_list_init(&server->link);
@@ -231,7 +232,7 @@ static inline od_retcode_t od_ldap_server_init(od_logger_t *logger,
 		return NOT_OK_RESPONSE;
 	}
 
-	if (od_ldap_server_prepare(logger, server, route) != OK_RESPONSE) {
+	if (od_ldap_server_prepare(logger, server, client) != OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}
 	return OK_RESPONSE;
@@ -328,7 +329,7 @@ static inline od_ldap_server_t *od_ldap_server_attach(od_route_t *route,
 		/* create new server object */
 		server = od_ldap_server_allocate();
 
-		int ldap_rc = od_ldap_server_init(logger, server, route);
+		int ldap_rc = od_ldap_server_init(logger, server, route, client);
 
 		od_route_lock(route);
 		od_ldap_server_pool_set(&route->ldap_pool, server,


### PR DESCRIPTION
If we use `user default` - ldap auth always fails, cause all searchRequets gone to LDAP server with `default_user`. Need to use `client->startup.user.value` in LDAP requests to server not `route rule name`.

Before:
![Failed](https://downloader.disk.yandex.ru/preview/7c3eaa4fc482d17a22218aaf193697e7451a13ac8d2a296527ac72044a2c410b/6090c99a/soTNjkFnDddkly6gHvMAirb9vmibaQlrTv2bXC-3NTlgZmQl2KGmGVse2o7TtQ3tVfE_BgFzObup3zppDxSJlw%3D%3D?uid=0&filename=Screenshot%20from%202021-05-04%2003-07-55.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&owner_uid=0&tknv=v2&size=2048x2048)
After fix:
![success](https://downloader.disk.yandex.ru/preview/f7c679046c0bbe3b0acc822b8820c059a15ed1562a1edb5e25ecc192d7c3f2c2/6090c9ee/pZ2gh2cQ9AcfFE5WdKlws7b9vmibaQlrTv2bXC-3NTlnIOiJgQBLawBS-sXnvHUfIhshHZ_X-pgAKpzjjIGLUA%3D%3D?uid=0&filename=Screenshot%20from%202021-05-04%2003-09-28.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&owner_uid=0&tknv=v2&size=2048x2048)