### PR TITLE
Update server_login_retry on odyssey.conf

### DIFF
--- a/odyssey.conf
+++ b/odyssey.conf
@@ -292,6 +292,13 @@ keepalive_usr_timeout 0
 #
 # client_max_routing 32
 
+#
+# If server responds with "Too many clients" client will wait for server_login_retry milliseconds.
+#
+# server_login_retry
+#
+# 1 by default.
+
 ###
 ### LISTEN
 ###
@@ -345,10 +352,6 @@ listen {
 #   client_login_timeout
 #   Prevent client stall during routing for more that client_login_timeout milliseconds.
 #   Defaults to 15000.
-
-#   server_login_retry
-#   If server responds with "Too many clients" client will wait for server_login_retry milliseconds.
-#   Defaults to 1.
 }
 
 ###


### PR DESCRIPTION
`server_login_retry` is not a listen variable, but a global one.