### PR TITLE
fix reload config

### DIFF
--- a/sources/config.c
+++ b/sources/config.c
@@ -57,6 +57,7 @@ void od_config_init(od_config_t *config)
 
 void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 {
+	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;
 	current_config->client_max_routing = new_config->client_max_routing;
 	current_config->server_login_retry = new_config->server_login_retry;


### PR DESCRIPTION
reload client_max_set variable
resolve bug when user comment 'client_max' setting, reload config and still get restriction on connections number
