### PR TITLE
Fix incorrect function used for deinitialization on error in config reader

### DIFF
--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1170,7 +1170,7 @@ init:
 	return OK_RESPONSE;
 error:
 	if (ldap_current) {
-		od_ldap_server_free(ldap_current);
+		od_ldap_endpoint_free(ldap_current);
 	}
 	return NOT_OK_RESPONSE;
 }

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1337,8 +1337,8 @@ void od_frontend(void *arg)
 				client->startup.database.value,
 				client->startup.user.value,
 				client->rule != NULL ?
-					      client->rule->client_max :
-					      -1);
+					client->rule->client_max :
+					-1);
 			break;
 		case OD_ROUTER_ERROR_REPLICATION:
 			od_error(

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -779,8 +779,7 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 				return -1;
 			}
 
-			if (rule->password == NULL
-			    && rule->auth_query == NULL
+			if (rule->password == NULL && rule->auth_query == NULL
 #ifdef PAM_FOUND
 			    && rule->auth_pam_service == NULL
 #endif


### PR DESCRIPTION
Incorrect function used for LDAP endpoint deinitialization causes segmentation fault error.