### PR TITLE
Detach only synchronized server

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -743,7 +743,7 @@ static od_frontend_status_t od_frontend_remote_server(od_relay_t *relay,
 		return OD_SKIP;
 
 	/* handle transaction pooling */
-	if (is_ready_for_query) {
+	if (is_ready_for_query && od_server_synchronized(server)) {
 		if ((route->rule->pool == OD_RULE_POOL_TRANSACTION ||
 		     server->offline) &&
 		    !server->is_transaction && !route->id.physical_rep &&


### PR DESCRIPTION
Currently client can issue two consequtive sync requests and we will detach
his server connection right after first ReadyForQuery. This seems incorrect.