### PR TITLE
Reject extraneous data after SSL negatiation

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -141,7 +141,7 @@ static int od_frontend_startup(od_client_t *client)
 	int rc = od_tls_frontend_accept(client, &instance->logger,
 					client->config_listen, client->tls);
 	if (rc == -1)
-		return -1;
+		goto error;
 
 	if (!client->startup.is_ssl_request) {
 		rc = od_compression_frontend_setup(

--- a/sources/tls.c
+++ b/sources/tls.c
@@ -88,7 +88,8 @@ int od_tls_frontend_accept(od_client_t *client, od_logger_t *logger,
 		}
 
 		if (od_readahead_unread(&client->io.readahead) > 0) {
-			od_error(logger, "tls", client, NULL, "extraneous data from client");
+			od_error(logger, "tls", client, NULL,
+				 "extraneous data from client");
 			return -1; // prevent possible buffer, protecting against CVE-2021-23214-like attacks
 		}
 
@@ -190,10 +191,11 @@ int od_tls_backend_connect(od_server_t *server, od_logger_t *logger,
 	case 'S':
 		/* supported */
 		od_debug(logger, "tls", NULL, server, "supported");
-                if (od_readahead_unread(&server->io.readahead) > 0) {
-			od_error(logger, "tls", NULL, server, "extraneous data from client");
-                        return -1; // prevent possible buffer, protecting against CVE-2021-23214-like attacks
-                }
+		if (od_readahead_unread(&server->io.readahead) > 0) {
+			od_error(logger, "tls", NULL, server,
+				 "extraneous data from client");
+			return -1; // prevent possible buffer, protecting against CVE-2021-23214-like attacks
+		}
 
 		rc = machine_set_tls(server->io.io, server->tls, UINT32_MAX);
 		if (rc == -1) {


### PR DESCRIPTION
This prevents attacks like in CVE-2021-23214 and CVE-2021-23222.