### PR TITLE
Fix show storages to actually show storages

### DIFF
--- a/sources/config.c
+++ b/sources/config.c
@@ -225,9 +225,8 @@ int od_config_validate(od_config_t *config, od_logger_t *logger)
 			"online restart or/and enable bindwith_reuseport");
 		return NOT_OK_RESPONSE;
 	}
-	return OK_RESPONSE;
 
-	return 0;
+	return OK_RESPONSE;
 }
 
 static inline char *od_config_yes_no(int value)
@@ -334,23 +333,22 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 		       listen->backlog);
 		if (listen->tls_opts->tls)
 			od_log(logger, "config", NULL, NULL,
-			       "  tls_opts->tls           %s",
-			       listen->tls_opts->tls);
+			       "  tls           %s", listen->tls_opts->tls);
 		if (listen->tls_opts->tls_ca_file)
 			od_log(logger, "config", NULL, NULL,
-			       "  tls_opts->tls_ca_file   %s",
+			       "  tls_ca_file   %s",
 			       listen->tls_opts->tls_ca_file);
 		if (listen->tls_opts->tls_key_file)
 			od_log(logger, "config", NULL, NULL,
-			       "  tls_opts->tls_key_file  %s",
+			       "  tls_key_file  %s",
 			       listen->tls_opts->tls_key_file);
 		if (listen->tls_opts->tls_cert_file)
 			od_log(logger, "config", NULL, NULL,
-			       "  tls_opts->tls_cert_file %s",
+			       "  tls_cert_file %s",
 			       listen->tls_opts->tls_cert_file);
 		if (listen->tls_opts->tls_protocols)
 			od_log(logger, "config", NULL, NULL,
-			       "  tls_opts->tls_protocols %s",
+			       "  tls_protocols %s",
 			       listen->tls_opts->tls_protocols);
 		od_log(logger, "config", NULL, NULL, "");
 	}

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -148,6 +148,7 @@ struct od_rule {
 };
 
 struct od_rules {
+	pthread_mutex_t mu;
 	od_list_t storages;
 #ifdef LDAP_FOUND
 	od_list_t ldap_endpoints;
@@ -155,12 +156,16 @@ struct od_rules {
 	od_list_t rules;
 };
 
+/* rules */
+
 void od_rules_init(od_rules_t *);
 void od_rules_free(od_rules_t *);
 int od_rules_validate(od_rules_t *, od_config_t *, od_logger_t *);
 int od_rules_merge(od_rules_t *, od_rules_t *, od_list_t *added,
 		   od_list_t *deleted);
 void od_rules_print(od_rules_t *, od_logger_t *);
+
+int od_rules_cleanup(od_rules_t *rules);
 
 /* rule */
 od_rule_t *od_rules_add(od_rules_t *);


### PR DESCRIPTION
```
console=> show storages
;
  type  |   host    | port |   tls   | tls_cert_file | tls_key_file | tls_ca_file | tls_protocols 
--------+-----------+------+---------+---------------+--------------+-------------+---------------
 remote | localhost | 5432 | disable | (None)        | (None)       | (None)      | (None)
 local  |           |    0 | disable | (None)        | (None)       | (None)      | (None)
(2 rows)

console=> show listen;
 host | port |   tls   | tls_cert_file | tls_key_file | tls_ca_file | tls_protocols 
------+------+---------+---------------+--------------+-------------+---------------
 *    | 6432 | disable | (None)        | (None)       | (None)      | (None)
(1 row)


```