### PR TITLE
 Refactor rule pool, add internal pooling feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ local_build: clean
 	make -C$(BUILD_TEST_DIR) -j$(COMPILE_CONCURRENCY)
 
 local_run: 
-	$(BUILD_TEST_DIR)/sources/odyssey ./odyssey-dev.conf
+	$(BUILD_TEST_DIR)/sources/odyssey ./config-examples/odyssey-dev-no-ldap.conf
 
 fmtinit:
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ copy_test_bin:
 
 build_dbg: clean
 	mkdir -p $(BUILD_TEST_DIR)
-	cd $(BUILD_TEST_DIR) && $(CMAKE_BIN) -DCMAKE_BUILD_TYPE=Debug $(ODY_DIR) && make -j$(COMPILE_CONCURRENCY)
+	cd $(BUILD_TEST_DIR) && $(CMAKE_BIN) -DCMAKE_BUILD_TYPE=Debug -DUSE_SCRAM=YES $(ODY_DIR) && make -j$(COMPILE_CONCURRENCY)
 
 copy_dbg_bin:
 	cp $(BUILD_TEST_DIR)/sources/odyssey ./docker/bin/odyssey-dbg

--- a/config-examples/odyssey-dev-no-ldap.conf
+++ b/config-examples/odyssey-dev-no-ldap.conf
@@ -27,7 +27,7 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 16
+coroutine_stack_size 32
 
 nodelay yes
 
@@ -70,10 +70,10 @@ database default {
 		pool_cancel yes
 
 		pool_rollback yes
-#               seconds
+#		seconds
 		pool_client_idle_timeout 20
-#               seconds
-                pool_idle_in_transaction_timeout 20
+#		seconds
+		pool_idle_in_transaction_timeout 20
 
 		client_fwd_error yes
 
@@ -83,13 +83,27 @@ database default {
 		log_debug no
 
 		quantiles "0.99,0.95,0.5"
-                client_max 107
+		client_max 107
 	}
 }
 
 database "postgres" {
+	user "reshke" {
+		authentication "none"
+
+		storage "postgres_server"
+		
+		pool "session"
+
+		log_debug yes
+		pool_discard yes
+#		pool_routing "internal"
+
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
 	user "user_aq" {
-		authentication "scram-sha-256"
+		authentication "clear_text"
 #		password "passwd"
 		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
 		auth_query_user "reshke"

--- a/config-examples/odyssey-dev-no-ldap.conf
+++ b/config-examples/odyssey-dev-no-ldap.conf
@@ -27,7 +27,7 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 32
+coroutine_stack_size 16
 
 nodelay yes
 
@@ -88,16 +88,18 @@ database default {
 }
 
 database "postgres" {
-	user "reshke" {
+	user "user_aq_internal_pooling" {
 		authentication "none"
 
 		storage "postgres_server"
 		
 		pool "session"
+		storage_user "reshke"
+		storage_db "postgres"
 
 		log_debug yes
 		pool_discard yes
-#		pool_routing "internal"
+		pool_routing "internal"
 
 		quantiles "0.99,0.95,0.5"
 		client_max 107
@@ -106,7 +108,7 @@ database "postgres" {
 		authentication "clear_text"
 #		password "passwd"
 		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
-		auth_query_user "reshke"
+		auth_query_user "user_aq_internal_pooling"
 		auth_query_db "postgres"
 
 		storage "postgres_server"
@@ -116,6 +118,33 @@ database "postgres" {
 
 		pool_timeout 0
 
+		pool_ttl 60
+
+		pool_discard no
+
+		pool_cancel yes
+
+		pool_rollback yes
+
+		client_fwd_error yes
+
+		application_name_add_host yes
+		server_lifetime 3600
+		log_debug no
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
+	user "user_aq2" {
+		authentication "md5"
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "user_aq_internal_pooling"
+		auth_query_db "postgres"
+
+		storage "postgres_server"
+		
+		pool "session"
+		pool_size 1
+		pool_timeout 0
 		pool_ttl 60
 
 		pool_discard no

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -6,6 +6,7 @@ set(od_src
     daemon.c
     pid.c
     logger.c
+    pool.c
     rules.c
     config.c
     config_reader.c

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -212,6 +212,7 @@ int od_auth_query(od_client_t *client, char *peer)
 	if (auth_client == NULL)
 		return -1;
 	auth_client->global = global;
+	auth_client->type = OD_POOL_CLIENT_INTERNAL;
 	od_id_generate(&auth_client->id, "a");
 
 	/* set auth query route user and database */

--- a/sources/client.h
+++ b/sources/client.h
@@ -60,7 +60,7 @@ struct od_client {
 static inline void od_client_init(od_client_t *client)
 {
 	client->state = OD_CLIENT_UNDEF;
-	client->type = OD_POOL_CLIENT_INTERNAL;
+	client->type = OD_POOL_CLIENT_EXTERNAL;
 	client->coroutine_id = 0;
 	client->tls = NULL;
 	client->cond = NULL;

--- a/sources/client.h
+++ b/sources/client.h
@@ -25,6 +25,7 @@ struct od_client_ctl {
 
 struct od_client {
 	od_client_state_t state;
+	od_pool_client_type_t type;
 	od_id_t id;
 	od_client_ctl_t ctl;
 	uint64_t coroutine_id;
@@ -35,14 +36,18 @@ struct od_client {
 	machine_io_t *notify_io;
 	od_rule_t *rule;
 	od_config_listen_t *config_listen;
+
 	uint64_t time_accept;
 	uint64_t time_setup;
 	uint64_t time_last_active;
+
 	kiwi_be_startup_t startup;
 	kiwi_vars_t vars;
 	kiwi_key_t key;
+
 	od_server_t *server;
 	void *route;
+
 	/* passwd from config rule */
 	kiwi_password_t password;
 	/* user - proveded passwd, fallback to use this when no other option is available*/
@@ -55,6 +60,7 @@ struct od_client {
 static inline void od_client_init(od_client_t *client)
 {
 	client->state = OD_CLIENT_UNDEF;
+	client->type = OD_POOL_CLIENT_INTERNAL;
 	client->coroutine_id = 0;
 	client->tls = NULL;
 	client->cond = NULL;

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -77,8 +77,10 @@ enum { OD_LYES,
        OD_LUSER,
        OD_LPASSWORD,
        OD_LPOOL,
+#ifdef LDAP_FOUND
        OD_LLDAPPOOL_SIZE,
        OD_LLDAPPOOL_TIMEOUT,
+#endif
        OD_LPOOL_SIZE,
        OD_LPOOL_TIMEOUT,
        OD_LPOOL_TTL,
@@ -203,8 +205,10 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("user", OD_LUSER),
 	od_keyword("password", OD_LPASSWORD),
 	od_keyword("pool", OD_LPOOL),
+#ifdef LDAP_FOUND
 	od_keyword("ldap_pool_size", OD_LLDAPPOOL_SIZE),
 	od_keyword("ldap_pool_timeout", OD_LLDAPPOOL_TIMEOUT),
+#endif
 	od_keyword("pool_size", OD_LPOOL_SIZE),
 	od_keyword("pool_timeout", OD_LPOOL_TIMEOUT),
 	od_keyword("pool_ttl", OD_LPOOL_TTL),
@@ -917,11 +921,6 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 			rule->server_lifetime_us = server_lifetime * 1000000L;
 		}
 			continue;
-		/* pool */
-		case OD_LPOOL:
-			if (!od_config_reader_string(reader, &rule->pool_sz))
-				return -1;
-			continue;
 #ifdef LDAP_FOUND
 		/* ldap_pool_size */
 		case OD_LLDAPPOOL_SIZE:
@@ -936,6 +935,11 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 				return -1;
 			continue;
 #endif
+		/* pool */
+		case OD_LPOOL:
+			if (!od_config_reader_string(reader, &rule->pool_type))
+				return -1;
+			continue;
 		/* pool_size */
 		case OD_LPOOL_SIZE:
 			if (!od_config_reader_number(reader, &rule->pool_size))
@@ -951,26 +955,6 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		case OD_LPOOL_TTL:
 			if (!od_config_reader_number(reader, &rule->pool_ttl))
 				return -1;
-			continue;
-		/* storage_database */
-		case OD_LSTORAGE_DB:
-			if (!od_config_reader_string(reader, &rule->storage_db))
-				return -1;
-			continue;
-		/* storage_user */
-		case OD_LSTORAGE_USER:
-			if (!od_config_reader_string(reader,
-						     &rule->storage_user))
-				return -1;
-			rule->storage_user_len = strlen(rule->storage_user);
-			continue;
-		/* storage_password */
-		case OD_LSTORAGE_PASSWORD:
-			if (!od_config_reader_string(reader,
-						     &rule->storage_password))
-				return -1;
-			rule->storage_password_len =
-				strlen(rule->storage_password);
 			continue;
 		/* pool_discard */
 		case OD_LPOOL_DISCARD:
@@ -998,7 +982,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 			}
 			rule->pool_client_idle_timeout *= interval_usec;
 			continue;
-			/* pool_idle_in_transaction_timeout */
+		/* pool_idle_in_transaction_timeout */
 		case OD_LPOOL_IDLE_IN_TRANSACTION_TIMEOUT:
 			if (!od_config_reader_number64(
 				    reader,
@@ -1006,6 +990,26 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 				return NOT_OK_RESPONSE;
 			}
 			rule->pool_idle_in_transaction_timeout *= interval_usec;
+			continue;
+		/* storage_database */
+		case OD_LSTORAGE_DB:
+			if (!od_config_reader_string(reader, &rule->storage_db))
+				return -1;
+			continue;
+		/* storage_user */
+		case OD_LSTORAGE_USER:
+			if (!od_config_reader_string(reader,
+						     &rule->storage_user))
+				return -1;
+			rule->storage_user_len = strlen(rule->storage_user);
+			continue;
+		/* storage_password */
+		case OD_LSTORAGE_PASSWORD:
+			if (!od_config_reader_string(reader,
+						     &rule->storage_password))
+				return -1;
+			rule->storage_password_len =
+				strlen(rule->storage_password);
 			continue;
 		/* log_debug */
 		case OD_LLOG_DEBUG:

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -77,6 +77,7 @@ enum { OD_LYES,
        OD_LUSER,
        OD_LPASSWORD,
        OD_LPOOL,
+       OD_LPOOL_ROUTING,
 #ifdef LDAP_FOUND
        OD_LLDAPPOOL_SIZE,
        OD_LLDAPPOOL_TIMEOUT,
@@ -205,6 +206,7 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("user", OD_LUSER),
 	od_keyword("password", OD_LPASSWORD),
 	od_keyword("pool", OD_LPOOL),
+	od_keyword("pool_routing", OD_LPOOL_ROUTING),
 #ifdef LDAP_FOUND
 	od_keyword("ldap_pool_size", OD_LLDAPPOOL_SIZE),
 	od_keyword("ldap_pool_timeout", OD_LLDAPPOOL_TIMEOUT),
@@ -290,7 +292,7 @@ static int od_config_reader_open(od_config_reader_t *reader, char *config_file)
 		od_errorf(reader->error, "failed to close config file '%s': %d",
 			  config_file, errno);
 		free(config_buf);
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 	default:
 		assert(0);
@@ -302,7 +304,7 @@ error:
 	if (file) {
 		fclose(file);
 	}
-	return -1;
+	return NOT_OK_RESPONSE;
 }
 
 static void od_config_reader_close(od_config_reader_t *reader)
@@ -469,12 +471,12 @@ static int od_config_reader_listen(od_config_reader_t *reader)
 	od_config_listen_t *listen;
 	listen = od_config_listen_add(config);
 	if (listen == NULL) {
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 
 	/* { */
 	if (!od_config_reader_symbol(reader, '{'))
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	for (;;) {
 		od_token_t token;
@@ -486,7 +488,7 @@ static int od_config_reader_listen(od_config_reader_t *reader)
 		case OD_PARSER_EOF:
 			od_config_reader_error(reader, &token,
 					       "unexpected end of config file");
-			return -1;
+			return NOT_OK_RESPONSE;
 		case OD_PARSER_SYMBOL:
 			/* } */
 			if (token.value.num == '}')
@@ -496,81 +498,81 @@ static int od_config_reader_listen(od_config_reader_t *reader)
 			od_config_reader_error(
 				reader, &token,
 				"incorrect or unexpected parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 		od_keyword_t *keyword;
 		keyword = od_keyword_match(od_config_keywords, &token);
 		if (keyword == NULL) {
 			od_config_reader_error(reader, &token,
 					       "unknown parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 		switch (keyword->id) {
 		/* host */
 		case OD_LHOST:
 			if (!od_config_reader_string(reader, &listen->host))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* port */
 		case OD_LPORT:
 			if (!od_config_reader_number(reader, &listen->port))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* client_login_timeout */
 		case OD_LCLIENT_LOGIN_TIMEOUT:
 			if (!od_config_reader_number(
 				    reader, &listen->client_login_timeout))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* backlog */
 		case OD_LBACKLOG:
 			if (!od_config_reader_number(reader, &listen->backlog))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls */
 		case OD_LTLS:
 			if (!od_config_reader_string(reader,
 						     &listen->tls_opts->tls))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_ca_file */
 		case OD_LTLS_CA_FILE:
 			if (!od_config_reader_string(
 				    reader, &listen->tls_opts->tls_ca_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_key_file */
 		case OD_LTLS_KEY_FILE:
 			if (!od_config_reader_string(
 				    reader, &listen->tls_opts->tls_key_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_cert_file */
 		case OD_LTLS_CERT_FILE:
 			if (!od_config_reader_string(
 				    reader, &listen->tls_opts->tls_cert_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_protocols */
 		case OD_LTLS_PROTOCOLS:
 			if (!od_config_reader_string(
 				    reader, &listen->tls_opts->tls_protocols))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* compression */
 		case OD_LCOMPRESSION:
 			if (!od_config_reader_yes_no(reader,
 						     &listen->compression))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		default:
 			od_config_reader_error(reader, &token,
 					       "unexpected parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 	}
 	/* unreach */
-	return -1;
+	return NOT_OK_RESPONSE;
 }
 
 static int od_config_reader_storage(od_config_reader_t *reader)
@@ -578,22 +580,22 @@ static int od_config_reader_storage(od_config_reader_t *reader)
 	od_rule_storage_t *storage;
 	storage = od_rules_storage_allocate();
 	if (storage == NULL)
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	/* name */
 	if (!od_config_reader_string(reader, &storage->name))
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	if (od_rules_storage_match(reader->rules, storage->name) != NULL) {
 		od_config_reader_error(reader, NULL,
 				       "duplicate storage definition: %s",
 				       storage->name);
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 	od_rules_storage_add(reader->rules, storage);
 	/* { */
 	if (!od_config_reader_symbol(reader, '{'))
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	for (;;) {
 		od_token_t token;
@@ -605,7 +607,7 @@ static int od_config_reader_storage(od_config_reader_t *reader)
 		case OD_PARSER_EOF:
 			od_config_reader_error(reader, &token,
 					       "unexpected end of config file");
-			return -1;
+			return NOT_OK_RESPONSE;
 		case OD_PARSER_SYMBOL:
 			/* } */
 			if (token.value.num == '}')
@@ -615,76 +617,76 @@ static int od_config_reader_storage(od_config_reader_t *reader)
 			od_config_reader_error(
 				reader, &token,
 				"incorrect or unexpected parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 		od_keyword_t *keyword;
 		keyword = od_keyword_match(od_config_keywords, &token);
 		if (keyword == NULL) {
 			od_config_reader_error(reader, &token,
 					       "unknown parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 
 		switch (keyword->id) {
 		/* type */
 		case OD_LTYPE:
 			if (!od_config_reader_string(reader, &storage->type))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* host */
 		case OD_LHOST:
 			if (!od_config_reader_string(reader, &storage->host))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* port */
 		case OD_LPORT:
 			if (!od_config_reader_number(reader, &storage->port))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls */
 		case OD_LTLS:
 			if (!od_config_reader_string(reader,
 						     &storage->tls_opts->tls))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_ca_file */
 		case OD_LTLS_CA_FILE:
 			if (!od_config_reader_string(
 				    reader, &storage->tls_opts->tls_ca_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_key_file */
 		case OD_LTLS_KEY_FILE:
 			if (!od_config_reader_string(
 				    reader, &storage->tls_opts->tls_key_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_cert_file */
 		case OD_LTLS_CERT_FILE:
 			if (!od_config_reader_string(
 				    reader, &storage->tls_opts->tls_cert_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* tls_protocols */
 		case OD_LTLS_PROTOCOLS:
 			if (!od_config_reader_string(
 				    reader, &storage->tls_opts->tls_protocols))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 			/* server_max_routing */
 		case OD_LSERVERS_MAX_ROUTING:
 			if (!od_config_reader_number(
 				    reader, &storage->server_max_routing))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		default:
 			od_config_reader_error(reader, &token,
 					       "unexpected parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 	}
 	/* unreach */
-	return -1;
+	return NOT_OK_RESPONSE;
 }
 
 static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
@@ -698,15 +700,15 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 	/* user name or default */
 	if (od_config_reader_is(reader, OD_PARSER_STRING)) {
 		if (!od_config_reader_string(reader, &user_name))
-			return -1;
+			return NOT_OK_RESPONSE;
 	} else {
 		if (!od_config_reader_keyword(reader,
 					      &od_config_keywords[OD_LDEFAULT]))
-			return -1;
+			return NOT_OK_RESPONSE;
 		user_is_default = 1;
 		user_name = strdup("default_user");
 		if (user_name == NULL)
-			return -1;
+			return NOT_OK_RESPONSE;
 	}
 	user_name_len = strlen(user_name);
 
@@ -718,28 +720,28 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		od_errorf(reader->error, "route '%s.%s': is redefined", db_name,
 			  user_name);
 		free(user_name);
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 	rule = od_rules_add(reader->rules);
 	if (rule == NULL) {
 		free(user_name);
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 	rule->user_is_default = user_is_default;
 	rule->user_name_len = user_name_len;
 	rule->user_name = strdup(user_name);
 	free(user_name);
 	if (rule->user_name == NULL)
-		return -1;
+		return NOT_OK_RESPONSE;
 	rule->db_is_default = db_is_default;
 	rule->db_name_len = db_name_len;
 	rule->db_name = strdup(db_name);
 	if (rule->db_name == NULL)
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	/* { */
 	if (!od_config_reader_symbol(reader, '{'))
-		return -1;
+		return NOT_OK_RESPONSE;
 
 	for (;;) {
 		od_token_t token;
@@ -751,7 +753,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		case OD_PARSER_EOF:
 			od_config_reader_error(reader, &token,
 					       "unexpected end of config file");
-			return -1;
+			return NOT_OK_RESPONSE;
 		case OD_PARSER_SYMBOL:
 			/* } */
 			if (token.value.num == '}')
@@ -761,7 +763,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 			od_config_reader_error(
 				reader, &token,
 				"incorrect or unexpected parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 		od_keyword_t *keyword;
 		keyword = od_keyword_match(od_config_keywords, &token);
@@ -784,7 +786,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 			if (!token_ok) {
 				od_config_reader_error(reader, &token,
 						       "unknown parameter");
-				return -1;
+				return NOT_OK_RESPONSE;
 			}
 			/* continue reading config */
 			continue;
@@ -794,7 +796,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		/* authentication */
 		case OD_LAUTHENTICATION:
 			if (!od_config_reader_string(reader, &rule->auth))
-				return -1;
+				return NOT_OK_RESPONSE;
 #ifndef USE_SCRAM
 			if (strcmp(rule->auth, "scram-sha-256") == 0) {
 				od_config_reader_error(
@@ -810,86 +812,86 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 				if (!od_config_reader_keyword(
 					    reader,
 					    &od_config_keywords[OD_LDEFAULT]))
-					return -1;
+					return NOT_OK_RESPONSE;
 				rule->auth_common_name_default = 1;
 				break;
 			}
 			od_rule_auth_t *auth;
 			auth = od_rules_auth_add(rule);
 			if (auth == NULL)
-				return -1;
+				return NOT_OK_RESPONSE;
 			if (!od_config_reader_string(reader,
 						     &auth->common_name))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 		}
 		/* auth_module */
 		case OD_LAUTH_MODULE:
 			if (!od_config_reader_string(reader,
 						     &rule->auth_module))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 #ifdef PAM_FOUND
 		/* auth_pam_service */
 		case OD_LAUTH_PAM_SERVICE:
 			if (!od_config_reader_string(reader,
 						     &rule->auth_pam_service))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 #endif
 		/* auth_query */
 		case OD_LAUTH_QUERY:
 			if (!od_config_reader_string(reader, &rule->auth_query))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 		/* auth_query_db */
 		case OD_LAUTH_QUERY_DB:
 			if (!od_config_reader_string(reader,
 						     &rule->auth_query_db))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 		/* auth_query_user */
 		case OD_LAUTH_QUERY_USER:
 			if (!od_config_reader_string(reader,
 						     &rule->auth_query_user))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 		/* auth_query_user */
 		case OD_LAUTH_PASSWORD_PASSTHROUGH:
 			if (!od_config_reader_yes_no(
 				    reader, &rule->enable_password_passthrough))
-				return -1;
+				return NOT_OK_RESPONSE;
 			break;
 		/* password */
 		case OD_LPASSWORD:
 			if (!od_config_reader_string(reader, &rule->password))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rule->password_len = strlen(rule->password);
 			continue;
 		/* storage */
 		case OD_LSTORAGE:
 			if (!od_config_reader_string(reader,
 						     &rule->storage_name))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* client_max */
 		case OD_LCLIENT_MAX:
 			if (!od_config_reader_number(reader, &rule->client_max))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rule->client_max_set = 1;
 			continue;
 		/* client_fwd_error */
 		case OD_LCLIENT_FWD_ERROR:
 			if (!od_config_reader_yes_no(reader,
 						     &rule->client_fwd_error))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* reserve_session_server_connection */
 		case OD_LPRESERVE_SESSION_SERVER_CONN:
 			if (!od_config_reader_yes_no(
 				    reader,
 				    &rule->reserve_session_server_connection)) {
-				return -1;
+				return NOT_OK_RESPONSE;
 			}
 			continue;
 		/* quantiles */
@@ -911,13 +913,13 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		case OD_LAPPLICATION_NAME_ADD_HOST:
 			if (!od_config_reader_yes_no(
 				    reader, &rule->application_name_add_host))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* server_lifetime */
 		case OD_LSERVER_LIFETIME: {
 			int server_lifetime;
 			if (!od_config_reader_number(reader, &server_lifetime))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rule->server_lifetime_us = server_lifetime * 1000000L;
 		}
 			continue;
@@ -926,106 +928,113 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		case OD_LLDAPPOOL_SIZE:
 			if (!od_config_reader_number(reader,
 						     &rule->ldap_pool_size))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* ldap_pool_timeout */
 		case OD_LLDAPPOOL_TIMEOUT:
 			if (!od_config_reader_number(reader,
 						     &rule->ldap_pool_timeout))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 #endif
 		/* pool */
 		case OD_LPOOL:
-			if (!od_config_reader_string(reader, &rule->pool_type))
-				return -1;
+			if (!od_config_reader_string(reader, &rule->pool->type))
+				return NOT_OK_RESPONSE;
+			continue;
+		/* pool routing */
+		case OD_LPOOL_ROUTING:
+			if (!od_config_reader_string(reader,
+						     &rule->pool->routing_type))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_size */
 		case OD_LPOOL_SIZE:
-			if (!od_config_reader_number(reader, &rule->pool_size))
-				return -1;
+			if (!od_config_reader_number(reader, &rule->pool->size))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_timeout */
 		case OD_LPOOL_TIMEOUT:
 			if (!od_config_reader_number(reader,
-						     &rule->pool_timeout))
-				return -1;
+						     &rule->pool->timeout))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_ttl */
 		case OD_LPOOL_TTL:
-			if (!od_config_reader_number(reader, &rule->pool_ttl))
-				return -1;
+			if (!od_config_reader_number(reader, &rule->pool->ttl))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_discard */
 		case OD_LPOOL_DISCARD:
 			if (!od_config_reader_yes_no(reader,
-						     &rule->pool_discard))
-				return -1;
+						     &rule->pool->discard))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_cancel */
 		case OD_LPOOL_CANCEL:
 			if (!od_config_reader_yes_no(reader,
-						     &rule->pool_cancel))
-				return -1;
+						     &rule->pool->cancel))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_rollback */
 		case OD_LPOOL_ROLLBACK:
 			if (!od_config_reader_yes_no(reader,
-						     &rule->pool_rollback))
-				return -1;
+						     &rule->pool->rollback))
+				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_client_idle_timeout */
 		case OD_LPOOL_CLIENT_IDLE_TIMEOUT:
 			if (!od_config_reader_number64(
-				    reader, &rule->pool_client_idle_timeout)) {
+				    reader, &rule->pool->client_idle_timeout)) {
 				return NOT_OK_RESPONSE;
 			}
-			rule->pool_client_idle_timeout *= interval_usec;
+			rule->pool->client_idle_timeout *= interval_usec;
 			continue;
 		/* pool_idle_in_transaction_timeout */
 		case OD_LPOOL_IDLE_IN_TRANSACTION_TIMEOUT:
 			if (!od_config_reader_number64(
 				    reader,
-				    &rule->pool_idle_in_transaction_timeout)) {
+				    &rule->pool->idle_in_transaction_timeout)) {
 				return NOT_OK_RESPONSE;
 			}
-			rule->pool_idle_in_transaction_timeout *= interval_usec;
+			rule->pool->idle_in_transaction_timeout *=
+				interval_usec;
 			continue;
 		/* storage_database */
 		case OD_LSTORAGE_DB:
 			if (!od_config_reader_string(reader, &rule->storage_db))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* storage_user */
 		case OD_LSTORAGE_USER:
 			if (!od_config_reader_string(reader,
 						     &rule->storage_user))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rule->storage_user_len = strlen(rule->storage_user);
 			continue;
 		/* storage_password */
 		case OD_LSTORAGE_PASSWORD:
 			if (!od_config_reader_string(reader,
 						     &rule->storage_password))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rule->storage_password_len =
 				strlen(rule->storage_password);
 			continue;
 		/* log_debug */
 		case OD_LLOG_DEBUG:
 			if (!od_config_reader_yes_no(reader, &rule->log_debug))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		/* log_query */
 		case OD_LLOG_QUERY:
 			if (!od_config_reader_yes_no(reader, &rule->log_query))
-				return -1;
+				return NOT_OK_RESPONSE;
 			continue;
 		case OD_LLDAP_ENDPOINT_NAME: {
 #ifdef LDAP_FOUND
 			if (!od_config_reader_string(reader,
 						     &rule->ldap_endpoint_name))
-				return -1;
+				return NOT_OK_RESPONSE;
 			od_ldap_endpoint_t *le = od_ldap_endpoint_find(
 				&reader->rules->ldap_endpoints,
 				rule->ldap_endpoint_name);
@@ -1046,12 +1055,12 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 		}
 			continue;
 		default:
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 	}
 
 	/* unreach */
-	return -1;
+	return NOT_OK_RESPONSE;
 }
 
 #ifdef LDAP_FOUND
@@ -1107,7 +1116,7 @@ od_config_reader_ldap_endpoint(od_config_reader_t *reader)
 		if (keyword == NULL) {
 			od_config_reader_error(reader, &token,
 					       "unknown parameter");
-			return -1;
+			return NOT_OK_RESPONSE;
 		}
 
 		switch (keyword->id) {
@@ -1208,7 +1217,7 @@ static inline od_retcode_t od_config_reader_module(od_config_reader_t *reader,
 		// skip all related conf
 		/* { */
 		if (!od_config_reader_symbol(reader, '{'))
-			return -1;
+			return NOT_OK_RESPONSE;
 
 		for (;;) {
 			od_token_t token;
@@ -1261,15 +1270,15 @@ static int od_config_reader_database(od_config_reader_t *reader,
 	/* name or default */
 	if (od_config_reader_is(reader, OD_PARSER_STRING)) {
 		if (!od_config_reader_string(reader, &db_name))
-			return -1;
+			return NOT_OK_RESPONSE;
 	} else {
 		if (!od_config_reader_keyword(reader,
 					      &od_config_keywords[OD_LDEFAULT]))
-			return -1;
+			return NOT_OK_RESPONSE;
 		db_is_default = 1;
 		db_name = strdup("default_db");
 		if (db_name == NULL)
-			return -1;
+			return NOT_OK_RESPONSE;
 	}
 	db_name_len = strlen(db_name);
 
@@ -1324,10 +1333,10 @@ static int od_config_reader_database(od_config_reader_t *reader,
 		}
 	}
 	/* unreach */
-	return -1;
+	return NOT_OK_RESPONSE;
 error:
 	free(db_name);
-	return -1;
+	return NOT_OK_RESPONSE;
 }
 
 static int od_config_reader_parse(od_config_reader_t *reader,
@@ -1362,7 +1371,7 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 		case OD_LINCLUDE: {
 			char *config_file = NULL;
 			if (!od_config_reader_string(reader, &config_file))
-				return -1;
+				return NOT_OK_RESPONSE;
 			rc = od_config_reader_import(reader->config,
 						     reader->rules,
 						     reader->error, extentions,
@@ -1725,9 +1734,9 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 		}
 	}
 	/* unreach */
-	return -1;
+	return NOT_OK_RESPONSE;
 error:
-	return -1;
+	return NOT_OK_RESPONSE;
 success:
 	if (!config->client_max_routing) {
 		config->client_max_routing = config->workers * 16;
@@ -1748,7 +1757,7 @@ int od_config_reader_import(od_config_t *config, od_rules_t *rules,
 	int rc;
 	rc = od_config_reader_open(&reader, config_file);
 	if (rc == -1) {
-		return -1;
+		return NOT_OK_RESPONSE;
 	}
 
 	rc = od_config_reader_parse(&reader, extentions);

--- a/sources/console.c
+++ b/sources/console.c
@@ -605,7 +605,7 @@ static inline int od_console_show_pools_add_cb(od_route_t *route, void **argv)
 	/* pool_mode */
 	rc = NOT_OK_RESPONSE;
 
-	switch (route->rule->pool) {
+	switch (route->rule->pool->pool) {
 	case OD_RULE_POOL_SESSION:
 		rc = kiwi_be_write_data_row_add(stream, offset, "session", 7);
 		break;
@@ -729,8 +729,8 @@ static inline int od_console_show_databases_add_cb(od_route_t *route,
 	if (rc == NOT_OK_RESPONSE)
 		goto error;
 
-	/* pool_size */
-	data_len = od_snprintf(data, sizeof(data), "%d", rule->pool_size);
+	/* pool size */
+	data_len = od_snprintf(data, sizeof(data), "%d", rule->pool->size);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE)
 		goto error;
@@ -741,11 +741,11 @@ static inline int od_console_show_databases_add_cb(od_route_t *route,
 	if (rc == NOT_OK_RESPONSE)
 		goto error;
 
-	/* pool_mode */
-	rc = -1;
-	if (rule->pool == OD_RULE_POOL_SESSION)
+	/* pool mode */
+	rc = NOT_OK_RESPONSE;
+	if (rule->pool->pool == OD_RULE_POOL_SESSION)
 		rc = kiwi_be_write_data_row_add(stream, offset, "session", 7);
-	if (rule->pool == OD_RULE_POOL_TRANSACTION)
+	if (rule->pool->pool == OD_RULE_POOL_TRANSACTION)
 		rc = kiwi_be_write_data_row_add(stream, offset, "transaction",
 						11);
 

--- a/sources/odyssey.h
+++ b/sources/odyssey.h
@@ -44,7 +44,11 @@
 #include "sources/ldap_endpoint.h"
 #endif
 
+#ifdef PAM_FOUND
 #include "sources/pam.h"
+#endif
+
+#include "sources/pool.h"
 #include "sources/rules.h"
 
 #include "sources/config_common.h"

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -42,6 +42,10 @@ int od_rule_pool_compare(od_rule_pool_t *a, od_rule_pool_t *b)
 	if (a->pool != b->pool)
 		return 0;
 
+	/* pool routing */
+	if (a->routing != b->routing)
+		return 0;
+
 	/* size */
 	if (a->size != b->size)
 		return 0;

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -1,0 +1,91 @@
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+ */
+
+#include <kiwi.h>
+#include <machinarium.h>
+#include <odyssey.h>
+
+od_rule_pool_t *od_rule_pool_alloc()
+{
+	od_rule_pool_t *pool;
+	pool = malloc(sizeof(od_rule_pool_t));
+
+	if (pool == NULL) {
+		return NULL;
+	}
+	memset(pool, 0, sizeof(od_rule_pool_t));
+
+	pool->discard = 1;
+	pool->cancel = 1;
+	pool->rollback = 1;
+
+	return pool;
+}
+
+int od_rule_pool_free(od_rule_pool_t *pool)
+{
+	if (pool->routing_type) {
+		free(pool->routing_type);
+	}
+	if (pool->type) {
+		free(pool->type);
+	}
+	return OK_RESPONSE;
+}
+
+int od_rule_pool_compare(od_rule_pool_t *a, od_rule_pool_t *b)
+{
+	/* pool */
+	if (a->pool != b->pool)
+		return 0;
+
+	/* size */
+	if (a->size != b->size)
+		return 0;
+
+	/* timeout */
+	if (a->timeout != b->timeout)
+		return 0;
+
+	/* ttl */
+	if (a->ttl != b->ttl)
+		return 0;
+
+	/* pool_discard */
+	if (a->discard != b->discard)
+		return 0;
+
+	/* cancel */
+	if (a->cancel != b->cancel)
+		return 0;
+
+	/* rollback*/
+	if (a->rollback != b->rollback)
+		return 0;
+
+	/* client idle timeout */
+	if (a->client_idle_timeout != b->client_idle_timeout) {
+		return 0;
+	}
+
+	/* idle_in_transaction_timeout */
+	if (a->idle_in_transaction_timeout != b->idle_in_transaction_timeout) {
+		return 0;
+	}
+}
+
+int od_rule_matches_client(od_rule_pool_t *pool, od_pool_client_type_t t)
+{
+	switch (t) {
+	case OD_POOL_CLIENT_INTERNAL:
+		return pool->routing == OD_RULE_POOL_INTERVAL;
+	case OD_POOL_CLIENT_EXTERNAL:
+		return pool->routing == OD_RULE_POOL_CLIENT_VISIBLE;
+	default:
+		// no macthes
+		return 0;
+	}
+}

--- a/sources/pool.h
+++ b/sources/pool.h
@@ -1,0 +1,58 @@
+#ifndef ODYSSEY_POOL_H
+#define ODYSSEY_POOL_H
+
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+ */
+
+typedef struct od_rule_pool od_rule_pool_t;
+
+typedef enum {
+	OD_RULE_POOL_SESSION,
+	OD_RULE_POOL_TRANSACTION,
+	OD_RULE_POOL_STATEMENT,
+} od_rule_pool_type_t;
+
+typedef enum {
+	OD_RULE_POOL_INTERVAL,
+	OD_RULE_POOL_CLIENT_VISIBLE,
+} od_rule_routing_type_t;
+
+typedef enum {
+	OD_POOL_CLIENT_UNDEF,
+	OD_POOL_CLIENT_INTERNAL,
+	OD_POOL_CLIENT_EXTERNAL,
+} od_pool_client_type_t;
+
+struct od_rule_pool {
+	/* pool */
+	od_rule_pool_type_t pool;
+	od_rule_routing_type_t routing;
+
+	char *type;
+	char *routing_type;
+
+	int size;
+	int timeout;
+	int ttl;
+	int discard;
+	int cancel;
+	int rollback;
+
+	// --------  makes sence only for session poolin  -------------------------------
+	uint64_t client_idle_timeout;
+	uint64_t idle_in_transaction_timeout;
+	// ------------------------------------------------------------------------------
+};
+
+od_rule_pool_t *od_rule_pool_alloc();
+
+int od_rule_pool_free(od_rule_pool_t *pool);
+
+int od_rule_pool_compare(od_rule_pool_t *a, od_rule_pool_t *b);
+
+int od_rule_matches_client(od_rule_pool_t *pool, od_pool_client_type_t t);
+
+#endif /* ODYSSEY_POOL_H */

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -22,7 +22,7 @@ int od_reset(od_server_t *server)
 	}
 
 	/* support route rollback off */
-	if (!route->rule->pool_rollback) {
+	if (!route->rule->pool->rollback) {
 		if (server->is_transaction) {
 			od_log(&instance->logger, "reset", server->client,
 			       server, "in active transaction, closing");
@@ -74,7 +74,7 @@ int od_reset(od_server_t *server)
 				goto error;
 
 			/* support route cancel off */
-			if (!route->rule->pool_cancel) {
+			if (!route->rule->pool->cancel) {
 				od_log(&instance->logger, "reset",
 				       server->client, server,
 				       "not synchronized, closing");
@@ -106,7 +106,7 @@ int od_reset(od_server_t *server)
 
 	/* send rollback in case server has an active
 	 * transaction running */
-	if (route->rule->pool_rollback) {
+	if (route->rule->pool->rollback) {
 		if (server->is_transaction) {
 			char query_rlb[] = "ROLLBACK";
 			rc = od_backend_query(server, "reset-rollback",
@@ -119,7 +119,7 @@ int od_reset(od_server_t *server)
 	}
 
 	/* send DISCARD ALL */
-	if (route->rule->pool_discard) {
+	if (route->rule->pool->discard) {
 		char query_discard[] = "DISCARD ALL";
 		rc = od_backend_query(server, "reset-discard", query_discard,
 				      sizeof(query_discard), wait_timeout);

--- a/sources/route_pool.h
+++ b/sources/route_pool.h
@@ -115,8 +115,7 @@ static inline int od_route_pool_foreach(od_route_pool_t *pool,
 }
 
 static inline od_route_t *
-od_route_pool_match(od_route_pool_t *pool, od_route_id_t *key, od_rule_t *rule,
-		    od_pool_client_type_t pool_client_type)
+od_route_pool_match(od_route_pool_t *pool, od_route_id_t *key, od_rule_t *rule)
 {
 	od_list_t *i;
 	od_list_foreach(&pool->list, i)
@@ -124,9 +123,9 @@ od_route_pool_match(od_route_pool_t *pool, od_route_id_t *key, od_rule_t *rule,
 		od_route_t *route;
 		route = od_container_of(i, od_route_t, link);
 		if (route->rule == rule &&
-		    od_route_id_compare(&route->id, key) &&
-		    od_rule_matches_client(rule->pool, pool_client_type))
+		    od_route_id_compare(&route->id, key)) {
 			return route;
+		}
 	}
 	return NULL;
 }

--- a/sources/route_pool.h
+++ b/sources/route_pool.h
@@ -115,14 +115,17 @@ static inline int od_route_pool_foreach(od_route_pool_t *pool,
 }
 
 static inline od_route_t *
-od_route_pool_match(od_route_pool_t *pool, od_route_id_t *key, od_rule_t *rule)
+od_route_pool_match(od_route_pool_t *pool, od_route_id_t *key, od_rule_t *rule,
+		    od_pool_client_type_t pool_client_type)
 {
 	od_list_t *i;
 	od_list_foreach(&pool->list, i)
 	{
 		od_route_t *route;
 		route = od_container_of(i, od_route_t, link);
-		if (route->rule == rule && od_route_id_compare(&route->id, key))
+		if (route->rule == rule &&
+		    od_route_id_compare(&route->id, key) &&
+		    od_rule_matches_client(rule->pool, pool_client_type))
 			return route;
 	}
 	return NULL;

--- a/sources/router.c
+++ b/sources/router.c
@@ -180,7 +180,7 @@ static inline int od_router_expire_server_tick_cb(od_server_t *server,
 
 	/* advance idle time for 1 sec */
 	if (server_life < lifetime &&
-	    server->idle_time < route->rule->pool_ttl) {
+	    server->idle_time < route->rule->pool->ttl) {
 		server->idle_time++;
 		return 0;
 	}
@@ -216,7 +216,7 @@ static inline int od_router_expire_cb(od_route_t *route, void **argv)
 		return 0;
 	}
 
-	if (!route->rule->pool_ttl) {
+	if (!route->rule->pool->ttl) {
 		od_route_unlock(route);
 		return 0;
 	}
@@ -332,9 +332,11 @@ od_router_status_t od_router_route(od_router_t *router, od_client_t *client)
 
 	/* match or create dynamic route */
 	od_route_t *route;
-	route = od_route_pool_match(&router->route_pool, &id, rule);
+	route = od_route_pool_match(&router->route_pool, &id, rule,
+				    client->type);
 	if (route == NULL) {
 		route = od_route_pool_new(&router->route_pool, &id, rule);
+		//od_debug()
 		if (route == NULL) {
 			od_router_unlock(router);
 			return OD_ROUTER_ERROR;
@@ -449,7 +451,7 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 			/* Maybe start new connection, if we still have capacity for it */
 			int connections_in_pool =
 				od_server_pool_total(&route->server_pool);
-			int pool_size = route->rule->pool_size;
+			int pool_size = route->rule->pool->size;
 			uint32_t currently_routing =
 				od_atomic_u32_of(&router->servers_routing);
 			uint32_t max_routing = (uint32_t)route->rule->storage
@@ -493,7 +495,7 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 		 * The condition triggered when a server connection
 		 * put into idle state by DETACH events.
 		 */
-		uint32_t timeout = route->rule->pool_timeout;
+		uint32_t timeout = route->rule->pool->timeout;
 		if (timeout == 0)
 			timeout = UINT32_MAX;
 		rc = od_route_wait(route, timeout);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -1035,7 +1035,7 @@ void od_rules_print(od_rules_t *rules, od_logger_t *logger)
 			       rule->auth_query);
 		if (rule->auth_query_db)
 			od_log(logger, "rules", NULL, NULL,
-			       "  auth_query_db                    %s",
+			       "  auth_query_db                     %s",
 			       rule->auth_query_db);
 		if (rule->auth_query_user)
 			od_log(logger, "rules", NULL, NULL,
@@ -1046,6 +1046,11 @@ void od_rules_print(od_rules_t *rules, od_logger_t *logger)
 		od_log(logger, "rules", NULL, NULL,
 		       "  pool                              %s",
 		       rule->pool->type);
+		od_log(logger, "rules", NULL, NULL,
+		       "  pool routing                      %s",
+		       rule->pool->routing_type == NULL ?
+			       "client visible" :
+			       rule->pool->routing_type);
 		od_log(logger, "rules", NULL, NULL,
 		       "  pool size                         %d",
 		       rule->pool->size);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -250,8 +250,8 @@ void od_rules_rule_free(od_rule_t *rule)
 		free(rule->storage_user);
 	if (rule->storage_password)
 		free(rule->storage_password);
-	if (rule->pool_sz)
-		free(rule->pool_sz);
+	if (rule->pool_type)
+		free(rule->pool_type);
 	od_list_t *i, *n;
 	od_list_foreach_safe(&rule->auth_common_names, i, n)
 	{
@@ -831,17 +831,17 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 			return -1;
 
 		/* pooling mode */
-		if (!rule->pool_sz) {
+		if (!rule->pool_type) {
 			od_error(logger, "rules", NULL, NULL,
 				 "rule '%s.%s': pooling mode is not set",
 				 rule->db_name, rule->user_name);
 			return -1;
 		}
-		if (strcmp(rule->pool_sz, "session") == 0) {
+		if (strcmp(rule->pool_type, "session") == 0) {
 			rule->pool = OD_RULE_POOL_SESSION;
-		} else if (strcmp(rule->pool_sz, "transaction") == 0) {
+		} else if (strcmp(rule->pool_type, "transaction") == 0) {
 			rule->pool = OD_RULE_POOL_TRANSACTION;
-		} else if (strcmp(rule->pool_sz, "statement") == 0) {
+		} else if (strcmp(rule->pool_type, "statement") == 0) {
 			rule->pool = OD_RULE_POOL_STATEMENT;
 		} else {
 			od_error(logger, "rules", NULL, NULL,
@@ -1056,7 +1056,7 @@ void od_rules_print(od_rules_t *rules, od_logger_t *logger)
 
 		/* pool  */
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool                              %s", rule->pool_sz);
+		       "  pool                              %s", rule->pool_type);
 		od_log(logger, "rules", NULL, NULL,
 		       "  pool_size                         %d",
 		       rule->pool_size);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -8,9 +8,6 @@
 #include <kiwi.h>
 #include <machinarium.h>
 #include <odyssey.h>
-#ifdef PAM_FOUND
-#include <pam.h>
-#endif
 
 void od_rules_init(od_rules_t *rules)
 {
@@ -194,17 +191,16 @@ od_rule_t *od_rules_add(od_rules_t *rules)
 		return NULL;
 	memset(rule, 0, sizeof(*rule));
 	/* pool */
-	rule->pool_size = 0;
-	rule->pool_timeout = 0;
-	rule->pool_discard = 1;
-	rule->pool_cancel = 1;
-	rule->pool_rollback = 1;
-	rule->pool_client_idle_timeout = 0;
-	rule->pool_idle_in_transaction_timeout = 0;
+	rule->pool = od_rule_pool_alloc();
+	if (rule->pool == NULL) {
+		free(rule);
+		return NULL;
+	}
 
 	rule->obsolete = 0;
 	rule->mark = 0;
 	rule->refs = 0;
+
 	rule->auth_common_name_default = 0;
 	rule->auth_common_names_count = 0;
 	rule->server_lifetime_us = 3600 * 1000000L;
@@ -250,8 +246,9 @@ void od_rules_rule_free(od_rule_t *rule)
 		free(rule->storage_user);
 	if (rule->storage_password)
 		free(rule->storage_password);
-	if (rule->pool_type)
-		free(rule->pool_type);
+	if (rule->pool)
+		od_rule_pool_free(rule->pool);
+
 	od_list_t *i, *n;
 	od_list_foreach_safe(&rule->auth_common_names, i, n)
 	{
@@ -531,45 +528,6 @@ int od_rules_rule_compare(od_rule_t *a, od_rule_t *b)
 		return 0;
 	}
 
-	/* pool */
-	if (a->pool != b->pool)
-		return 0;
-
-	/* pool_size */
-	if (a->pool_size != b->pool_size)
-		return 0;
-
-	/* pool_timeout */
-	if (a->pool_timeout != b->pool_timeout)
-		return 0;
-
-	/* pool_ttl */
-	if (a->pool_ttl != b->pool_ttl)
-		return 0;
-
-	/* pool_discard */
-	if (a->pool_discard != b->pool_discard)
-		return 0;
-
-	/* pool_cancel */
-	if (a->pool_cancel != b->pool_cancel)
-		return 0;
-
-	/* pool_rollback*/
-	if (a->pool_rollback != b->pool_rollback)
-		return 0;
-
-	/* pool client idle timeout */
-	if (a->pool_client_idle_timeout != b->pool_client_idle_timeout) {
-		return 0;
-	}
-
-	/* pool_idle_in_transaction_timeout */
-	if (a->pool_idle_in_transaction_timeout !=
-	    b->pool_idle_in_transaction_timeout) {
-		return 0;
-	}
-
 	/* client_fwd_error */
 	if (a->client_fwd_error != b->client_fwd_error)
 		return 0;
@@ -738,6 +696,51 @@ __attribute__((hot)) int od_rules_merge(od_rules_t *rules, od_rules_t *src,
 	return count_new + count_mark + count_deleted;
 }
 
+int od_pool_validate(od_logger_t *logger, od_rule_pool_t *pool, char *db_name,
+		     char *user_name)
+{
+	/* pooling mode */
+	if (!pool->type) {
+		od_error(logger, "rules", NULL, NULL,
+			 "rule '%s.%s': pooling mode is not set", db_name,
+			 user_name);
+		return NOT_OK_RESPONSE;
+	}
+	if (strcmp(pool->type, "session") == 0) {
+		pool->pool = OD_RULE_POOL_SESSION;
+	} else if (strcmp(pool->type, "transaction") == 0) {
+		pool->pool = OD_RULE_POOL_TRANSACTION;
+	} else if (strcmp(pool->type, "statement") == 0) {
+		pool->pool = OD_RULE_POOL_STATEMENT;
+	} else {
+		od_error(logger, "rules", NULL, NULL,
+			 "rule '%s.%s': unknown pooling mode", db_name,
+			 user_name);
+		return NOT_OK_RESPONSE;
+	}
+
+	pool->routing = OD_RULE_POOL_CLIENT_VISIBLE;
+	if (!pool->routing_type) {
+		od_debug(
+			logger, "rules", NULL, NULL,
+			"rule '%s.%s': pool routing mode is not set, assuming \"client_visible\" by default",
+			db_name, user_name);
+		return OK_RESPONSE;
+	}
+	if (strcmp(pool->routing_type, "internal") == 0) {
+		pool->routing = OD_RULE_POOL_INTERVAL;
+	} else if (strcmp(pool->routing_type, "client_visible") == 0) {
+		pool->routing = OD_RULE_POOL_CLIENT_VISIBLE;
+	} else {
+		od_error(logger, "rules", NULL, NULL,
+			 "rule '%s.%s': unknown pool routing mode", db_name,
+			 user_name);
+		return NOT_OK_RESPONSE;
+	}
+
+	return OK_RESPONSE;
+}
+
 int od_rules_validate(od_rules_t *rules, od_config_t *config,
 		      od_logger_t *logger)
 {
@@ -830,24 +833,9 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 		if (rule->storage == NULL)
 			return -1;
 
-		/* pooling mode */
-		if (!rule->pool_type) {
-			od_error(logger, "rules", NULL, NULL,
-				 "rule '%s.%s': pooling mode is not set",
-				 rule->db_name, rule->user_name);
-			return -1;
-		}
-		if (strcmp(rule->pool_type, "session") == 0) {
-			rule->pool = OD_RULE_POOL_SESSION;
-		} else if (strcmp(rule->pool_type, "transaction") == 0) {
-			rule->pool = OD_RULE_POOL_TRANSACTION;
-		} else if (strcmp(rule->pool_type, "statement") == 0) {
-			rule->pool = OD_RULE_POOL_STATEMENT;
-		} else {
-			od_error(logger, "rules", NULL, NULL,
-				 "rule '%s.%s': unknown pooling mode",
-				 rule->db_name, rule->user_name);
-			return -1;
+		if (od_pool_validate(logger, rule->pool, rule->db_name,
+				     rule->user_name) == NOT_OK_RESPONSE) {
+			return NOT_OK_RESPONSE;
 		}
 
 		/* auth */
@@ -1056,31 +1044,32 @@ void od_rules_print(od_rules_t *rules, od_logger_t *logger)
 
 		/* pool  */
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool                              %s", rule->pool_type);
+		       "  pool                              %s",
+		       rule->pool->type);
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_size                         %d",
-		       rule->pool_size);
+		       "  pool size                         %d",
+		       rule->pool->size);
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_timeout                      %d",
-		       rule->pool_timeout);
+		       "  pool timeout                      %d",
+		       rule->pool->timeout);
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_ttl                          %d",
-		       rule->pool_ttl);
+		       "  pool ttl                          %d",
+		       rule->pool->ttl);
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_discard                      %s",
-		       rule->pool_discard ? "yes" : "no");
+		       "  pool discard                      %s",
+		       rule->pool->discard ? "yes" : "no");
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_cancel                       %s",
-		       rule->pool_cancel ? "yes" : "no");
+		       "  pool cancel                       %s",
+		       rule->pool->cancel ? "yes" : "no");
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_rollback                     %s",
-		       rule->pool_rollback ? "yes" : "no");
+		       "  pool rollback                     %s",
+		       rule->pool->rollback ? "yes" : "no");
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_client_idle_timeout          %d",
-		       rule->pool_client_idle_timeout);
+		       "  pool client_idle_timeout          %d",
+		       rule->pool->client_idle_timeout);
 		od_log(logger, "rules", NULL, NULL,
-		       "  pool_idle_in_transaction_timeout  %d",
-		       rule->pool_idle_in_transaction_timeout);
+		       "  pool idle_in_transaction_timeout  %d",
+		       rule->pool->idle_in_transaction_timeout);
 
 		if (rule->client_max_set)
 			od_log(logger, "rules", NULL, NULL,

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -23,12 +23,6 @@ typedef enum {
 } od_rule_auth_type_t;
 
 typedef enum {
-	OD_RULE_POOL_SESSION,
-	OD_RULE_POOL_TRANSACTION,
-	OD_RULE_POOL_STATEMENT,
-} od_rule_pool_type_t;
-
-typedef enum {
 	OD_RULE_STORAGE_REMOTE,
 	OD_RULE_STORAGE_LOCAL,
 } od_rule_storage_type_t;
@@ -77,6 +71,7 @@ struct od_rule {
 	int mark;
 	int obsolete;
 	int refs;
+
 	/* id */
 	char *db_name;
 	int db_name_len;
@@ -84,6 +79,7 @@ struct od_rule {
 	char *user_name;
 	int user_name_len;
 	int user_is_default;
+
 	/* auth */
 	char *auth;
 	od_rule_auth_type_t auth_mode;
@@ -96,7 +92,6 @@ struct od_rule {
 
 #ifdef PAM_FOUND
 	/*  PAM parametrs */
-
 	char *auth_pam_service;
 	od_pam_auth_data_t *auth_pam_data;
 #endif
@@ -122,16 +117,7 @@ struct od_rule {
 	char *storage_password;
 	int storage_password_len;
 	/* pool */
-	od_rule_pool_type_t pool;
-	char *pool_type;
-	int pool_size;
-	int pool_timeout;
-	int pool_ttl;
-	int pool_discard;
-	int pool_cancel;
-	int pool_rollback;
-	uint64_t pool_client_idle_timeout; // makes sence only for session pooling
-	uint64_t pool_idle_in_transaction_timeout; // makes sence only for session pooling
+	od_rule_pool_t *pool;
 	/* misc */
 	int client_fwd_error;
 	int reserve_session_server_connection;

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -123,7 +123,7 @@ struct od_rule {
 	int storage_password_len;
 	/* pool */
 	od_rule_pool_type_t pool;
-	char *pool_sz;
+	char *pool_type;
 	int pool_size;
 	int pool_timeout;
 	int pool_ttl;


### PR DESCRIPTION
It is now possible to mark some pools as "internal", which means that only Odyssey can use this routing rule (user + db). This can be used to fine tune the reuse of server connections, for example to use the same connection pool for all users using auth method "auth_query".