### PR TITLE
pgsql12 missing library fix

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -6,7 +6,7 @@
 #  PQ_LIBRARY             - PostgreSQL PQ library
 #  PQ_LIBRARY             - PostgreSQL version
 
-if("${POSTGRESQL_INCLUDE_DIR}" STREQUAL "" OR "${POSTGRESQL_INCLUDE_DIR}" STREQUAL "POSTGRESQL_INCLUDE_DIR-NOTFOUND") 
+if("${POSTGRESQL_INCLUDE_DIR}" STREQUAL "" OR "${POSTGRESQL_INCLUDE_DIR}" STREQUAL "POSTGRESQL_INCLUDE_DIR-NOTFOUND")
     find_path(
         POSTGRESQL_INCLUDE_DIR
         NAMES common/base64.h common/saslprep.h common/scram-common.h common/sha2.h
@@ -17,7 +17,7 @@ if("${POSTGRESQL_INCLUDE_DIR}" STREQUAL "" OR "${POSTGRESQL_INCLUDE_DIR}" STREQU
         OUTPUT_VARIABLE PG_INCLUDE_SERVER
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    
+
     execute_process (
         COMMAND pg_config --version
         OUTPUT_VARIABLE PG_VERSION_NUM
@@ -55,7 +55,7 @@ find_library(
 
 find_library(
     PQ_LIBRARY
-    NAMES libpq.a libpq.so
+    NAMES libpq.a libpq.so libpq.so.5
     HINTS ${PG_LIBDIR}
 )
 


### PR DESCRIPTION
Building on CentOS7 with PostgreSQL 12.10 crashes due to missing library.
After adding the proper filename to cmake, the app builds and works flawlessly.