### PR TITLE
SHOW DATABASES: fill force_user column with 'user' rule name

### DIFF
--- a/sources/console.c
+++ b/sources/console.c
@@ -740,7 +740,7 @@ static inline int od_console_show_databases_add_cb(od_route_t *route,
 		goto error;
 
 	/* force_user */
-	rc = kiwi_be_write_data_row_add(stream, offset, "", 0);
+	rc = kiwi_be_write_data_row_add(stream, offset, rule->user_name, rule->user_name_len);
 	if (rc == NOT_OK_RESPONSE)
 		goto error;
 


### PR DESCRIPTION
Currently `force_user` column is empty. This leads to an issue with some configurations, e.g.:
```
    database "foo" {
      user "user1" {
        storage "storage_foo"
        storage_user myuser
        ...
      }
      user "user2" {
        storage "storage_foo"
        storage_user myuser
        ...
      }
    }
```
In this case `SHOW DATABASES` command produces one row per database per user, but since the force_user field left empty rows are identical.
This makes the output ambiguous. It also makes hard for various exporters to deal with that data as many on them rely on `SHOW DATABASES` output.
I've chosen `user_name` field as the source for `force_user` field since it's it forms unique pair with database name whereas  `storage_user` may repeat.

The impact has been described at #432