### PR TITLE
fix compression build

### DIFF
--- a/third_party/machinarium/sources/zpq_stream.c
+++ b/third_party/machinarium/sources/zpq_stream.c
@@ -82,7 +82,7 @@ struct mm_zpq_stream {
 #ifdef MM_BUILD_COMPRESSION
 #ifdef MM_HAVE_ZSTD
 
-#include < stdlib.h>
+#include <stdlib.h>
 #include <zstd.h>
 
 #define MM_ZSTD_BUFFER_SIZE (8 * 1024)
@@ -283,7 +283,7 @@ static char zstd_name(void)
 
 #ifdef MM_HAVE_ZLIB
 
-#include < stdlib.h>
+#include <stdlib.h>
 #include <zlib.h>
 
 #define MM_ZLIB_BUFFER_SIZE \


### PR DESCRIPTION
```
/prj/odyssey-1.3/build/third_party/machinarium/sources/zpq_stream.c:85:10: fatal error:  stdlib.h: No such file or directory
 #include < stdlib.h>
          ^~~~~~~~~~~
compilation terminated.
sources/CMakeFiles/machine_library_static.dir/build.make:950: recipe for target 'sources/CMakeFiles/machine_library_static.dir/zpq_stream.c.o' failed
make[5]: *** [sources/CMakeFiles/machine_library_static.dir/zpq_stream.c.o] Error 1
```