### PR TITLE
Fix idle in transaction session timeout pgoption

### DIFF
--- a/third_party/kiwi/kiwi/var.h
+++ b/third_party/kiwi/kiwi/var.h
@@ -22,7 +22,7 @@ typedef enum {
 	KIWI_VAR_SEARCH_PATH,
 	KIWI_VAR_STATEMENT_TIMEOUT,
 	KIWI_VAR_LOCK_TIMEOUT,
-	KIWI_VAR_IDLE_IN_TRANSACTION_TIMEOUT,
+	KIWI_VAR_IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
 	KIWI_VAR_DEFAULT_TABLE_ACCESS_METHOD,
 	KIWI_VAR_DEFAULT_TOAST_COMPRESSION,
 	KIWI_VAR_CHECK_FUNCTION_BODIES,
@@ -116,9 +116,9 @@ static inline void kiwi_vars_init(kiwi_vars_t *vars)
 		      "statement_timeout", sizeof("statement_timeout"));
 	kiwi_var_init(&vars->vars[KIWI_VAR_LOCK_TIMEOUT], "lock_timeout",
 		      sizeof("lock_timeout"));
-	kiwi_var_init(&vars->vars[KIWI_VAR_IDLE_IN_TRANSACTION_TIMEOUT],
-		      "idle_in_transaction_timeout",
-		      sizeof("idle_in_transaction_timeout"));
+	kiwi_var_init(&vars->vars[KIWI_VAR_IDLE_IN_TRANSACTION_SESSION_TIMEOUT],
+		      "idle_in_transaction_session_timeout",
+		      sizeof("idle_in_transaction_session_timeout"));
 	kiwi_var_init(&vars->vars[KIWI_VAR_DEFAULT_TABLE_ACCESS_METHOD],
 		      "default_table_access_method",
 		      sizeof("default_table_access_method"));


### PR DESCRIPTION
FIx a typo. Advanced PGOPTIONS parsing was added between
1.1 and 1.2 odyssey versions, including idle_in_transaction_session_timeout
parameter passing. Thats means odyssey will lookup in startup parameter
key/value pairs and parse all hardcoded pgoptions, but this require full match
between hardcoded pgoption name and startup key