### PR TITLE
Fix undefined behaviour in od_worker_pool_feed function

### DIFF
--- a/sources/atomic.h
+++ b/sources/atomic.h
@@ -75,4 +75,16 @@ static inline uint64_t od_atomic_u64_sub(od_atomic_u64_t *atomic,
 	return __sync_sub_and_fetch(atomic, value);
 }
 
+static inline uint32_t od_atomic_u32_cas(od_atomic_u32_t *atomic,
+					 uint32_t compValue, uint32_t exchValue)
+{
+	return __sync_val_compare_and_swap(atomic, compValue, exchValue);
+}
+
+static inline uint64_t od_atomic_u64_cas(od_atomic_u64_t *atomic,
+					 uint64_t compValue, uint64_t exchValue)
+{
+	return __sync_val_compare_and_swap(atomic, compValue, exchValue);
+}
+
 #endif /* ODYSSEY_ATOMIC_H */

--- a/sources/system.c
+++ b/sources/system.c
@@ -500,7 +500,7 @@ static inline void od_system(void *arg)
 	/* start worker threads */
 	od_worker_pool_t *worker_pool = system->global->worker_pool;
 	rc = od_worker_pool_start(worker_pool, system->global,
-				  instance->config.workers);
+				  (uint32_t)instance->config.workers);
 	if (rc == -1)
 		return;
 


### PR DESCRIPTION
Currently od_worker_pool_feed function uses non-atomic access to
pool->round_robin variable. But od_worker_pool_feed function can be
called multiple time simultaneously from od_system_server, as odyssey
supports multiple listen addresses feauture, and no synchronization is
performed between concurrent listen coroutines. This entails data race, which
leads undefined behaviour in C/C++