### PR TITLE
remove extra spaces from "user blocked:" message

### DIFF
--- a/sources/auth.c
+++ b/sources/auth.c
@@ -647,9 +647,9 @@ static inline int od_auth_frontend_block(od_client_t *client)
 	od_frontend_error(
 		client, KIWI_INVALID_AUTHORIZATION_SPECIFICATION,
 		"user blocked: %s %s",
-		client->rule->db_is_default ? " (unknown database)" :
+		client->rule->db_is_default ? "(unknown database)" :
 					      client->startup.database.value,
-		client->rule->user_is_default ? " (unknown user)" :
+		client->rule->user_is_default ? "(unknown user)" :
 						client->startup.user.value);
 	return 0;
 }


### PR DESCRIPTION
These spaces are, obviously, leftovers from back when formatting string contained "%s%s" without spaces.

Update: Please see https://github.com/yandex/odyssey/commit/136dcca1a4fa8f92094b86132133272bbc444b2d for when "%s%s" turned into " %s %s".