### PR TITLE
ldap_pool_ttl

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -611,6 +611,16 @@ ldap_endpoint "ldap1" {
 }
 ```
 
+#### ldap\_pool\_ttl *integer*
+
+Ldap server pool idle timeout.
+
+Close ldap server connection when it becomes idle for 'ldap\_pool\_ttl' seconds.
+
+Set to zero to disable.
+
+`ldap_pool_ttl 60`
+
 #### password\_passthrough *bool*
 
 By default odyssey authenticate users itself, but if side auth application is used,

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -90,6 +90,7 @@ typedef enum {
 #ifdef LDAP_FOUND
 	OD_LLDAPPOOL_SIZE,
 	OD_LLDAPPOOL_TIMEOUT,
+	OD_LLDAPPOOL_TTL,
 #endif
 	OD_LPOOL_SIZE,
 	OD_LPOOL_TIMEOUT,
@@ -242,6 +243,7 @@ static od_keyword_t od_config_keywords[] = {
 #ifdef LDAP_FOUND
 	od_keyword("ldap_pool_size", OD_LLDAPPOOL_SIZE),
 	od_keyword("ldap_pool_timeout", OD_LLDAPPOOL_TIMEOUT),
+	od_keyword("ldap_pool_ttl", OD_LLDAPPOOL_TTL),
 #endif
 	od_keyword("pool_size", OD_LPOOL_SIZE),
 	od_keyword("pool_timeout", OD_LPOOL_TIMEOUT),
@@ -1310,6 +1312,12 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 		case OD_LLDAPPOOL_TIMEOUT:
 			if (!od_config_reader_number(reader,
 						     &rule->ldap_pool_timeout))
+				return NOT_OK_RESPONSE;
+			continue;
+		/* ldap_pool_ttl */
+		case OD_LLDAPPOOL_TTL:
+			if (!od_config_reader_number(reader,
+						     &rule->ldap_pool_ttl))
 				return NOT_OK_RESPONSE;
 			continue;
 #endif

--- a/sources/od_ldap.h
+++ b/sources/od_ldap.h
@@ -13,6 +13,7 @@ typedef struct {
 
 	od_global_t *global;
 	void *route;
+	int idle_timestamp;
 
 	od_list_t link;
 } od_ldap_server_t;

--- a/sources/router.c
+++ b/sources/router.c
@@ -403,6 +403,7 @@ od_router_status_t od_router_route(od_router_t *router, od_client_t *client)
 		switch (ldap_rc) {
 		case OK_RESPONSE: {
 			od_ldap_endpoint_lock(rule->ldap_endpoint);
+			ldap_server->idle_timestamp = (int)time(NULL);
 			od_ldap_server_pool_set(
 				rule->ldap_endpoint->ldap_search_pool,
 				ldap_server, OD_SERVER_IDLE);
@@ -421,6 +422,7 @@ od_router_status_t od_router_route(od_router_t *router, od_client_t *client)
 		}
 		case LDAP_INSUFFICIENT_ACCESS: {
 			od_ldap_endpoint_lock(rule->ldap_endpoint);
+			ldap_server->idle_timestamp = (int)time(NULL);
 			od_ldap_server_pool_set(
 				rule->ldap_endpoint->ldap_search_pool,
 				ldap_server, OD_SERVER_IDLE);

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -90,6 +90,7 @@ struct od_rule {
 	od_ldap_endpoint_t *ldap_endpoint;
 	int ldap_pool_timeout;
 	int ldap_pool_size;
+	int ldap_pool_ttl;
 	od_list_t ldap_storage_creds_list;
 	char *ldap_storage_credentials_attr;
 #endif


### PR DESCRIPTION
To avoid using a broken ldap connection when getting it from the pool, need to add the ttl parameter to ldap_server.