### PR TITLE
Bugs  autocommit

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -994,7 +994,7 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 
 	od_frontend_status_t retstatus = OD_OK;
 	machine_msg_t *msg;
-	bool forwarded = 0 ;
+	bool forwarded = 0;
 	switch (type) {
 	case KIWI_FE_COPY_DONE:
 	case KIWI_FE_COPY_FAIL:
@@ -1453,7 +1453,6 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 			uint32_t name_len;
 			kiwi_fe_close_type_t type;
 			int rc;
-			
 			forwarded = 1;
 
 			if (od_frontend_parse_close(data, size, &name,
@@ -1510,12 +1509,11 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 	}
 
 	/* If the retstatus is not SKIP */
-	if( route->rule->pool->reserve_prepared_statement  && forwarded  != 1)
+	if( route->rule->pool->reserve_prepared_statement && forwarded != 1)
 	{
 		msg = kiwi_fe_copy_msg(msg, data ,size);
 		od_write(&server->io, msg);
 		retstatus = OD_SKIP;
-
 	}
 	/* update server stats */
 	od_stat_query_start(&server->stats_state);

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1510,7 +1510,7 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 
 	/* If the retstatus is not SKIP */
 	if (route->rule->pool->reserve_prepared_statement && forwarded != 1) {
-		msg = kiwi_fe_copy_msg(msg, data ,size);
+		msg = kiwi_fe_copy_msg(msg, data, size);
 		od_write(&server->io, msg);
 		retstatus = OD_SKIP;
 	}

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1509,8 +1509,7 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 	}
 
 	/* If the retstatus is not SKIP */
-	if( route->rule->pool->reserve_prepared_statement && forwarded != 1)
-	{
+	if (route->rule->pool->reserve_prepared_statement && forwarded != 1) {
 		msg = kiwi_fe_copy_msg(msg, data ,size);
 		od_write(&server->io, msg);
 		retstatus = OD_SKIP;

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1441,6 +1441,10 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 	case KIWI_FE_EXECUTE:
 		if (instance->config.log_query || route->rule->log_query)
 			od_frontend_log_execute(instance, client, data, size);
+		//od_write(&server->io,data);
+		msg = kiwi_fe_copy_execute(msg,data,size);
+		od_write(&server->io,msg);
+		retstatus = OD_SKIP;
 		break;
 	case KIWI_FE_CLOSE:
 		if (route->rule->pool->reserve_prepared_statement) {

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1510,17 +1510,9 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 	}
 
 	/* If the retstatus is not SKIP */
-	if(			forwarded  != 1)
+	if( route->rule->pool->reserve_prepared_statement  && forwarded  != 1)
 	{
-		od_error(&instance->logger,
-						 "forwaRDING", NULL, server,
-						 "log: writing message of size %d, type %c", kiwi_pkt_size_copy(data,size), type);
-
-		msg = kiwi_fe_copy_msg(msg, data ,kiwi_pkt_size_copy(data,size));
-
-		od_error(&instance->logger,
-						 "forwaRDING", NULL, server,
-						 "log: forwarding");
+		msg = kiwi_fe_copy_msg(msg, data ,size);
 		od_write(&server->io, msg);
 		retstatus = OD_SKIP;
 

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -386,11 +386,10 @@ KIWI_API static inline machine_msg_t *kiwi_fe_write_authentication_scram_final(
 }
 
 KIWI_API static inline machine_msg_t *kiwi_fe_copy_msg(machine_msg_t *msg,
-							    char *data,
-							    int sizes)
+					char *data, int sizes)
 {
 	int size = sizes;
-	int offset = 0 ;
+	int offset = 0;
 	msg = machine_msg_create_or_advance(msg, size);
 	if (kiwi_unlikely(msg == NULL))
 		return NULL;
@@ -401,4 +400,3 @@ KIWI_API static inline machine_msg_t *kiwi_fe_copy_msg(machine_msg_t *msg,
 }
 
 #endif /* KIWI_FE_WRITE_H */
-

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -386,7 +386,7 @@ KIWI_API static inline machine_msg_t *kiwi_fe_write_authentication_scram_final(
 }
 
 KIWI_API static inline machine_msg_t *kiwi_fe_copy_msg(machine_msg_t *msg,
-					char *data, int sizes)
+						       char *data, int sizes)
 {
 	int size = sizes;
 	int offset = 0;

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -385,12 +385,25 @@ KIWI_API static inline machine_msg_t *kiwi_fe_write_authentication_scram_final(
 	return msg;
 }
 
-#endif /* KIWI_FE_WRITE_H */
-
-KIWI_API static inline machine_msg_t *kiwi_fe_copy_execute(machine_msg_t *msg,
+KIWI_API static inline machine_msg_t *kiwi_fe_copy_msg(machine_msg_t *msg,
 							    char *data,
-							    int data_len)
-{	
-	return kiwi_fe_write_execute(msg,data+5,  strlen(data + 5) +1 ,0);
+							    int sizes)
+{
+	int size = sizes;
+	int offset = 0 ;
+	msg = machine_msg_create_or_advance(msg, size);
+	if (kiwi_unlikely(msg == NULL))
+		return NULL;
+	char *pos;
+	pos = (char *)machine_msg_data(msg) + offset;
+	kiwi_write(&pos, data, sizes);
+	return msg;
 }
+
+KIWI_API static inline int kiwi_pkt_size_copy(char *ptr , int size)
+{ 	
+	ptr++;
+	return (((uint32_t)ptr[0]) << 24 | ptr[1] << 16 | ptr[2] << 8 | ptr[3]) + 1 ;
+}
+#endif /* KIWI_FE_WRITE_H */
 

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -386,3 +386,11 @@ KIWI_API static inline machine_msg_t *kiwi_fe_write_authentication_scram_final(
 }
 
 #endif /* KIWI_FE_WRITE_H */
+
+KIWI_API static inline machine_msg_t *kiwi_fe_copy_execute(machine_msg_t *msg,
+							    char *data,
+							    int data_len)
+{	
+	return kiwi_fe_write_execute(msg,data+5,  strlen(data + 5) +1 ,0);
+}
+

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -400,10 +400,5 @@ KIWI_API static inline machine_msg_t *kiwi_fe_copy_msg(machine_msg_t *msg,
 	return msg;
 }
 
-KIWI_API static inline int kiwi_pkt_size_copy(char *ptr , int size)
-{ 	
-	ptr++;
-	return (((uint32_t)ptr[0]) << 24 | ptr[1] << 16 | ptr[2] << 8 | ptr[3]) + 1 ;
-}
 #endif /* KIWI_FE_WRITE_H */
 


### PR DESCRIPTION
This PR is regarding the issue: https://github.com/yandex/odyssey/issues/459
In the case of the `Multi-Query` transaction (or `AutoCommit=false`, the client application received the following error when it use the prepared statements.
```
org.postgresql.util.PSQLException: Expected command status BEGIN, got INSERT 0 1.
        at org.postgresql.core.v3.QueryExecutorImpl$1.handleCommandStatus(QueryExecutorImpl.java:620)
        at org.postgresql.core.v3.QueryExecutorImpl.interpretCommandStatus(QueryExecutorImpl.java:2720)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2313)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:167)
        at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:135)
        at com.yugabyte.WriteTest.TestExtendedQuery(PerfTest.java:387)
        at com.yugabyte.WriteTest.run(PerfTest.java:429)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

When protocol level prepare statement is used the `statement_id` present in the [parse packet](https://www.postgresql.org/docs/current/protocol-message-formats.html#:~:text=of%20the%20parameter.-,Parse,-(F)) or [bind packet](https://www.postgresql.org/docs/current/protocol-message-formats.html#:~:text=of%20this%20backend.-,Bind,-(F)) is updated.
New `BIND` and `PARSE` packets are created by odyssey and sent to the server connection immediately; while for all other packets it forwarding takes a delay of one loop (odyssey packet processing loop).
This causes a `mismatch in the sequence of the packets sent to the server`.
In this workaround, all other packets(except `BIND` or `PARSE` which are modified) are also sent immediately (similar to `BIND` or `PARSE`) packets.