### PR TITLE
Reject connection initiating in replication lag too high.

### DIFF
--- a/config-examples/odyssey-dev.conf
+++ b/config-examples/odyssey-dev.conf
@@ -53,6 +53,30 @@ storage "postgres_server" {
 	host "[localhost]:5432,localhost"
 	port 5550
 	target_session_attrs "read-only"
+
+	watchdog {
+		authentication "none"
+
+		storage "postgres_server"
+		storage_db "postgres"
+		storage_user "lag_usr"
+		
+		pool_routing "internal"
+		pool "transaction"
+		pool_size 10
+
+		pool_timeout 0
+		pool_ttl 1201
+
+		pool_discard yes
+		pool_cancel yes
+
+		server_lifetime 1901
+		log_debug no
+
+		watchdog_lag_query "SELECT TRUNC(EXTRACT(EPOCH FROM NOW())) - 100"
+		watchdog_lag_interval 10
+	}
 }
 
 database "db2" {
@@ -138,6 +162,26 @@ database "postgres" {
 		log_debug yes
 		pool_discard yes
 		pool_routing "internal"
+
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
+
+
+	user "user_lag_pooling" {
+		authentication "none"
+
+		storage "postgres_server"
+		
+		pool "session"
+		storage_user "reshke"
+		storage_db "postgres"
+
+		log_debug yes
+		pool_discard yes
+
+		catchup_timeout 10
+		catchup_checks 1
 
 		quantiles "0.99,0.95,0.5"
 		client_max 107

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -460,6 +460,37 @@ storage "postgres_server" {
 #	Unset or zero 'server_max_routing' will set it's value equal to number of workers
 #
 #	server_max_routing 4
+
+
+#   Storage lag-polling watchdog
+#
+#   Defines storage lag-polling watchdog options and actually enables cron-like
+#   watchdog for this storage. This routine will execute `watchdog_lag_query` againts
+#   storage server and send return value to all routes, to decide, if connecting is desirable 
+#   with particular lag value.
+
+	watchdog {
+		authentication "none"
+
+		storage "postgres_server"
+		storage_db "postgres"
+		storage_user "postgres"
+		
+		pool_routing "internal"
+		pool "transaction"
+		pool_size 10
+
+		pool_timeout 0
+		pool_ttl 1201
+		
+		log_debug no
+
+#       Watchdog will execute this query to get underlaying server lag. 
+#       Consider something like now() - pg_last_xact_replay_timestamp() or 
+#       git@github.com:man-brain/repl_mon.git for production  usages
+		watchdog_lag_query "SELECT TRUNC(EXTRACT(EPOCH FROM NOW())) - 100"
+		watchdog_lag_interval 10
+	}
 }
 
 database default {


### PR DESCRIPTION
In replication lag polling feature, check replication lag on connection startuy (before auth), and reject connection if replication lag is too high.

Error message example:
```
reshke@oheijweoij:~$ psql -p 6432 -h localhost -d postgres -U user_lag_pooling
psql: error: connection to server at "localhost" (::1), port 6432 failed: FATAL:  odyssey: cf5d8ae30d4a2: replicaion lag too big, connection rejected: postgres user_lag_pooling
```