### PR TITLE
Add pool_discard_query option

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -685,6 +685,27 @@ from the pool.
 
 `pool_discard no`
 
+#### pool\_smart\_discard *yes|no*
+
+When this parameter is enabled, Odyssey sends smart discard query instead of default `DISCARD ALL` when it
+returns connection to the pool. Its default value may be overwritten by pool\_discard\_string setting.
+
+#### pool\_discard\_string *string*
+
+When resetting a database connection, a pre-defined query string is sent to the server. This query string consists of a set of SQL statements that will be executed during a `DISCARD ALL` command, except for `DEALLOCATE ALL`. The default query string includes the following statements:
+
+```sql
+SET SESSION AUTHORIZATION DEFAULT;
+RESET ALL;
+CLOSE ALL;
+UNLISTEN *;
+SELECT pg_advisory_unlock_all();
+DISCARD PLANS;
+DISCARD SEQUENCES;DISCARD TEMP;
+```
+
+This sequence of statements is designed to reset the connection to a clean state, without affecting the authentication credentials of the session. By executing these queries, any open transactions will be closed, locks will be released, and any cached execution plans and sequences will be discarded.
+
 #### pool\_cancel *yes|no*
 
 Server pool auto-cancel.

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -97,7 +97,7 @@ typedef enum {
 	OD_LPOOL_TTL,
 	OD_LPOOL_DISCARD,
 	OD_LPOOL_SMART_DISCARD,
-	OD_LPOOL_DISCARD_STRING,
+	OD_LPOOL_DISCARD_QUERY,
 	OD_LPOOL_CANCEL,
 	OD_LPOOL_ROLLBACK,
 	OD_LPOOL_RESERVE_PREPARED_STATEMENT,
@@ -250,7 +250,7 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("pool_timeout", OD_LPOOL_TIMEOUT),
 	od_keyword("pool_ttl", OD_LPOOL_TTL),
 	od_keyword("pool_discard", OD_LPOOL_DISCARD),
-	od_keyword("pool_discard_string", OD_LPOOL_DISCARD_STRING),
+	od_keyword("pool_discard_query", OD_LPOOL_DISCARD_QUERY),
 	od_keyword("pool_smart_discard", OD_LPOOL_SMART_DISCARD),
 	od_keyword("pool_cancel", OD_LPOOL_CANCEL),
 	od_keyword("pool_rollback", OD_LPOOL_ROLLBACK),
@@ -1362,10 +1362,10 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 				    reader, &rule->pool->smart_discard))
 				return NOT_OK_RESPONSE;
 			continue;
-		/* pool_discard_string */
-		case OD_LPOOL_DISCARD_STRING:
+		/* pool_discard_query */
+		case OD_LPOOL_DISCARD_QUERY:
 			if (!od_config_reader_string(
-				    reader, &rule->pool->discard_string))
+				    reader, &rule->pool->discard_query))
 				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_cancel */

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -97,7 +97,7 @@ typedef enum {
 	OD_LPOOL_TTL,
 	OD_LPOOL_DISCARD,
 	OD_LPOOL_SMART_DISCARD,
-	OD_LPOOL_NO_RESET_AUTH,
+	OD_LPOOL_DISCARD_STRING,
 	OD_LPOOL_CANCEL,
 	OD_LPOOL_ROLLBACK,
 	OD_LPOOL_RESERVE_PREPARED_STATEMENT,
@@ -250,8 +250,8 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("pool_timeout", OD_LPOOL_TIMEOUT),
 	od_keyword("pool_ttl", OD_LPOOL_TTL),
 	od_keyword("pool_discard", OD_LPOOL_DISCARD),
+	od_keyword("pool_discard_string", OD_LPOOL_DISCARD_STRING),
 	od_keyword("pool_smart_discard", OD_LPOOL_SMART_DISCARD),
-	od_keyword("pool_no_reset_auth", OD_LPOOL_NO_RESET_AUTH),
 	od_keyword("pool_cancel", OD_LPOOL_CANCEL),
 	od_keyword("pool_rollback", OD_LPOOL_ROLLBACK),
 	od_keyword("pool_reserve_prepared_statement",
@@ -1362,10 +1362,10 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 				    reader, &rule->pool->smart_discard))
 				return NOT_OK_RESPONSE;
 			continue;
-		/* pool_no_reset_auth */
-		case OD_LPOOL_NO_RESET_AUTH:
-			if (!od_config_reader_yes_no(
-				    reader, &rule->pool->no_reset_auth))
+		/* pool_discard_string */
+		case OD_LPOOL_DISCARD_STRING:
+			if (!od_config_reader_string(
+				    reader, &rule->pool->discard_string))
 				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_cancel */

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -97,6 +97,7 @@ typedef enum {
 	OD_LPOOL_TTL,
 	OD_LPOOL_DISCARD,
 	OD_LPOOL_SMART_DISCARD,
+	OD_LPOOL_NO_RESET_AUTH,
 	OD_LPOOL_CANCEL,
 	OD_LPOOL_ROLLBACK,
 	OD_LPOOL_RESERVE_PREPARED_STATEMENT,
@@ -250,6 +251,7 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("pool_ttl", OD_LPOOL_TTL),
 	od_keyword("pool_discard", OD_LPOOL_DISCARD),
 	od_keyword("pool_smart_discard", OD_LPOOL_SMART_DISCARD),
+	od_keyword("pool_no_reset_auth", OD_LPOOL_NO_RESET_AUTH),
 	od_keyword("pool_cancel", OD_LPOOL_CANCEL),
 	od_keyword("pool_rollback", OD_LPOOL_ROLLBACK),
 	od_keyword("pool_reserve_prepared_statement",
@@ -1358,6 +1360,12 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 		case OD_LPOOL_SMART_DISCARD:
 			if (!od_config_reader_yes_no(
 				    reader, &rule->pool->smart_discard))
+				return NOT_OK_RESPONSE;
+			continue;
+		/* pool_no_reset_auth */
+		case OD_LPOOL_NO_RESET_AUTH:
+			if (!od_config_reader_yes_no(
+					reader, &rule->pool->no_reset_auth))
 				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_cancel */

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1365,7 +1365,7 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 		/* pool_no_reset_auth */
 		case OD_LPOOL_NO_RESET_AUTH:
 			if (!od_config_reader_yes_no(
-					reader, &rule->pool->no_reset_auth))
+				    reader, &rule->pool->no_reset_auth))
 				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_cancel */

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -20,7 +20,7 @@ od_rule_pool_t *od_rule_pool_alloc()
 
 	pool->discard = 1;
 	pool->smart_discard = 0;
-	pool->discard_string = NULL;
+	pool->discard_query = NULL;
 	pool->cancel = 1;
 	pool->rollback = 1;
 
@@ -35,8 +35,8 @@ int od_rule_pool_free(od_rule_pool_t *pool)
 	if (pool->type) {
 		free(pool->type);
 	}
-	if (pool->discard_string) {
-		free(pool->discard_string);
+	if (pool->discard_query) {
+		free(pool->discard_query);
 	}
 	free(pool);
 	return OK_RESPONSE;

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -20,7 +20,7 @@ od_rule_pool_t *od_rule_pool_alloc()
 
 	pool->discard = 1;
 	pool->smart_discard = 0;
-	pool->no_reset_auth = 0;
+	pool->discard_string = NULL;
 	pool->cancel = 1;
 	pool->rollback = 1;
 
@@ -34,6 +34,9 @@ int od_rule_pool_free(od_rule_pool_t *pool)
 	}
 	if (pool->type) {
 		free(pool->type);
+	}
+	if (pool->discard_string) {
+		free(pool->discard_string);
 	}
 	free(pool);
 	return OK_RESPONSE;

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -20,6 +20,7 @@ od_rule_pool_t *od_rule_pool_alloc()
 
 	pool->discard = 1;
 	pool->smart_discard = 0;
+	pool->no_reset_auth = 0;
 	pool->cancel = 1;
 	pool->rollback = 1;
 

--- a/sources/pool.h
+++ b/sources/pool.h
@@ -33,7 +33,7 @@ struct od_rule_pool {
 
 	char *type;
 	char *routing_type;
-	char *discard_string;
+	char *discard_query;
 
 	int size;
 	int timeout;

--- a/sources/pool.h
+++ b/sources/pool.h
@@ -33,13 +33,13 @@ struct od_rule_pool {
 
 	char *type;
 	char *routing_type;
+	char *discard_string;
 
 	int size;
 	int timeout;
 	int ttl;
 	int discard;
 	int smart_discard;
-	int no_reset_auth;
 	int cancel;
 	int rollback;
 

--- a/sources/pool.h
+++ b/sources/pool.h
@@ -39,6 +39,7 @@ struct od_rule_pool {
 	int ttl;
 	int discard;
 	int smart_discard;
+	int no_reset_auth;
 	int cancel;
 	int rollback;
 

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -146,7 +146,7 @@ int od_reset(od_server_t *server)
 			rc = od_backend_query(
 				server, "reset-discard-smart-string",
 				route->rule->pool->discard_string, NULL,
-				sizeof(route->rule->pool->discard_string),
+				strlen(route->rule->pool->discard_string),
 				wait_timeout, 1);
 		}
 		if (rc == NOT_OK_RESPONSE)

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -131,19 +131,23 @@ int od_reset(od_server_t *server)
 
 	/* send smart discard */
 	if (route->rule->pool->smart_discard) {
-		if (route->rule->pool->discard_string) {
-			rc = od_backend_query(
-				server, "reset-discard-smart-string",
-				route->rule->pool->discard_string, NULL,
-				sizeof(route->rule->pool->discard_string),
-				wait_timeout, 1);
-		} else {
+		if (route->rule->pool->discard_string == NULL) {
 			char query_discard[] =
 				"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
 			rc = od_backend_query(server, "reset-discard-smart",
 					      query_discard, NULL,
 					      sizeof(query_discard),
 					      wait_timeout, 1);
+		} else {
+			od_log(&instance->logger, "reset",
+			       server->client, server,
+			       "smart discard query is %s", route->rule->pool->discard_string);
+
+			rc = od_backend_query(
+				server, "reset-discard-smart-string",
+				route->rule->pool->discard_string, NULL,
+				sizeof(route->rule->pool->discard_string),
+				wait_timeout, 1);
 		}
 		if (rc == NOT_OK_RESPONSE)
 			goto error;

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -139,10 +139,6 @@ int od_reset(od_server_t *server)
 					      sizeof(query_discard),
 					      wait_timeout, 1);
 		} else {
-			od_log(&instance->logger, "reset",
-			       server->client, server,
-			       "smart discard query is %s", route->rule->pool->discard_string);
-
 			rc = od_backend_query(
 				server, "reset-discard-smart-string",
 				route->rule->pool->discard_string, NULL,

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -141,11 +141,11 @@ int od_reset(od_server_t *server)
 			goto error;
 	}
 	if (route->rule->pool->discard_query != NULL) {
-		rc = od_backend_query(
-			server, "reset-discard-smart-string",
-			route->rule->pool->discard_query, NULL,
-			strlen(route->rule->pool->discard_query) + 1,
-			wait_timeout, 1);
+		rc = od_backend_query(server, "reset-discard-smart-string",
+				      route->rule->pool->discard_query, NULL,
+				      strlen(route->rule->pool->discard_query) +
+					      1,
+				      wait_timeout, 1);
 		if (rc == NOT_OK_RESPONSE)
 			goto error;
 	}

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -131,7 +131,7 @@ int od_reset(od_server_t *server)
 
 	/* send smart discard */
 	if (route->rule->pool->smart_discard &&
-	    route->rule->pool->discard_string == NULL) {
+	    route->rule->pool->discard_query == NULL) {
 		char query_discard[] =
 			"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
 		rc = od_backend_query(server, "reset-discard-smart",
@@ -140,11 +140,11 @@ int od_reset(od_server_t *server)
 		if (rc == NOT_OK_RESPONSE)
 			goto error;
 	}
-	if (route->rule->pool->discard_string != NULL) {
+	if (route->rule->pool->discard_query != NULL) {
 		rc = od_backend_query(
 			server, "reset-discard-smart-string",
-			route->rule->pool->discard_string, NULL,
-			strlen(route->rule->pool->discard_string) + 1,
+			route->rule->pool->discard_query, NULL,
+			strlen(route->rule->pool->discard_query) + 1,
 			wait_timeout, 1);
 		if (rc == NOT_OK_RESPONSE)
 			goto error;

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -130,7 +130,8 @@ int od_reset(od_server_t *server)
 	}
 
 	/* send smard DISCARD ALL with SET SESSION AUTHORIZATION DEFAULT */
-	if (route->rule->pool->smart_discard && !route->rule->pool->no_reset_auth) {
+	if (route->rule->pool->smart_discard &&
+	    !route->rule->pool->no_reset_auth) {
 		char query_discard[] =
 			"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
 		rc = od_backend_query(server, "reset-discard-smart",
@@ -141,10 +142,12 @@ int od_reset(od_server_t *server)
 	}
 
 	/* send smard DISCARD ALL without SET SESSION AUTHORIZATION DEFAULT */
-	if (route->rule->pool->smart_discard && route->rule->pool->no_reset_auth) {
+	if (route->rule->pool->smart_discard &&
+	    route->rule->pool->no_reset_auth) {
 		char query_discard[] =
 			"RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
-		rc = od_backend_query(server, "reset-discard-smart-no-auth-reset",
+		rc = od_backend_query(server,
+				      "reset-discard-smart-no-auth-reset",
 				      query_discard, NULL,
 				      sizeof(query_discard), wait_timeout, 1);
 		if (rc == NOT_OK_RESPONSE)

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -129,27 +129,22 @@ int od_reset(od_server_t *server)
 			goto error;
 	}
 
-	/* send smard DISCARD ALL with SET SESSION AUTHORIZATION DEFAULT */
-	if (route->rule->pool->smart_discard &&
-	    !route->rule->pool->no_reset_auth) {
-		char query_discard[] =
-			"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
-		rc = od_backend_query(server, "reset-discard-smart",
-				      query_discard, NULL,
-				      sizeof(query_discard), wait_timeout, 1);
-		if (rc == NOT_OK_RESPONSE)
-			goto error;
-	}
-
-	/* send smard DISCARD ALL without SET SESSION AUTHORIZATION DEFAULT */
-	if (route->rule->pool->smart_discard &&
-	    route->rule->pool->no_reset_auth) {
-		char query_discard[] =
-			"RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
-		rc = od_backend_query(server,
-				      "reset-discard-smart-no-auth-reset",
-				      query_discard, NULL,
-				      sizeof(query_discard), wait_timeout, 1);
+	/* send smart discard */
+	if (route->rule->pool->smart_discard) {
+		if (route->rule->pool->discard_string) {
+			rc = od_backend_query(
+				server, "reset-discard-smart-string",
+				route->rule->pool->discard_string, NULL,
+				sizeof(route->rule->pool->discard_string),
+				wait_timeout, 1);
+		} else {
+			char query_discard[] =
+				"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
+			rc = od_backend_query(server, "reset-discard-smart",
+					      query_discard, NULL,
+					      sizeof(query_discard),
+					      wait_timeout, 1);
+		}
 		if (rc == NOT_OK_RESPONSE)
 			goto error;
 	}

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -129,11 +129,22 @@ int od_reset(od_server_t *server)
 			goto error;
 	}
 
-	/* send smard DISCARD ALL */
-	if (route->rule->pool->smart_discard) {
+	/* send smard DISCARD ALL with SET SESSION AUTHORIZATION DEFAULT */
+	if (route->rule->pool->smart_discard && !route->rule->pool->no_reset_auth) {
 		char query_discard[] =
 			"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
 		rc = od_backend_query(server, "reset-discard-smart",
+				      query_discard, NULL,
+				      sizeof(query_discard), wait_timeout, 1);
+		if (rc == NOT_OK_RESPONSE)
+			goto error;
+	}
+
+	/* send smard DISCARD ALL without SET SESSION AUTHORIZATION DEFAULT */
+	if (route->rule->pool->smart_discard && route->rule->pool->no_reset_auth) {
+		char query_discard[] =
+			"RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
+		rc = od_backend_query(server, "reset-discard-smart-no-auth-reset",
 				      query_discard, NULL,
 				      sizeof(query_discard), wait_timeout, 1);
 		if (rc == NOT_OK_RESPONSE)

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -146,7 +146,7 @@ int od_reset(od_server_t *server)
 			rc = od_backend_query(
 				server, "reset-discard-smart-string",
 				route->rule->pool->discard_string, NULL,
-				strlen(route->rule->pool->discard_string),
+				strlen(route->rule->pool->discard_string) + 1,
 				wait_timeout, 1);
 		}
 		if (rc == NOT_OK_RESPONSE)

--- a/sources/reset.c
+++ b/sources/reset.c
@@ -130,21 +130,22 @@ int od_reset(od_server_t *server)
 	}
 
 	/* send smart discard */
-	if (route->rule->pool->smart_discard) {
-		if (route->rule->pool->discard_string == NULL) {
-			char query_discard[] =
-				"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
-			rc = od_backend_query(server, "reset-discard-smart",
-					      query_discard, NULL,
-					      sizeof(query_discard),
-					      wait_timeout, 1);
-		} else {
-			rc = od_backend_query(
-				server, "reset-discard-smart-string",
-				route->rule->pool->discard_string, NULL,
-				strlen(route->rule->pool->discard_string) + 1,
-				wait_timeout, 1);
-		}
+	if (route->rule->pool->smart_discard &&
+	    route->rule->pool->discard_string == NULL) {
+		char query_discard[] =
+			"SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;";
+		rc = od_backend_query(server, "reset-discard-smart",
+				      query_discard, NULL,
+				      sizeof(query_discard), wait_timeout, 1);
+		if (rc == NOT_OK_RESPONSE)
+			goto error;
+	}
+	if (route->rule->pool->discard_string != NULL) {
+		rc = od_backend_query(
+			server, "reset-discard-smart-string",
+			route->rule->pool->discard_string, NULL,
+			strlen(route->rule->pool->discard_string) + 1,
+			wait_timeout, 1);
 		if (rc == NOT_OK_RESPONSE)
 			goto error;
 	}

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -745,7 +745,7 @@ int od_pool_validate(od_logger_t *logger, od_rule_pool_t *pool, char *db_name,
 		return NOT_OK_RESPONSE;
 	}
 
-	// reserve prepare statemetn feature
+	// reserve prepare statement feature
 	if (pool->reserve_prepared_statement &&
 	    pool->pool == OD_RULE_POOL_SESSION) {
 		od_error(
@@ -775,7 +775,8 @@ int od_pool_validate(od_logger_t *logger, od_rule_pool_t *pool, char *db_name,
 		if (strcasestr(pool->discard_string, "DEALLOCATE ALL")) {
 			od_error(
 				logger, "rules", NULL, NULL,
-				"rule '%s.%s': cannot support prepared statements when 'DEALLOCATE ALL' present in discard string");
+				"rule '%s.%s': cannot support prepared statements when 'DEALLOCATE ALL' present in discard string",
+				db_name, user_name);
 			return NOT_OK_RESPONSE;
 		}
 	}

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -771,6 +771,15 @@ int od_pool_validate(od_logger_t *logger, od_rule_pool_t *pool, char *db_name,
 		return NOT_OK_RESPONSE;
 	}
 
+	if (pool->discard_string && pool->reserve_prepared_statement) {
+		if (strcasestr(pool->discard_string, "DEALLOCATE ALL")) {
+			od_error(
+				logger, "rules", NULL, NULL,
+				"rule '%s.%s': cannot support prepared statements when 'DEALLOCATE ALL' present in discard string");
+			return NOT_OK_RESPONSE;
+		}
+	}
+
 	return OK_RESPONSE;
 }
 

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -771,8 +771,8 @@ int od_pool_validate(od_logger_t *logger, od_rule_pool_t *pool, char *db_name,
 		return NOT_OK_RESPONSE;
 	}
 
-	if (pool->discard_string && pool->reserve_prepared_statement) {
-		if (strcasestr(pool->discard_string, "DEALLOCATE ALL")) {
+	if (pool->discard_query && pool->reserve_prepared_statement) {
+		if (strcasestr(pool->discard_query, "DEALLOCATE ALL")) {
 			od_error(
 				logger, "rules", NULL, NULL,
 				"rule '%s.%s': cannot support prepared statements when 'DEALLOCATE ALL' present in discard string",


### PR DESCRIPTION
In some PostgreSQL systems user permissions are not granted explicitly, they use `ROLE` session variable instead. For instance: `ALTER USER <login_user> SET ROLE <permission role>`. When Odyssey is in "smart_discard" mode and returns a connection to the pool, several statements are executed, including `SET SESSION AUTHORIZATION DEFAULT`. This causes the session `ROLE` variable to reset to "none", resulting in the loss of its initial value:
```
2023-04-14 14:19:40 UTC [1326951] => [501-1] client=127.0.0.1,db=<db>,user=<user> LOG:  duration: 0.160 ms  statement: SET SESSION AUTHORIZATION DEFAULT;RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;
```
I think Odyssey developers used all statements that execute when `DISCARD ALL` happens and removed `DEALLOCATE ALL` from them and thus `SET SESSION AUTHORIZATION DEFAULT` is also executed. After this statement is executed the session `ROLE` variable resets to `none` and its initial values is lost.
The new settings `pool_no_reset_auth` allows to skip `SET SESSION AUTHORIZATION DEFAULT` statement in smart discard mode.
```
2023-04-14 14:18:48 UTC [1326725] => [496-1] client=127.0.0.1,db=<db>,user=<db> LOG:  duration: 0.103 ms  statement: RESET ALL;CLOSE ALL;UNLISTEN *;SELECT pg_advisory_unlock_all();DISCARD PLANS;DISCARD SEQUENCES;DISCARD TEMP;
```
This setting should be used in tandem with `smart_discard`. When both `smart_discard` and `pool_no_reset_auth` are enabled `SET SESSION AUTHORIZATION DEFAULT` will not be executed when Odyssey returns connection to the pool.