### PR TITLE
Prevent reuse of logical replication connections

### DIFF
--- a/sources/router.c
+++ b/sources/router.c
@@ -641,6 +641,13 @@ attach:
 	server->idle_time = 0;
 	server->key_client = client->key;
 
+	/*
+	 * walsender connections are in "graceful shutdown" mode since we cannot
+	 * reuse it.
+	 */
+	if (route->id.physical_rep || route->id.logical_rep)
+		server->offline = 1;
+
 	od_route_unlock(route);
 
 	/* attach server io to clients machine context */


### PR DESCRIPTION
Currently walsender cannot continue to sync tables if has synced one. So we have to open new walsender connection for each client.