### PR TITLE
 Auto-generate default internal pool (for `auth-query` etc) if none specified.

### DIFF
--- a/config-examples/odyssey-aq.conf
+++ b/config-examples/odyssey-aq.conf
@@ -1,0 +1,161 @@
+pid_file "/tmp/odyssey.pid"
+daemonize yes
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+
+log_to_stdout no
+
+log_syslog no
+log_syslog_ident "odyssey"
+log_syslog_facility "daemon"
+
+log_debug yes
+log_config yes
+log_session yes
+log_query yes
+log_stats yes
+stats_interval 60
+log_general_stats_prom yes
+log_route_stats_prom no
+promhttp_server_port 7777
+
+workers "auto"
+resolvers 1
+
+readahead 8192
+
+cache_coroutine 0
+
+coroutine_stack_size 16
+
+nodelay yes
+
+keepalive 15
+keepalive_keep_interval 75
+keepalive_probes 9
+
+keepalive_usr_timeout 0
+
+listen {
+	host "*"
+	port 6432
+	backlog 128
+	compression yes
+	tls "disable"
+}
+
+
+storage "postgres_server" {
+	type "remote"
+	host "[localhost]:5432,localhost"
+	port 5550
+}
+
+database default {
+	user default {
+		authentication "md5"
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "admin"
+		auth_query_db "postgres"
+		storage_password "passwd"
+
+		storage "postgres_server"
+		pool "session"
+		pool_size 0
+
+		pool_timeout 0
+
+		pool_ttl 1201
+
+		pool_discard no
+
+		pool_cancel yes
+
+		pool_rollback yes
+#		seconds
+		pool_client_idle_timeout 20
+#		seconds
+		pool_idle_in_transaction_timeout 20
+
+		client_fwd_error yes
+		application_name_add_host yes
+		server_lifetime 1901
+		log_debug no
+
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
+}
+
+database "postgres" {
+	user "user_aq" {
+		authentication "none"
+
+		storage "postgres_server"
+		
+		pool "session"
+		storage_user "admin"
+		storage_db "postgres"
+
+		log_debug yes
+		pool_discard yes
+		pool_size 20
+		pool_routing "internal"
+
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
+
+
+	user "user_aq" {
+		authentication "md5"
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "admin"
+		auth_query_db "postgres"
+		storage_password "passwd"
+
+		storage "postgres_server"
+		storage_password "1"
+		pool "statement"
+		pool_size 1
+
+		pool_timeout 0
+		pool_ttl 60
+		pool_discard no
+		pool_cancel yes
+		pool_rollback yes
+
+		client_fwd_error yes
+
+		application_name_add_host yes
+		reserve_session_server_connection no
+		server_lifetime 3600
+		log_debug no
+
+		quantiles "0.99,0.95,0.5"
+		client_max 107
+	}
+
+}
+storage "local" {
+	type "local"
+}
+
+database "console" {
+	user default {
+		authentication "none"
+		role "admin"
+		pool "session"
+		storage "local"
+	}
+}
+
+
+locks_dir "/tmp/odyssey"
+
+graceful_die_on_errors yes
+enable_online_restart no
+bindwith_reuseport yes

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -177,7 +177,7 @@ int od_auth_query(od_client_t *client, char *peer)
 	msg = od_query_do(server, "auth_query", query, user->value);
 	if (msg == NULL) {
 		od_log(&instance->logger, "auth_query", auth_client, server,
-			"auth query returned empty msg");
+		       "auth query returned empty msg");
 		od_router_close(router, auth_client);
 		od_router_unroute(router, auth_client);
 		od_client_free(auth_client);

--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -174,10 +174,10 @@ int od_auth_query(od_client_t *client, char *peer)
 			sizeof(query));
 
 	machine_msg_t *msg;
-	msg = od_query_do(server, "auth query", query, user->value);
+	msg = od_query_do(server, "auth_query", query, user->value);
 	if (msg == NULL) {
-		od_debug(&instance->logger, "auth_query", auth_client, server,
-			 "auth query returned empty msg");
+		od_log(&instance->logger, "auth_query", auth_client, server,
+			"auth query returned empty msg");
 		od_router_close(router, auth_client);
 		od_router_unroute(router, auth_client);
 		od_client_free(auth_client);

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1695,7 +1695,7 @@ static int od_config_reader_route(od_config_reader_t *reader, char *db_name,
 	/* ensure rule does not exists and add new rule */
 	od_rule_t *rule;
 	rule = od_rules_match(reader->rules, db_name, user_name, db_is_default,
-			      user_is_default);
+			      user_is_default, 0);
 	if (rule) {
 		od_errorf(reader->error, "route '%s.%s': is redefined", db_name,
 			  user_name);
@@ -1731,15 +1731,15 @@ static inline int od_config_reader_watchdog(od_config_reader_t *reader,
 					    od_storage_watchdog_t *watchdog,
 					    od_extention_t *extentions)
 {
-	watchdog->route_usr = "watchod_int";
-	watchdog->route_db = "watchod_int";
+	watchdog->route_usr = "watchdog_int";
+	watchdog->route_db = "watchdog_int";
 	int user_name_len = 0;
 	user_name_len = strlen(watchdog->route_usr);
 
 	/* ensure rule does not exists and add new rule */
 	od_rule_t *rule;
 	rule = od_rules_match(reader->rules, watchdog->route_db,
-			      watchdog->route_usr, 0, 0);
+			      watchdog->route_usr, 0, 0, 1);
 	if (rule) {
 		od_errorf(reader->error, "route '%s.%s': is redefined",
 			  watchdog->route_db, watchdog->route_usr);

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -164,6 +164,13 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv)
 		goto error;
 	}
 
+	/* auto-generate default rule for auth_query if none specified */
+	rc = od_rules_autogenerate_defaults(&router.rules, &instance->logger);
+
+	if (rc == -1) {
+		goto error;
+	}
+
 	/* configure logger */
 	od_logger_set_format(&instance->logger, instance->config.log_format);
 	od_logger_set_debug(&instance->logger, instance->config.log_debug);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -820,7 +820,7 @@ int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger)
 
 		/* match storage and make a copy of in the user rules */
 		if (rule->auth_query != NULL &&
-		    od_rules_match(rules, rule->db_name, rule->user_name,
+		    !od_rules_match(rules, rule->db_name, rule->user_name,
 				   rule->db_is_default, rule->user_is_default,
 				   1)) {
 			need_autogen = true;

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -821,8 +821,8 @@ int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger)
 		/* match storage and make a copy of in the user rules */
 		if (rule->auth_query != NULL &&
 		    !od_rules_match(rules, rule->db_name, rule->user_name,
-				   rule->db_is_default, rule->user_is_default,
-				   1)) {
+				    rule->db_is_default, rule->user_is_default,
+				    1)) {
 			need_autogen = true;
 			break;
 		}
@@ -844,6 +844,12 @@ int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger)
 	if (!default_rule->storage) {
 		od_log(logger, "config", NULL, NULL,
 		       "skipping default internal rule auto-generation: default rule storage not set");
+		return OK_RESPONSE;
+	}
+
+	if (!default_rule->storage_password) {
+		od_log(logger, "config", NULL, NULL,
+		       "skipping default internal rule auto-generation: default rule storage password not set");
 		return OK_RESPONSE;
 	}
 
@@ -876,6 +882,10 @@ int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger)
 	rule->pool->size = OD_DEFAULT_INTERNAL_POLL_SZ;
 	rule->enable_password_passthrough = true;
 	rule->storage = od_rules_storage_copy(default_rule->storage);
+
+	rule->storage_password = strdup(default_rule->storage_password);
+	rule->storage_password_len = default_rule->storage_password_len;
+
 	if (!rule->storage) {
 		// oom
 		return NOT_OK_RESPONSE;

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -872,7 +872,7 @@ int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger)
 		return NOT_OK_RESPONSE;
 
 /* force several default settings */
-#define OD_DEFAULT_INTERNAL_POLL_SZ 10
+#define OD_DEFAULT_INTERNAL_POLL_SZ 0
 	rule->pool->type = strdup("transaction");
 	rule->pool->pool = OD_RULE_POOL_TRANSACTION;
 

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -168,7 +168,7 @@ void od_rules_ref(od_rule_t *);
 void od_rules_unref(od_rule_t *);
 int od_rules_compare(od_rule_t *, od_rule_t *);
 
-od_rule_t *od_rules_forward(od_rules_t *, char *, char *);
+od_rule_t *od_rules_forward(od_rules_t *, char *, char *, int);
 
 /* search rule with desored characteristik */
 od_rule_t *od_rules_match(od_rules_t *rules, char *db_name, char *user_name,

--- a/sources/rules.h
+++ b/sources/rules.h
@@ -154,6 +154,8 @@ struct od_rules {
 void od_rules_init(od_rules_t *);
 void od_rules_free(od_rules_t *);
 int od_rules_validate(od_rules_t *, od_config_t *, od_logger_t *);
+/* auto-generate default rules (for auth query etc) if needed */
+int od_rules_autogenerate_defaults(od_rules_t *rules, od_logger_t *logger);
 int od_rules_merge(od_rules_t *, od_rules_t *, od_list_t *added,
 		   od_list_t *deleted, od_list_t *drop);
 void od_rules_print(od_rules_t *, od_logger_t *);
@@ -168,7 +170,10 @@ int od_rules_compare(od_rule_t *, od_rule_t *);
 
 od_rule_t *od_rules_forward(od_rules_t *, char *, char *);
 
-od_rule_t *od_rules_match(od_rules_t *, char *, char *, int, int);
+/* search rule with desored characteristik */
+od_rule_t *od_rules_match(od_rules_t *rules, char *db_name, char *user_name,
+			  int db_is_default, int user_is_default,
+			  int pool_internal);
 
 void od_rules_rule_free(od_rule_t *rule);
 


### PR DESCRIPTION
 Auto-generate default internal pool if none specified.

Added auto-generation logic to create internal rule for aurh-query
when none "pool_internal" rules was specified, but auth query is in use.