### PR TITLE
Pin golang docker image to stabilize tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as base
+FROM golang:1.19 as base
 
 RUN mkdir -p /ody-integration-test
 RUN mkdir -p /prep_stmts

--- a/docker/auth_query/test_auth_query.sh
+++ b/docker/auth_query/test_auth_query.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+exit 0
 /usr/bin/odyssey /auth_query/config.conf
 
 PGPASSWORD=passwd psql -h localhost -p 6432 -U auth_query_user_scram_sha_256 -c "SELECT 1" auth_query_db >/dev/null 2>&1 || {

--- a/docker/auth_query/test_auth_query.sh
+++ b/docker/auth_query/test_auth_query.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-exit 0
 /usr/bin/odyssey /auth_query/config.conf
 
 PGPASSWORD=passwd psql -h localhost -p 6432 -U auth_query_user_scram_sha_256 -c "SELECT 1" auth_query_db >/dev/null 2>&1 || {

--- a/docker/ody-integration-test/pkg/util.go
+++ b/docker/ody-integration-test/pkg/util.go
@@ -166,14 +166,14 @@ func OdysseyIsAlive(ctx context.Context) error {
 }
 
 func waitOnOdysseyAlive(ctx context.Context, timeout time.Duration) error {
-	for ok := false; !ok && timeout > 0; ok = OdysseyIsAlive(ctx) == nil {
+	for OdysseyIsAlive(ctx) != nil {
 		timeout -= time.Second
+		if timeout < 0 {
+			return fmt.Errorf("timeout expired")
+		}
 		time.Sleep(time.Second)
 		fmt.Printf("waiting for od up: remamining time %d\n", timeout/time.Second)
 	}
 
-	if timeout < 0 {
-		return fmt.Errorf("timeout expired")
-	}
 	return nil
 }

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1557,14 +1557,12 @@ static inline od_frontend_status_t od_frontend_poll_catchup(od_client_t *client,
 	 * Heartbeat might be 0 after reload\restart.
 	 */
 	int absent_heartbeat_checks = 0;
-	while (route->last_heartbeat == 0)
-	{
+	while (route->last_heartbeat == 0) {
 		machine_sleep(ODYSSEY_CATCHUP_RECHECK_INTERVAL);
-		if (absent_heartbeat_checks++ > (timeout * 1000 / ODYSSEY_CATCHUP_RECHECK_INTERVAL))
-		{
-			od_debug(
-				&instance->logger, "catchup", client, NULL,
-				"No heartbeat for route detected\n");
+		if (absent_heartbeat_checks++ >
+		    (timeout * 1000 / ODYSSEY_CATCHUP_RECHECK_INTERVAL)) {
+			od_debug(&instance->logger, "catchup", client, NULL,
+				 "No heartbeat for route detected\n");
 			return OD_ECATCHUP_TIMEOUT;
 		}
 	}
@@ -1584,9 +1582,9 @@ static inline od_frontend_status_t od_frontend_poll_catchup(od_client_t *client,
 			"client %s replication %d lag is over catchup timeout %d\n",
 			client->id.id, lag, timeout);
 		/*
-		* TBD: Consider configuring `ODYSSEY_CATCHUP_RECHECK_INTERVAL` in 
-		* frontend rule.
-		*/
+		 * TBD: Consider configuring `ODYSSEY_CATCHUP_RECHECK_INTERVAL` in 
+		 * frontend rule.
+		 */
 		if (check < route->rule->catchup_checks) {
 			machine_sleep(ODYSSEY_CATCHUP_RECHECK_INTERVAL);
 		}

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1551,6 +1551,24 @@ static inline od_frontend_status_t od_frontend_poll_catchup(od_client_t *client,
 	od_dbg_printf_on_dvl_lvl(
 		1, "client %s polling replica for catchup with timeout %d\n",
 		client->id.id, timeout);
+
+	/*
+	 * Ensure heartbeet is initialized at least once.
+	 * Heartbeat might be 0 after reload\restart.
+	 */
+	int absent_heartbeat_checks = 0;
+	while (route->last_heartbeat == 0)
+	{
+		machine_sleep(ODYSSEY_CATCHUP_RECHECK_INTERVAL);
+		if (absent_heartbeat_checks++ > (timeout * 1000 / ODYSSEY_CATCHUP_RECHECK_INTERVAL))
+		{
+			od_debug(
+				&instance->logger, "catchup", client, NULL,
+				"No heartbeat for route detected\n");
+			return OD_ECATCHUP_TIMEOUT;
+		}
+	}
+
 	for (int check = 1; check <= route->rule->catchup_checks; ++check) {
 		od_dbg_printf_on_dvl_lvl(1, "current cached time %d\n",
 					 machine_timeofday_sec());


### PR DESCRIPTION
Currently tests fail due to changes in libraries of golang:latest. To avoid such situations this PR pins docker image of prep stmt test.