### PR TITLE
sources/auth_query.c: improve cleanup on error path

### DIFF
--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -193,6 +193,8 @@ int od_auth_query(od_client_t *client, char *peer)
 		od_debug(&instance->logger, "auth_query", auth_client, NULL,
 			 "failed to route internal auth query client: %s",
 			 od_router_status_to_str(status));
+		od_router_close(router, auth_client);
+		od_router_unroute(router, auth_client);
 		od_client_free(auth_client);
 		goto error;
 	}


### PR DESCRIPTION
found by Coverity

```
288error:
289        /* unlock hashmap entry */
290        od_hashmap_unlock_key(storage->acache, keyhash, &key);

CID 486482: (#1 of 1): Missing unlock (LOCK)
8. missing_unlock: Returning without unlocking router->lock.
291        return NOT_OK_RESPONSE;
```