### PR TITLE
Revert "Do not use machinarium API while holding lock"

### DIFF
--- a/sources/router.c
+++ b/sources/router.c
@@ -344,17 +344,6 @@ od_router_status_t od_router_route(od_router_t *router, od_client_t *client)
 	kiwi_be_startup_t *startup = &client->startup;
 	od_instance_t *instance = router->global->instance;
 
-	struct sockaddr_storage sa;
-	int salen;
-	struct sockaddr *saddr;
-	int rc;
-	salen = sizeof(sa);
-	saddr = (struct sockaddr *)&sa;
-	rc = machine_getpeername(client->io.io, saddr, &salen);
-	if (rc == -1) {
-		return OD_ROUTER_ERROR;
-	}
-
 	/* match route */
 	assert(startup->database.value_len);
 	assert(startup->user.value_len);
@@ -365,12 +354,23 @@ od_router_status_t od_router_route(od_router_t *router, od_client_t *client)
 	od_rule_t *rule =
 		NULL; // initialize rule for (line 365) and flag '-Wmaybe-uninitialized'
 
+	struct sockaddr_storage sa;
+	int salen;
+	struct sockaddr *saddr;
+	int rc;
 	switch (client->type) {
 	case OD_POOL_CLIENT_INTERNAL:
 		rule = od_rules_forward(&router->rules, startup->database.value,
 					startup->user.value, NULL, 1);
 		break;
 	case OD_POOL_CLIENT_EXTERNAL:
+		salen = sizeof(sa);
+		saddr = (struct sockaddr *)&sa;
+		rc = machine_getpeername(client->io.io, saddr, &salen);
+		if (rc == -1) {
+			od_router_unlock(router);
+			return OD_ROUTER_ERROR;
+		}
 		rule = od_rules_forward(&router->rules, startup->database.value,
 					startup->user.value, &sa, 0);
 		break;


### PR DESCRIPTION
It seems like #599 is breaking tests. I suspect that we call machine_getpeername() for internal pool, which is not expected. Let's revert it for now and return back later,