### PR TITLE
Fix bug in console_role_test

### DIFF
--- a/docker/shell-test/console_role_test.sh
+++ b/docker/shell-test/console_role_test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -x
 
-#Tests are based on fact that in case of insufficient privilege
+# Tests are based on fact that in case of insufficient privilege
 # psql return nothing and all of logging done by odyssey
 
+sleep 1
 /usr/bin/odyssey /shell-test/conf.conf
 
 response=$(psql -U rogue -d console -h localhost -p 6432 -c 'show errors;')


### PR DESCRIPTION
do not pass console_role_test periodically. added sleep so that the system had time to return to its original state before starting the test