### PR TITLE
sources/hba.c: fix memory overrun

### DIFF
--- a/sources/hba.c
+++ b/sources/hba.c
@@ -34,7 +34,7 @@ void od_hba_reload(od_hba_t *hba, od_hba_rules_t *rules)
 	od_hba_lock(hba);
 
 	od_list_init(&hba->rules);
-	memcpy(&hba->rules, &rules, sizeof(hba->rules));
+	memcpy(&hba->rules, &rules, sizeof(rules));
 
 	od_hba_unlock(hba);
 }


### PR DESCRIPTION
found by coverity

```
CID 477241: (#1 of 1): Out-of-bounds access (OVERRUN)
1. overrun-buffer-arg: Overrunning buffer pointed to by &rules of 8 bytes by passing it to a function which accesses it at byte offset 15 using argument 16UL.
 37        memcpy(&hba->rules, &rules, sizeof(hba->rules));
```