### PR TITLE
sources/logger.c: initialize empty_va_list 

### DIFF
--- a/sources/logger.c
+++ b/sources/logger.c
@@ -542,7 +542,7 @@ extern void od_logger_write_plain(od_logger_t *logger, od_logger_level_t level,
 
 	int len = strlen(string);
 	char output[len + OD_LOGLINE_MAXLEN];
-	va_list empty_va_list;
+	va_list empty_va_list = {0};
 	len = od_logger_format(logger, level, context, client, server, string,
 			       empty_va_list, output, len + 100);
 

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -542,7 +542,7 @@ extern void od_logger_write_plain(od_logger_t *logger, od_logger_level_t level,
 
 	int len = strlen(string);
 	char output[len + OD_LOGLINE_MAXLEN];
-	va_list empty_va_list = {0};
+	va_list empty_va_list = { 0 };
 	len = od_logger_format(logger, level, context, client, server, string,
 			       empty_va_list, output, len + 100);
 


### PR DESCRIPTION
found by coverity

```

10. var_decl: Declaring variable empty_va_list without initializer.
545        va_list empty_va_list;

CID 477250: (#1 of 1): Uninitialized pointer read (UNINIT)
11. uninit_use_in_call: Using uninitialized value empty_va_list when calling od_logger_format.["show details"]
```