### PR TITLE
docker/xproto/Dockerfile: skip TestHintRoutingXproto

### DIFF
--- a/docker/xproto/Dockerfile
+++ b/docker/xproto/Dockerfile
@@ -6,4 +6,5 @@ COPY . /root
 RUN go mod init prep_stmt_test && \
     go mod tidy
 
-ENTRYPOINT go test .
+# odyssey can't run TestHintRoutingXproto from spqr proto tests now
+ENTRYPOINT go test -skip TestHintRoutingXproto .


### PR DESCRIPTION
The test failed on odyssey: https://github.com/yandex/odyssey/actions/runs/9942496898/job/27464188331?pr=629
This patch exclude it from running temporarily.