### PR TITLE
od_relay_read_pending_aware

### DIFF
--- a/sources/relay.h
+++ b/sources/relay.h
@@ -36,6 +36,8 @@ struct od_relay {
 	void *on_read_arg;
 };
 
+static inline od_frontend_status_t
+od_relay_read_pending_aware(od_relay_t *relay);
 static inline od_frontend_status_t od_relay_read(od_relay_t *relay);
 
 static inline void od_relay_init(od_relay_t *relay, od_io_t *io)
@@ -108,7 +110,7 @@ od_relay_start(od_relay_t *relay, machine_cond_t *base,
 	// to avoid attaching to a new server connection
 
 	if (machine_cond_try(relay->src->on_read)) {
-		rc = od_relay_read(relay);
+		rc = od_relay_read_pending_aware(relay);
 		if (rc != OD_OK)
 			return rc;
 		// signal machine condition immidiatelly if we are not requested for pending data wait
@@ -318,12 +320,46 @@ static inline od_frontend_status_t od_relay_pipeline(od_relay_t *relay)
 	return OD_OK;
 }
 
+/*
+ * This is just like od_relay_read, but we must signal on read cond, when
+ * there are pending bytes, otherwise it will be lost
+ * (in case for tls cached bytes for example)
+*/
+static inline od_frontend_status_t
+od_relay_read_pending_aware(od_relay_t *relay)
+{
+	od_frontend_status_t rc = od_relay_read(relay);
+	if (rc == OD_READAHEAD_IS_FULL) {
+		if (machine_read_pending(relay->src->io)) {
+			machine_cond_signal(relay->src->on_read);
+		}
+		return OD_OK;
+	}
+
+	return rc;
+}
+
+/*
+ * This can lead to lost of relay->src->on_read in case of full readahead
+ * and some pending bytes available.
+ * Consider using od_relay_read_pending_aware instead
+ */
 static inline od_frontend_status_t od_relay_read(od_relay_t *relay)
 {
 	int to_read;
 	to_read = od_readahead_left(&relay->src->readahead);
-	if (to_read == 0)
+	if (to_read == 0) {
+		if (machine_read_pending(relay->src->io)) {
+			/*
+			 * This is situation, when we can read some bytes
+			 * but there is no place in readahead for it.
+			 * Therefore, this should be retry later, when readahead will
+			 * have free space to place the bytes.
+			*/
+			return OD_READAHEAD_IS_FULL;
+		}
 		return OD_OK;
+	}
 
 	char *pos;
 	pos = od_readahead_pos(&relay->src->readahead);
@@ -386,7 +422,7 @@ static inline od_frontend_status_t od_relay_step(od_relay_t *relay,
 			return OD_ATTACH;
 		}
 
-		rc = od_relay_read(relay);
+		rc = od_relay_read_pending_aware(relay);
 		if (rc != OD_OK)
 			return rc;
 

--- a/sources/status.h
+++ b/sources/status.h
@@ -17,6 +17,7 @@ typedef enum {
 	OD_WAIT_SYNC,
 	OD_READ_FULL,
 	OD_STOP,
+	OD_READAHEAD_IS_FULL,
 	OD_EOOM,
 	OD_EATTACH,
 	OD_EATTACH_TOO_MANY_CONNECTIONS,
@@ -70,6 +71,8 @@ static inline char *od_frontend_status_to_str(od_frontend_status_t status)
 		return "OD_ESYNC_BROKEN";
 	case OD_ECATCHUP_TIMEOUT:
 		return "OD_ECATCHUP_TIMEOUT";
+	case OD_READAHEAD_IS_FULL:
+		return "OD_EREADAHEAD_IS_FULL";
 	}
 	return "UNKNOWN";
 }

--- a/third_party/machinarium/sources/io.c
+++ b/third_party/machinarium/sources/io.c
@@ -402,3 +402,17 @@ ssize_t mm_io_read(mm_io_t *io, void *buf, size_t size)
 	io->connected = 0;
 	return rc;
 }
+
+int mm_io_read_pending(mm_io_t *io)
+{
+	mm_cond_t *on_read = (mm_cond_t *)io->on_read;
+	if (on_read->signal) {
+		return 1;
+	}
+
+	if (mm_tls_is_active(io)) {
+		return mm_tls_read_pending(io);
+	}
+
+	return mm_socket_read_pending(io->fd);
+}

--- a/third_party/machinarium/sources/io.h
+++ b/third_party/machinarium/sources/io.h
@@ -64,5 +64,6 @@ int mm_io_socket_set(mm_io_t *, int);
 int mm_io_socket(mm_io_t *, struct sockaddr *);
 ssize_t mm_io_write(mm_io_t *, void *, size_t);
 ssize_t mm_io_read(mm_io_t *, void *, size_t);
+int mm_io_read_pending(mm_io_t *);
 
 #endif /* MM_IO_H */

--- a/third_party/machinarium/sources/machinarium.h
+++ b/third_party/machinarium/sources/machinarium.h
@@ -258,6 +258,11 @@ MACHINE_API int machine_read_stop(machine_io_t *);
 
 MACHINE_API ssize_t machine_read_raw(machine_io_t *, void *, size_t);
 
+/*
+ * Returns 1 if there are some bytes in io, that are ready to be read.
+ */
+MACHINE_API int machine_read_pending(machine_io_t *);
+
 MACHINE_API machine_msg_t *machine_read(machine_io_t *, size_t,
 					uint32_t time_ms);
 

--- a/third_party/machinarium/sources/machinarium_private.h
+++ b/third_party/machinarium/sources/machinarium_private.h
@@ -36,6 +36,7 @@
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/signalfd.h>
+#include <sys/ioctl.h>
 
 #include <openssl/opensslv.h>
 #include <openssl/ssl.h>

--- a/third_party/machinarium/sources/read.c
+++ b/third_party/machinarium/sources/read.c
@@ -95,6 +95,12 @@ MACHINE_API ssize_t machine_read_raw(machine_io_t *obj, void *buf, size_t size)
 	return mm_io_read(io, buf, size);
 }
 
+MACHINE_API int machine_read_pending(machine_io_t *obj)
+{
+	mm_io_t *io = mm_cast(mm_io_t *, obj);
+	return mm_io_read_pending(io);
+}
+
 static inline int machine_read_to(machine_io_t *obj, machine_msg_t *msg,
 				  size_t size, uint32_t time_ms)
 {

--- a/third_party/machinarium/sources/socket.c
+++ b/third_party/machinarium/sources/socket.c
@@ -204,6 +204,17 @@ int mm_socket_read(int fd, void *buf, int size)
 	return rc;
 }
 
+int mm_socket_read_pending(int fd)
+{
+	int rc;
+	rc = ioctl(fd, FIONREAD, &rc);
+	if (rc == -1) {
+		return -1;
+	}
+
+	return rc > 0;
+}
+
 int mm_socket_getsockname(int fd, struct sockaddr *sa, socklen_t *salen)
 {
 	int rc;

--- a/third_party/machinarium/sources/socket.h
+++ b/third_party/machinarium/sources/socket.h
@@ -29,5 +29,6 @@ int mm_socket_getsockname(int, struct sockaddr *, socklen_t *);
 int mm_socket_getpeername(int, struct sockaddr *, socklen_t *);
 int mm_socket_getaddrinfo(char *, char *, struct addrinfo *,
 			  struct addrinfo **);
+int mm_socket_read_pending(int fd);
 
 #endif /* MM_SOCKET_H */


### PR DESCRIPTION
    sources/relay.h: od_relay_read_pending_aware
    
    There is a bug: when the readahead is full and there are some pending bytes
    (especially for tls read-ahead case), relay->src->on_read signal will be set to 0,
    and the client will be softlocked (no on_read signal with available
    bytes on it).
    
    This commit adds additional pending aware read functions, that performs
    mahcine_cond_signal when there are any pending bytes.
    
    Signed-off-by: Roman Khapov <r.khapov@ya.ru>

    machinarium/io: add mm_io_read_pending
    
    This function will inform the caller, if there is data in mm_io_t, that
    are ready for non-blocking read now.
    
    It will be used later in od_relay_read maybe.
    
    Signed-off-by: Roman Khapov <r.khapov@ya.ru>

