### PR TITLE
context_stack.c: rm PROT_EXEC

### DIFF
--- a/third_party/machinarium/sources/context_stack.c
+++ b/third_party/machinarium/sources/context_stack.c
@@ -16,7 +16,7 @@ int mm_contextstack_create(mm_contextstack_t *stack, size_t size,
 			   size_t size_guard)
 {
 	char *base;
-	base = mmap(0, size_guard + size, PROT_READ | PROT_WRITE | PROT_EXEC,
+	base = mmap(0, size_guard + size, PROT_READ | PROT_WRITE,
 		    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	if (base == MAP_FAILED)
 		return -1;


### PR DESCRIPTION
PROT_EXEC allows to execute code from coroutine stack, which is useless feature, and moreover, this is not secure.