### PR TITLE
docker-compose-test.yml: make network name

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -28,6 +28,7 @@ services:
 
 networks:
   od_net:
+    name: odyssey_od_net
     driver: bridge
     ipam:
       driver: default


### PR DESCRIPTION
It will help to run tests in forks with different repo's name.

Signed-off-by: Roman Khapov <r.khapov@ya.ru>
(cherry picked from commit f1ea4ccfae962cee6a16e7b6ce63c8f23b45f135)