### PR TITLE
sources/ldap.c: fix UAF found by coverity

### DIFF
--- a/sources/ldap.c
+++ b/sources/ldap.c
@@ -560,8 +560,7 @@ od_retcode_t od_auth_ldap(od_client_t *cl, kiwi_password_t *tok)
 
 		od_ldap_endpoint_unlock(cl->rule->ldap_endpoint);
 		if (rc == OK_RESPONSE) {
-			od_ldap_server_free(serv);
-			return rc;
+			break;
 		}
 	}
 

--- a/sources/ldap.c
+++ b/sources/ldap.c
@@ -553,7 +553,6 @@ od_retcode_t od_auth_ldap(od_client_t *cl, kiwi_password_t *tok)
 			od_ldap_server_pool_set(
 				cl->rule->ldap_endpoint->ldap_auth_pool, serv,
 				OD_SERVER_UNDEF);
-			od_ldap_server_free(serv);
 			rc = NOT_OK_RESPONSE;
 			break;
 		}
@@ -561,10 +560,12 @@ od_retcode_t od_auth_ldap(od_client_t *cl, kiwi_password_t *tok)
 
 		od_ldap_endpoint_unlock(cl->rule->ldap_endpoint);
 		if (rc == OK_RESPONSE) {
+			od_ldap_server_free(serv);
 			return rc;
 		}
 	}
 
+	od_ldap_server_free(serv);
 	return rc;
 }
 


### PR DESCRIPTION
527        while (retry_cnt--) {

CID 508598: (#1 of 1): Use after free (USE_AFTER_FREE)
13. deref_arg: Calling od_ldap_server_auth dereferences freed pointer serv.[show details]
528                ldap_rc = od_ldap_server_auth(serv, cl, tok);
529
530                od_ldap_endpoint_lock(cl->rule->ldap_endpoint);