### PR TITLE
sources/console.c: cleanup redundant check condition

### DIFF
--- a/sources/console.c
+++ b/sources/console.c
@@ -298,9 +298,6 @@ static inline int od_console_show_help(od_client_t *client,
 	stream = kiwi_be_write_notice_console_usage(stream, message);
 
 	int rc = kiwi_be_write_complete(stream, "SHOW", 5);
-	if (rc == NOT_OK_RESPONSE) {
-		return rc;
-	}
 	return rc;
 }
 


### PR DESCRIPTION
```
*** CID 508676:  Incorrect expression  (IDENTICAL_BRANCHES) /sources/console.c: 301 in od_console_show_help()
295                     "\tSET key=arg\n"
296                     "\tCREATE <module_path>\n"
297                     "\tDROP SERVERS|MODULE <servers>|<module>";
298             stream = kiwi_be_write_notice_console_usage(stream, message);
299
300             int rc = kiwi_be_write_complete(stream, "SHOW", 5);
>>>     CID 508676:  Incorrect expression  (IDENTICAL_BRANCHES)
>>>     The same code is executed when the condition "rc == -1" is true or false, because the code in the if-then branch and after the if statement is identical. Should the if statement be removed?
301             if (rc == NOT_OK_RESPONSE) {
302                     return rc;
303             }
304             return rc;
305     }
306
```