### PR TITLE
fix reloading group_rules

### DIFF
--- a/sources/system.c
+++ b/sources/system.c
@@ -535,6 +535,8 @@ void od_system_config_reload(od_system_t *system)
 
 	od_log(&instance->logger, "rules", NULL, NULL,
 	       "%d routes created/deleted and scheduled for removal", updates);
+
+	od_rules_groups_checkers_run(&instance->logger, &router->rules);
 }
 
 static inline void od_system(void *arg)


### PR DESCRIPTION
Fixed work with groups after reloading odyssey
* Run od_rules_groups_checkers_run after reloading odyssey
* Stop od_rules_groups_checkers_run if rule was deleted