### PR TITLE
bump golang docker image to 1.23.0 for xproto-test

### DIFF
--- a/docker/xproto/Dockerfile
+++ b/docker/xproto/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23.0
 
 WORKDIR /root
 COPY . /root


### PR DESCRIPTION
bump golang image tag to `golang:1.23.0` for xproto-test
https://github.com/pg-sharding/spqr/pull/756