### PR TITLE
check group rule settings are defined

### DIFF
--- a/sources/rules.c
+++ b/sources/rules.c
@@ -1650,6 +1650,34 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 				return -1;
 			}
 		}
+
+		/* group */
+		if (rule->group) {
+			if (rule->group->group_query == NULL) {
+				od_error(
+					logger, "rules", NULL, NULL,
+					"rule '%s.%s %s': group_query is not set",
+					rule->db_name, rule->user_name,
+					rule->address_range.string_value);
+				return -1;
+			}
+			if (rule->group->group_query_user == NULL) {
+				od_error(
+					logger, "rules", NULL, NULL,
+					"rule '%s.%s %s': group_query_user is not set",
+					rule->db_name, rule->user_name,
+					rule->address_range.string_value);
+				return -1;
+			}
+			if (rule->group->group_query_db == NULL) {
+				od_error(
+					logger, "rules", NULL, NULL,
+					"rule '%s.%s %s': group_query_db is not set",
+					rule->db_name, rule->user_name,
+					rule->address_range.string_value);
+				return -1;
+			}
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Received signal SIGSEGV if group_rule parameters not defined
```
database "db1" {
    group "group1" {
        authentication "md5"
        auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
        auth_query_user "postgres"
        auth_query_db "postgres"
        storage "postgres_server"
        pool "transaction"
        # group_query "SELECT rolname FROM pg_roles WHERE pg_has_role(rolname, 'group1', 'member')"
        # group_query_user "postgres"
        # group_query_db "postgres"
    }
}
```
```
Thread 4 "system" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff70ae640 (LWP 57430)]
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
74      ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x0000555555563a8d in od_rules_group_checker_run (arg=0x7fffe00078d0) at /odyssey/sources/rules.c:213
#2  0x00005555555bec49 in mm_scheduler_main (arg=0x7fffe00078f0) at /odyssey/build/third_party/machinarium/sources/scheduler.c:17
#3  0x00005555555c11ff in mm_context_runner () at /odyssey/build/third_party/machinarium/sources/context.c:28
#4  0x0000000000000000 in ?? ()
```