### PR TITLE
sources/hashmap.c: fix lock

### DIFF
--- a/sources/hashmap.c
+++ b/sources/hashmap.c
@@ -224,7 +224,7 @@ od_hashmap_elt_t *od_hashmap_lock_key(od_hashmap_t *hm, od_hash_t keyhash,
 	 * To avoid intra-machine locks we must yield cpu slice from time to time
 	 * even if waiting for other lock.
 	 */
-	while (!pthread_mutex_trylock(&hm->buckets[bucket_index]->mu))
+	while (pthread_mutex_trylock(&hm->buckets[bucket_index]->mu))
 		machine_sleep(1);
 
 	od_hashmap_elt_t *ptr = od_bucket_search(hm->buckets[bucket_index],


### PR DESCRIPTION
pthread_mutex_trylock returns non-zero, when mutex is not locked, so current usage will sleep when mutex is locked succesfully