### PR TITLE
sources/tls.c: eof error text improve

### DIFF
--- a/third_party/machinarium/sources/tls.c
+++ b/third_party/machinarium/sources/tls.c
@@ -142,7 +142,13 @@ static inline void mm_tls_error(mm_io_t *io, int ssl_rc, char *fmt, ...)
 	} else if (ssl_rc == 0) {
 		error_str = "unexpected EOF (connection reset)";
 	} else if (ssl_rc < 0) {
-		error_str = strerror(mm_errno_get());
+		int errno_ = mm_errno_get();
+		if (errno_ != 0) {
+			error_str = strerror(errno_);
+		} else {
+			error_str =
+				"no bio underlying error (client closed the connection?)";
+		}
 	}
 
 	/* error message */


### PR DESCRIPTION
When errno is 0, it means that client closed the connection


(cherry picked from commit e4021d359980ed8e6cb86271672a0895e7aa5ae7)