### PR TITLE
sources/config_reader.c: do not set tcp usr timeout

### DIFF
--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -2368,14 +2368,12 @@ static int od_config_reader_hba_import(od_config_reader_t *config_reader)
 
 static void od_config_setup_default_tcp_usr_timeout(od_config_t *config)
 {
-	if (config->keepalive_usr_timeout == 0) {
+	if (config->keepalive_usr_timeout < 0) {
 		config->keepalive_usr_timeout =
 			machine_advice_keepalive_usr_timeout(
 				config->keepalive,
 				config->keepalive_keep_interval,
 				config->keepalive_probes);
-	} else if (config->keepalive_usr_timeout < 0) {
-		config->keepalive_usr_timeout = 0;
 	}
 }
 


### PR DESCRIPTION
Should use system tcp usr timeout by default