### PR TITLE
Bump pgproto version

### DIFF
--- a/docker/ody_integration_test/go.mod
+++ b/docker/ody_integration_test/go.mod
@@ -3,7 +3,7 @@ module pkg
 go 1.14
 
 require (
-	github.com/jackc/pgproto3 v1.1.0
+	github.com/jackc/pgproto3 v2.3.3
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/lib/pq v1.10.2


### PR DESCRIPTION
pgproto v1.1.0 has a security issue https://github.com/advisories/GHSA-7jwh-3vrq-q3m8 which is discovered among others by AWS Inspector and classified as a Critical vulnerability.
closes #728 