### PR TITLE
.github/workflows/cmake.yml: remove install ci

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,8 +30,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Install dependencies
-      run: sudo bash scripts/install_ci.sh
     - name: Format
       run: make fmt
     - name: Test


### PR DESCRIPTION
All other steps are running in docker, so there is no need in executing install_ci.sh