### PR TITLE
CI: try to fix coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache Coverity build tool
-      uses: actions/cache@v4
-      with:
-        path: |
-          coverity_tool.tar.gz
-        key: ${{ runner.os }}
-
     - name: Download Coverity build tool
       run: |
         wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=yandex%2Fodyssey" -O coverity_tool.tar.gz


### PR DESCRIPTION
coverity scan has been failing since 12 Jan 2025
no idea why "tar" cannot uncompress.

let's eliminate cache (it was setup in wrong way anyway)