### PR TITLE
sources/logger.c: set logger lvl type

### DIFF
--- a/sources/logger.c
+++ b/sources/logger.c
@@ -578,6 +578,7 @@ extern void od_logger_write_plain(od_logger_t *logger, od_logger_level_t level,
 		_od_log_entry *le = machine_msg_data(msg);
 		strncpy(le->msg, output, len);
 		le->msg[len] = '\0';
+		le->lvl = level;
 
 		machine_channel_write(logger->task_channel, msg);
 	} else {


### PR DESCRIPTION
Otherwise it will crash at logger.c:444 in
od_log_syslog_level[lvl] with random lvl value