### PR TITLE
relay.h: sleep when eagain in write

### DIFF
--- a/sources/relay.h
+++ b/sources/relay.h
@@ -406,8 +406,10 @@ static inline od_frontend_status_t od_relay_write(od_relay_t *relay)
 		/* retry or error */
 		int errno_ = machine_errno();
 		if (errno_ == EAGAIN || errno_ == EWOULDBLOCK ||
-		    errno_ == EINTR)
+		    errno_ == EINTR) {
+			machine_sleep(1);
 			return OD_OK;
+		}
 		return relay->error_write;
 	}
 


### PR DESCRIPTION
Otherwise there will be infinite cycle untill success write, which leads to other coroutines on thread stucks