### PR TITLE
docker/tls-compat: add tls listen compat tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,7 @@ COPY ./docker/xproto /xproto
 COPY ./docker/copy /copy
 COPY ./docker/gorm /gorm
 COPY ./docker/reload /reload
+COPY ./docker/tls-compat /tls-compat
 
 COPY ./third_party/machinarium/gdb/machinarium-gdb.py /gdb.py
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,12 @@ ody-stop
 
 setup
 
+/tls-compat/test-tls-compat.sh
+if [ $? -eq 1 ]
+then
+	exit 1
+fi
+
 /reload/test-reload.sh
 if [ $? -eq 1 ]
 then

--- a/docker/tls-compat/config.conf
+++ b/docker/tls-compat/config.conf
@@ -1,0 +1,64 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug yes
+log_session yes
+log_stats no
+log_query yes
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+
+	tls "require"
+	tls_key_file "/tls-compat/server.key"
+	tls_cert_file "/tls-compat/server.pem"
+	tls_ca_file "/tls-compat/root.pem"
+	tls_protocols "tlsv1.2"
+}
+
+storage "postgres_server" {
+	type "remote"
+	host "127.0.0.1"
+	port 5432
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		pool_routing "internal"
+		storage "postgres_server"
+		pool "session"
+	}
+}
+
+database "auth_query_db" {
+	user "auth_query_user_md5" {
+		authentication "md5"
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "postgres"
+		auth_query_db "postgres"
+		storage "postgres_server"
+		pool "session"
+	}
+
+	user "auth_query_user_scram_sha_256" {
+		authentication "scram-sha-256"
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "postgres"
+		auth_query_db "postgres"
+		storage "postgres_server"
+		pool "session"
+	}
+}

--- a/docker/tls-compat/test-tls-compat.sh
+++ b/docker/tls-compat/test-tls-compat.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -x
+
+set -ex
+
+pushd /tls-compat/
+
+openssl genrsa -out root.key 2048
+openssl req -new -key root.key -out root.csr -nodes -subj "/CN=odyssey-test-cn"
+openssl x509 -req -days 2 -in root.csr -signkey root.key -out root.pem
+
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr -nodes -subj "/CN=localhost"
+openssl x509 -req -in server.csr -CA root.pem -CAkey root.key -CAcreateserial -out server.pem -days 2
+
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr -nodes -subj "/CN=localhost"
+openssl x509 -req -in client.csr -CA root.pem -CAkey root.key -CAcreateserial -out client.pem -days 2
+
+popd
+
+echo "ssl packages:"
+dpkg -l | grep ssl
+
+/usr/bin/odyssey /tls-compat/config.conf
+sleep 1
+
+psql "host=localhost port=6432 user=auth_query_user_scram_sha_256 dbname=auth_query_db password=passwd sslmode=verify-full sslrootcert=/tls-compat/root.pem" -c "SELECT 1" || {
+    echo "scram + tls failed"
+    exit 1
+}
+
+psql "host=localhost port=6432 user=auth_query_user_md5 dbname=auth_query_db password=passwd sslmode=verify-full sslrootcert=/tls-compat/root.pem" -c "SELECT 1" || {
+    echo "md5 + tls failed"
+    exit 1
+}
+
+ody-stop


### PR DESCRIPTION
Seems like there are some problem with openssl > 3.0.0 used in odyssey. This patch adds some first base for test to debug it (or prove that there is no bug)