### PR TITLE
sources/machine.c: up stack size by three times

### DIFF
--- a/third_party/machinarium/sources/machine.c
+++ b/third_party/machinarium/sources/machine.c
@@ -119,8 +119,8 @@ MACHINE_API int64_t machine_create(char *name, machine_coroutine_t function,
 		return -1;
 	}
 	mm_machinemgr_add(&machinarium.machine_mgr, machine);
-	rc = mm_thread_create(&machine->thread, PTHREAD_STACK_MIN, machine_main,
-			      machine);
+	rc = mm_thread_create(&machine->thread, 3 * PTHREAD_STACK_MIN,
+			      machine_main, machine);
 	if (rc == -1) {
 		mm_machinemgr_delete(&machinarium.machine_mgr, machine);
 		mm_eventmgr_free(&machine->event_mgr, &machine->loop);


### PR DESCRIPTION
There is a problem when odyssey is compiled with openssl >= 3.0.0

The problem is SIGSEGV inside openssl functions because of
stackoverflow. This happens because odyssey allocates thread with
minimum possible stack size, which works with openssl 1.1.1, but leads
to SIGSEGV on openssl >= 3

This patch increases machine's stack size by three times to solve the
issue.

Signed-off-by: rkhapov <r.khapov@ya.ru>
