### PR TITLE
allow newer libmicrohttpd versions and do not fail if ipv6 stack is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,6 @@ format:
 	docker build -f docker/format/Dockerfile --tag=odyssey/clang-format-runner .
 	docker run --user=`stat -c "%u:%g" .` -v .:/odyssey:rw odyssey/clang-format-runner -i modules sources stress test third_party
 
-apply_fmt:
-	for d in sources test third_party stress modules ; do \
-		find $$d -maxdepth 5 -iname '*.h' -o -iname '*.c'  | xargs -n 1 -t -P $(CONCURRENCY) $(FMT_BIN) -i ; \
-	done
-
 build_asan:
 	rm -rf $(BUILD_TEST_ASAN_DIR)
 	mkdir -p $(BUILD_TEST_ASAN_DIR)

--- a/sources/parser.h
+++ b/sources/parser.h
@@ -40,7 +40,10 @@ struct od_keyword {
 	int name_len;
 };
 
-#define od_keyword(name, token) { token, name, sizeof(name) - 1 }
+#define od_keyword(name, token)               \
+	{                                     \
+		token, name, sizeof(name) - 1 \
+	}
 
 struct od_parser {
 	char *pos;

--- a/sources/parser.h
+++ b/sources/parser.h
@@ -40,10 +40,7 @@ struct od_keyword {
 	int name_len;
 };
 
-#define od_keyword(name, token)               \
-	{                                     \
-		token, name, sizeof(name) - 1 \
-	}
+#define od_keyword(name, token) { token, name, sizeof(name) - 1 }
 
 struct od_parser {
 	char *pos;

--- a/sources/prom_metrics.c
+++ b/sources/prom_metrics.c
@@ -12,12 +12,12 @@
 #include <promhttp.h>
 
 #if MHD_VERSION >= 0x00097002
-enum MHD_Result od_prom_AcceptPolicyCallback(void *cls, 
-	const struct sockaddr *addr,
-	socklen_t addrlen)
+enum MHD_Result od_prom_AcceptPolicyCallback(void *cls,
+					     const struct sockaddr *addr,
+					     socklen_t addrlen)
 #else
 int od_prom_AcceptPolicyCallback(void *cls, const struct sockaddr *addr,
-	socklen_t addrlen)
+				 socklen_t addrlen)
 #endif
 {
 	return MHD_YES;
@@ -30,12 +30,12 @@ static bool system_supports_ipv6()
 		return false; // cannot create IPv6 socket
 	}
 
-	struct sockaddr_in6 addr = {0};
+	struct sockaddr_in6 addr = { 0 };
 	addr.sin6_family = AF_INET6;
 	addr.sin6_addr = in6addr_loopback;
 	addr.sin6_port = htons(0); // Let OS choose port
 
-	int result = bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+	int result = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
 	close(sock);
 	return result == 0;
 }
@@ -49,8 +49,7 @@ int od_prom_switch_server_on(od_prom_metrics_t *self)
 	}
 
 	self->http_server = promhttp_start_daemon(
-		flags, self->port,
-		od_prom_AcceptPolicyCallback, NULL);
+		flags, self->port, od_prom_AcceptPolicyCallback, NULL);
 
 	return self->http_server ? OK_RESPONSE : NOT_OK_RESPONSE;
 }

--- a/sources/prom_metrics.c
+++ b/sources/prom_metrics.c
@@ -11,19 +11,47 @@
 #ifdef PROMHTTP_FOUND
 #include <promhttp.h>
 
+#if MHD_VERSION >= 0x00097002
+enum MHD_Result od_prom_AcceptPolicyCallback(void *cls, 
+	const struct sockaddr *addr,
+	socklen_t addrlen)
+#else
 int od_prom_AcceptPolicyCallback(void *cls, const struct sockaddr *addr,
-				 socklen_t addrlen)
+	socklen_t addrlen)
+#endif
 {
 	return MHD_YES;
 }
 
+static bool system_supports_ipv6()
+{
+	int sock = socket(AF_INET6, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return false; // cannot create IPv6 socket
+	}
+
+	struct sockaddr_in6 addr = {0};
+	addr.sin6_family = AF_INET6;
+	addr.sin6_addr = in6addr_loopback;
+	addr.sin6_port = htons(0); // Let OS choose port
+
+	int result = bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+	close(sock);
+	return result == 0;
+}
+
 int od_prom_switch_server_on(od_prom_metrics_t *self)
 {
-	if (self->http_server)
-		return NOT_OK_RESPONSE;
+	int flags = MHD_USE_AUTO_INTERNAL_THREAD;
+
+	if (system_supports_ipv6()) {
+		flags |= MHD_USE_DUAL_STACK;
+	}
+
 	self->http_server = promhttp_start_daemon(
-		MHD_USE_DUAL_STACK | MHD_USE_AUTO_INTERNAL_THREAD, self->port,
+		flags, self->port,
 		od_prom_AcceptPolicyCallback, NULL);
+
 	return self->http_server ? OK_RESPONSE : NOT_OK_RESPONSE;
 }
 


### PR DESCRIPTION
two fixes in one go. 
First of all, we are running a new libmicrohttpd lib and it switched to enum. hence the change. (similar to https://github.com/digitalocean/prometheus-client-c/pull/65, which is unfortunately not accepted for ages 😢 )
Also, I see Odyssey erroring and exiting if I try to enable Prometheus on a machine without an Ipv6 stack. Hence the second change. Thx for review in advance!