### PR TITLE
sources/system.c: copy unix path by memcpy

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,8 @@ jobs:
         submodules: recursive
     - name: Format
       run: make check-format
+    - name: Fedora build check
+      run: make fedora-build-check
     - name: Release Build Test
       env:
         CC: ${{ matrix.compiler }}

--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,6 @@ install:
 start-dev-env:
 	docker compose build dev
 	docker compose up -d dev
+
+fedora-build-check:
+	docker build -f docker/fedora-build/Dockerfile --tag=odyssey/fedora-img .

--- a/docker/fedora-build/Dockerfile
+++ b/docker/fedora-build/Dockerfile
@@ -1,0 +1,13 @@
+FROM fedora:40
+
+RUN dnf install -y cmake gcc make git openssl-devel zlib-devel bison flex libicu-devel readline-devel perl
+
+RUN git clone --depth 1 -b REL_17_STABLE https://github.com/postgres/postgres.git
+RUN cd postgres && ./configure --prefix=/usr/lib/postgresql/17 && make -j $(nproc) && make install
+
+ENV PATH="$PATH:/usr/lib/postgresql/17/bin"
+
+COPY . /workdir
+WORKDIR /workdir
+
+RUN make build_release

--- a/sources/system.c
+++ b/sources/system.c
@@ -206,11 +206,10 @@ static inline od_retcode_t od_system_server_start(od_system_t *system,
 		memset(&saddr_un, 0, sizeof(saddr_un));
 		saddr_un.sun_family = AF_UNIX;
 		saddr = (struct sockaddr *)&saddr_un;
-		addr_name_len = od_snprintf(addr_name, sizeof(addr_name),
-					    "%s/.s.PGSQL.%d",
-					    instance->config.unix_socket_dir,
-					    config->port);
-		strncpy(saddr_un.sun_path, addr_name, addr_name_len);
+		addr_name_len = od_snprintf(
+			addr_name, sizeof(saddr_un.sun_path), "%s/.s.PGSQL.%d",
+			instance->config.unix_socket_dir, config->port);
+		memcpy(saddr_un.sun_path, addr_name, addr_name_len);
 	}
 
 	/* bind */


### PR DESCRIPTION
To avoid strncpy compiler warning like
'strncpy' output may be truncated copying between 0 and 4095 bytes from a string of length 4095

https://github.com/yandex/odyssey/issues/795