### PR TITLE
sources/frontend.c: fix od_eject_conn_with_rate

### DIFF
--- a/sources/ejection.h
+++ b/sources/ejection.h
@@ -10,7 +10,7 @@
 /* only for online restart */
 typedef struct {
 	pthread_mutex_t mu;
-	int last_conn_drop_ts;
+	uint32_t last_conn_drop_ts;
 } od_conn_eject_info;
 
 extern od_retcode_t od_conn_eject_info_init(od_conn_eject_info **dst);


### PR DESCRIPTION
1) Get time by machine time functions to reduce overhead of syscalls 2) Remove log about too early ejection - it produces too many garbage
   messages in logs