### PR TITLE
Implementing new option - pool_ignore_discardall

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Set up your CLion to build project in container, [manual](https://github.com/shu
 * [pool\_timeout](documentation/configuration.md#pool_timeout-integer)
 * [pool\_ttl](documentation/configuration.md#pool_ttl-integer)
 * [pool\_discard](documentation/configuration.md#pool_discard-yesno)
+* [pool\_ignore\_discardall](documentation/configuration.md#pool_ignore_discardall-yesno)
 * [pool\_cancel](documentation/configuration.md#pool_cancel-yesno)
 * [pool\_rollback](documentation/configuration.md#pool_rollback-yesno)
 * [client\_fwd\_error](documentation/configuration.md#client_fwd_error-yesno)

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -726,6 +726,24 @@ from the pool.
 
 `pool_discard no`
 
+#### pool\_ignore\_discardall *yes|no*
+
+Server-pool parameter: ignore client DISCARD.
+
+Skips client-side `DISCARD ALL` statements instead of forwarding them to the
+backend (preventing the command from reaching PostgreSQL).
+
+Odyssey intercepts every simple query whose text is exactly `DISCARD ALL`
+(case-insensitive, with optional whitespace or a trailing semicolon) and
+immediately returns `CommandComplete: DISCARD` + `ReadyForQuery` to the client.
+The query never reaches PostgreSQL, so no session reset or plan-cache flush
+occurs on the server side.
+
+This is useful when the client driver in use offers no option to disable its
+automatic `DISCARD ALL` calls.
+
+`pool_ignore_discardall no`
+
 #### pool\_smart\_discard *yes|no*
 
 When this parameter is enabled, Odyssey sends smart discard query instead of default `DISCARD ALL` when it

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -631,6 +631,14 @@ database default {
 #		from the pool.
 #
 		pool_discard no
+		
+#
+#		Server pool parameters ignore client discard.
+#
+#		Skips client-side DISCARD ALL statements instead of forwarding them to the backend 
+#		(preventing it from reaching PostgreSQL).
+#
+		pool_ignore_discardall no
 
 #
 #		Server pool auto-cancel.

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -99,6 +99,7 @@ typedef enum {
 	OD_LPOOL_TIMEOUT,
 	OD_LPOOL_TTL,
 	OD_LPOOL_DISCARD,
+	OD_LPOOL_IGNORE_DISCARDALL,
 	OD_LPOOL_SMART_DISCARD,
 	OD_LPOOL_DISCARD_QUERY,
 	OD_LPOOL_CANCEL,
@@ -266,6 +267,7 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("pool_timeout", OD_LPOOL_TIMEOUT),
 	od_keyword("pool_ttl", OD_LPOOL_TTL),
 	od_keyword("pool_discard", OD_LPOOL_DISCARD),
+	od_keyword("pool_ignore_discardall", OD_LPOOL_IGNORE_DISCARDALL),
 	od_keyword("pool_discard_query", OD_LPOOL_DISCARD_QUERY),
 	od_keyword("pool_smart_discard", OD_LPOOL_SMART_DISCARD),
 	od_keyword("pool_cancel", OD_LPOOL_CANCEL),
@@ -1536,6 +1538,12 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 		case OD_LPOOL_DISCARD:
 			if (!od_config_reader_yes_no(reader,
 						     &rule->pool->discard))
+				return NOT_OK_RESPONSE;
+			continue;
+		/* pool_ignore_discardall */
+		case OD_LPOOL_IGNORE_DISCARDALL:
+			if (!od_config_reader_yes_no(reader,
+						     &rule->pool->ignore_discardall))
 				return NOT_OK_RESPONSE;
 			continue;
 		/* pool_smart_discard */

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1108,6 +1108,107 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 		if (instance->config.log_query || route->rule->log_query)
 			od_frontend_log_query(instance, client, data, size);
 
+		/* Ignore “DISCARD ALL” completely, but make sure
+		   we preserve packet order by using a sync-point instead of
+		   writing to the client immediately */
+		if (route->rule->pool->ignore_discardall)
+		{
+			/* 1. Very fast size guard */
+			/* FE Query header: 1 (type) + 4 (length) = 5 bytes */
+			const uint32_t MAX_RELEVANT = 5 + 15;          /* 20 bytes total */
+            
+			if ((uint32_t)size <= MAX_RELEVANT)            /* longer packets → skip */
+			{
+				od_debug(&instance->logger, "ignore_discardall",
+						 client, server,
+						 "query size <= 20 bytes");
+                
+				char *q; 
+				uint32_t qlen;
+                
+				if (kiwi_be_read_query(data, size, &q, &qlen) == 0 && qlen > 10) /* min 11 chars */
+				{
+					od_debug(&instance->logger, "ignore_discardall",
+							 client, server,
+							 "query = \"%.*s\" (len=%u)", qlen, q, qlen);
+		
+					/* 2. Trim leading whitespace */
+					while (qlen && isspace((unsigned char)*q)) {
+						++q;
+						--qlen;
+					}
+		
+					/* 3. Trim trailing whitespace, semicolon, and null terminator in one loop */
+					while (qlen) {
+						unsigned char ch = (unsigned char)q[qlen - 1];
+						if (ch == '\0' || isspace(ch)) {
+							--qlen;
+						}
+						else if (ch == ';') {
+							--qlen;
+							/* remove any whitespace that comes before the semicolon */
+							while (qlen && isspace((unsigned char)q[qlen - 1])) {
+								--qlen;
+							}
+							break;
+						}
+						else {
+							break;
+						}
+					}
+		
+					od_debug(&instance->logger, "ignore_discardall",
+							 client, server,
+							 "query after trim = \"%.*s\" (len=%u)", qlen, q, qlen);
+		
+					/* 4. Compare with “DISCARD ALL” (11 chars) */
+					if (qlen == 11)     /* any other length → skip */
+					{
+						od_debug(&instance->logger, "ignore_discardall",
+								 client, server,
+								 "query length is 11");
+                        
+						static const char pat[11] = "DISCARD ALL";
+						bool match = true;
+                        
+						for (int i = 0; i < 11; ++i)
+							if ( (q[i] | 32) != (pat[i] | 32) ) { match = false; break; }
+                        
+						if (match)
+						{
+							od_debug(&instance->logger, "ignore_discardall",
+									 client, server,
+									 "intercepted – skipped");
+									
+							/* 5. Create CommandComplete + ReadyForQuery */
+							machine_msg_t *stream = machine_msg_create(0);
+							if (!stream) return OD_EOOM;
+
+							if (kiwi_be_write_complete(stream, "DISCARD", 8) == -1) {
+								machine_msg_free(stream);
+								return OD_EOOM;
+							}
+							
+							if (kiwi_be_write_ready(stream, 'I') == NULL) {
+								machine_msg_free(stream);
+								return OD_EOOM;
+							}
+
+							/* Hold the packet until all previous packets
+							   reach the client; the main loop will send it
+							   right after the sync-point */
+							server->sync_point_deploy_msg = stream;
+
+							/* Ask the main loop to establish a sync-point. */
+							return OD_REQ_SYNC;
+						}
+					}
+				}
+			}
+		}
+		
+		/* reached here -> packet was NOT “intercepted”
+           so it will be sent to PostgreSQL — we may need to invalidate */
 		int invalidate = 0;
 
 		if (size >= 7) {
@@ -1122,10 +1223,11 @@ static od_frontend_status_t od_frontend_remote_client(od_relay_t *relay,
 		if (invalidate) {
 			od_hashmap_empty(server->prep_stmts);
 		}
-
+		
 		/* update server sync state */
 		od_server_sync_request(server, 1);
 		break;
+
 	case KIWI_FE_FUNCTION_CALL:
 	case KIWI_FE_SYNC:
 		/* update server sync state */
@@ -1737,17 +1839,20 @@ static od_frontend_status_t od_frontend_remote(od_client_t *client)
 			}
 
 			// deploy here
-
-			assert(server->parse_msg != NULL);
-
-			/* fill internals structs in */
-			if (od_frontend_deploy_prepared_stmt_msg(
-				    server, &server->relay,
-				    "sync-point-deploy") != OD_OK) {
-				status = OD_ESERVER_WRITE;
-				break;
-			}
-
+			
+			/* Two possible reasons to be here:
+               1) prepared-statement reserve path -> parse_msg != NULL
+               2) our intercepted “DISCARD ALL”   -> parse_msg == NULL */
+            if (server->parse_msg) {
+                /* fill internals structs in */
+                if (od_frontend_deploy_prepared_stmt_msg(
+                            server, &server->relay,
+                            "sync-point-deploy") != OD_OK) {
+                    status = OD_ESERVER_WRITE;
+                    break;
+                }
+            }
+			
 			machine_msg_t *msg;
 			msg = kiwi_fe_write_sync(NULL);
 			if (msg == NULL) {

--- a/sources/pool.c
+++ b/sources/pool.c
@@ -19,6 +19,7 @@ od_rule_pool_t *od_rule_pool_alloc()
 	memset(pool, 0, sizeof(od_rule_pool_t));
 
 	pool->discard = 1;
+	pool->ignore_discardall = 0;
 	pool->smart_discard = 0;
 	pool->discard_query = NULL;
 	pool->cancel = 1;
@@ -66,6 +67,10 @@ int od_rule_pool_compare(od_rule_pool_t *a, od_rule_pool_t *b)
 
 	/* pool_discard */
 	if (a->discard != b->discard)
+		return 0;
+		
+	/* pool_ignore_discardall */
+	if (a->ignore_discardall != b->ignore_discardall)
 		return 0;
 
 	/* cancel */

--- a/sources/pool.h
+++ b/sources/pool.h
@@ -39,6 +39,7 @@ struct od_rule_pool {
 	int timeout;
 	int ttl;
 	int discard;
+	int ignore_discardall;
 	int smart_discard;
 	int cancel;
 	int rollback;

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -1837,6 +1837,9 @@ void od_rules_print(od_rules_t *rules, od_logger_t *logger)
 		       "  pool discard                      %s",
 		       rule->pool->discard ? "yes" : "no");
 		od_log(logger, "rules", NULL, NULL,
+		       "  pool ignore discard all           %s",
+		       rule->pool->ignore_discardall ? "yes" : "no");
+		od_log(logger, "rules", NULL, NULL,
 		       "  pool smart discard                %s",
 		       rule->pool->smart_discard ? "yes" : "no");
 		od_log(logger, "rules", NULL, NULL,


### PR DESCRIPTION
Skips client-side DISCARD ALL statements instead of forwarding them to the backend (preventing it from reaching PostgreSQL).

Closes #788