### PR TITLE
Simplify od_relay_step logics.  Conservative variant

### DIFF
--- a/sources/relay.h
+++ b/sources/relay.h
@@ -423,10 +423,14 @@ static inline od_frontend_status_t od_relay_step(od_relay_t *relay,
 	od_frontend_status_t retstatus;
 	retstatus = OD_OK;
 	int rc;
-	rc = await_read ?
-		     (machine_cond_wait(relay->src->on_read, UINT32_MAX) == 0) :
-		     machine_cond_try(relay->src->on_read);
-	if (rc || od_relay_data_pending(relay)) {
+	int should_try_read;
+	int pending;
+	should_try_read = await_read ? (machine_cond_wait(relay->src->on_read,
+							  UINT32_MAX) == 0) :
+				       machine_cond_try(relay->src->on_read);
+
+	pending = od_relay_data_pending(relay);
+	if (should_try_read || pending) {
 		if (relay->dst == NULL) {
 			/* signal to retry on read logic */
 			machine_cond_signal(relay->src->on_read);
@@ -445,11 +449,13 @@ static inline od_frontend_status_t od_relay_step(od_relay_t *relay,
 	} else if (rc != OD_OK)
 		return rc;
 
-	if (machine_iov_pending(relay->iov)) {
-		/* try to optimize write path and handle it right-away */
-		machine_cond_signal(relay->dst->on_write);
-	} else {
-		od_readahead_reuse(&relay->src->readahead);
+	if (should_try_read || pending) {
+		if (machine_iov_pending(relay->iov)) {
+			/* try to optimize write path and handle it right-away */
+			machine_cond_signal(relay->dst->on_write);
+		} else {
+			od_readahead_reuse(&relay->src->readahead);
+		}
 	}
 
 	if (relay->dst == NULL)

--- a/sources/relay.h
+++ b/sources/relay.h
@@ -427,15 +427,15 @@ static inline od_frontend_status_t od_relay_step(od_relay_t *relay,
 		     (machine_cond_wait(relay->src->on_read, UINT32_MAX) == 0) :
 		     machine_cond_try(relay->src->on_read);
 	if (rc || od_relay_data_pending(relay)) {
+		if (relay->dst == NULL) {
+			/* signal to retry on read logic */
+			machine_cond_signal(relay->src->on_read);
+			return OD_ATTACH;
+		}
+
 		rc = od_relay_read_pending_aware(relay);
 		if (rc != OD_OK)
 			return rc;
-	}
-
-	if (relay->dst == NULL) {
-		/* signal to retry on read logic */
-		machine_cond_signal(relay->src->on_read);
-		return OD_ATTACH;
 	}
 
 	rc = od_relay_pipeline(relay);


### PR DESCRIPTION
Do relay step processing unconditionally. This allow more flexible
relay usage by outer facilities.