### PR TITLE
Simplify od_relay_step logics. Modern variant

### DIFF
--- a/sources/relay.h
+++ b/sources/relay.h
@@ -433,15 +433,15 @@ static inline od_frontend_status_t od_relay_step(od_relay_t *relay,
 
 	pending = od_relay_data_pending(relay);
 	if (should_try_read || pending) {
-		if (relay->dst == NULL) {
-			/* signal to retry on read logic */
-			machine_cond_signal(relay->src->on_read);
-			return OD_ATTACH;
-		}
-
 		rc = od_relay_read_pending_aware(relay);
 		if (rc != OD_OK)
 			return rc;
+	}
+
+	/* XXX: todo - do check first byte of next package, and
+	* if KIWI_FE_QUERY, try to parse attach-time hint */
+	if (relay->dst == NULL) {
+		return OD_ATTACH;
 	}
 
 	rc = od_relay_pipeline(relay);


### PR DESCRIPTION
Do relay step processing unconditionally. This allow more flexible
relay usage by outer facilities.