### PR TITLE
Fix potential NULL pointer dereference in auth.c

### DIFF
--- a/sources/auth.c
+++ b/sources/auth.c
@@ -888,8 +888,8 @@ static inline int od_auth_backend_sasl(od_server_t *server, od_client_t *client)
 		 "requested SASL authentication");
 
 	if (!route->rule->storage_password && !route->rule->password &&
-	    (client == NULL || client->password.password == NULL) &&
-	    client->received_password.password == NULL) {
+	    (client == NULL || (client->password.password == NULL &&
+							client->received_password.password == NULL))) {
 		od_error(&instance->logger, "auth", NULL, server,
 			 "password required for route '%s.%s'",
 			 route->rule->db_name, route->rule->user_name);
@@ -958,7 +958,7 @@ static inline int od_auth_backend_sasl_continue(od_server_t *server,
 		return -1;
 	} else if (route->rule->password) {
 		password = route->rule->password;
-	} else if (client->received_password.password) {
+	} else if (client != NULL && client->received_password.password) {
 		password = client->received_password.password;
 	} else {
 		od_error(&instance->logger, "auth", NULL, server,


### PR DESCRIPTION
The issue I'm addressing is a potential NULL pointer dereference in the `auth.c` file when accessing `client->received_password.password` or `client->password.password` without sufficient prior validation. In some cases, if `client == NULL` or those fields are not set, this can lead to undefined behavior or crashes during authentication flow.

This change ensures that all accesses to these fields are guarded by checks on `client` and its subfields before they're used. The logic has been simplified and centralized to avoid redundant NULL checks and make the code safer.