### PR TITLE
MINOR: fix leak on error path found by Coverity

### DIFF
--- a/sources/instance.c
+++ b/sources/instance.c
@@ -328,5 +328,6 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv)
 
 error:
 	od_router_free(&router);
+	od_extension_free(&instance->logger, &extensions);
 	return NOT_OK_RESPONSE;
 }


### PR DESCRIPTION
329error:
330        od_router_free(&router);

CID 552610: (#1 of 1): Resource leak (RESOURCE_LEAK)
8. leaked_storage: Variable extensions going out of scope leaks the storage extensions.modules points to.
331        return NOT_OK_RESPONSE;