### PR TITLE
fix leak on error path found by Coverity

### DIFF
--- a/sources/console.c
+++ b/sources/console.c
@@ -1340,6 +1340,7 @@ static inline int od_console_show_is_paused(od_client_t *client,
 	}
 
 	if (kiwi_be_write_data_row(stream, &offset) == NULL) {
+		machine_msg_free(msg);
 		return NOT_OK_RESPONSE;
 	}
 


### PR DESCRIPTION
1342        if (kiwi_be_write_data_row(stream, &offset) == NULL) {

CID 552620: (#2 of 2): Resource leak (RESOURCE_LEAK)
5. leaked_storage: Variable msg going out of scope leaks the storage it points to.
1343                return NOT_OK_RESPONSE;
1344        }