### PR TITLE
rewrite wait list (notify_all, sleepy release)

### DIFF
--- a/test/machinarium/test_wait_list_notify_all.c
+++ b/test/machinarium/test_wait_list_notify_all.c
@@ -1,25 +1,50 @@
 #include <machinarium.h>
 #include <odyssey_test.h>
 
+#define NUM_THREADS 10
+
 typedef struct {
 	machine_wait_list_t *wait_list;
 	int num;
 } waiter_arg_t;
 
-static inline void test_waiter(void *arg)
+static inline void test_waiter_coroutine(void *arg)
 {
 	waiter_arg_t *warg = arg;
 
 	machine_wait_list_t *wait_list = warg->wait_list;
 
-	int rc = machine_wait_list_wait(wait_list, 1000);
+	int rc = machine_wait_list_wait(wait_list, 10000);
 	test(rc == 0);
 
 	/*
 	 * sleep here to parent coroutine's machine_join
 	 * catch this coro before destroying
 	 */
-	machine_sleep(warg->num * 100);
+	machine_sleep(warg->num * 50);
+}
+
+static inline void test_waiter_thread(void *arg)
+{
+	(void)arg;
+
+	waiter_arg_t *warg = arg;
+
+	waiter_arg_t arg1 = { .wait_list = warg->wait_list, .num = warg->num };
+	int waiter1 = machine_coroutine_create(test_waiter_coroutine, &arg1);
+	test(waiter1 != -1);
+
+	waiter_arg_t arg2 = { .wait_list = warg->wait_list,
+			      .num = warg->num + 1 };
+	int waiter2 = machine_coroutine_create(test_waiter_coroutine, &arg2);
+	test(waiter2 != -1);
+
+	int rc;
+	rc = machine_join(waiter1);
+	test(rc == 0);
+
+	rc = machine_join(waiter2);
+	test(rc == 0);
 }
 
 static inline void test_notify_all(void *arg)
@@ -28,31 +53,33 @@ static inline void test_notify_all(void *arg)
 
 	machine_wait_list_t *wl = machine_wait_list_create(NULL);
 
-	waiter_arg_t arg1 = { .wait_list = wl, .num = 1 };
-	int waiter1 = machine_coroutine_create(test_waiter, &arg1);
-	test(waiter1 != -1);
+	int waiters[NUM_THREADS];
 
-	waiter_arg_t arg2 = { .wait_list = wl, .num = 2 };
-	int waiter2 = machine_coroutine_create(test_waiter, &arg2);
-	test(waiter2 != -1);
+	for (int i = 0; i != NUM_THREADS; ++i) {
+		waiter_arg_t *arg = malloc(sizeof(waiter_arg_t));
+		arg->wait_list = wl;
+		arg->num = 1 + 2 * i;
+		char buf[256];
+		snprintf(buf, sizeof(buf), "%s%d", "test_waiter_thread_",
+			 i + 1);
+		int waiter = machine_create(buf, test_waiter_thread, arg);
+		test(waiter != -1);
 
-	waiter_arg_t arg3 = { .wait_list = wl, .num = 3 };
-	int waiter3 = machine_coroutine_create(test_waiter, &arg3);
-	test(waiter3 != -1);
+		waiters[i] = waiter;
+	}
 
-	machine_sleep(100);
+	machine_sleep(1000);
 
 	machine_wait_list_notify_all(wl);
 
 	int rc;
-	rc = machine_join(waiter1);
-	test(rc == 0);
+	for (int i = 0; i != NUM_THREADS; ++i) {
+		rc = machine_wait(waiters[i]);
+		test(rc == 0);
+	}
 
-	rc = machine_join(waiter2);
-	test(rc == 0);
-
-	rc = machine_join(waiter3);
-	test(rc == 0);
+	// check that notify_all doesn't break when the wait list is empty
+	machine_wait_list_notify_all(wl);
 
 	machine_wait_list_destroy(wl);
 }

--- a/third_party/machinarium/sources/wait_list.c
+++ b/third_party/machinarium/sources/wait_list.c
@@ -7,12 +7,16 @@
 #include <machinarium.h>
 #include <machinarium_private.h>
 
+
+
+// holding wait_list lock
 static inline void release_sleepy(mm_wait_list_t *wait_list,
 				  mm_sleepy_t *sleepy)
 {
-	if (atomic_exchange(&sleepy->released, 1) == 0) {
+	if (!sleepy->released) {
 		mm_list_unlink(&sleepy->link);
-		atomic_fetch_sub(&wait_list->sleepies_count, 1);
+		--wait_list->sleepies_count;
+		sleepy->released = 1;
 	}
 }
 
@@ -24,7 +28,7 @@ static inline void init_sleepy(mm_sleepy_t *sleepy)
 		sleepy->coro_id = MM_SLEEPY_NO_CORO_ID;
 	}
 
-	atomic_init(&sleepy->released, 0);
+	sleepy->released = 0;
 
 	mm_list_init(&sleepy->link);
 	mm_eventmgr_add(&mm_self->event_mgr, &sleepy->event);
@@ -33,18 +37,9 @@ static inline void init_sleepy(mm_sleepy_t *sleepy)
 static inline void release_sleepy_with_lock(mm_wait_list_t *wait_list,
 					    mm_sleepy_t *sleepy)
 {
-	// in case sleepy wasn't released from list due to timeout
-
-	if (atomic_load(&sleepy->released) == 0) {
-		mm_sleeplock_lock(&wait_list->lock);
-
-		// need to check once again, in case some notify has released
-		// this sleepy between first check and locking
-		// once-again checking will be performed inside release_sleepy
-		release_sleepy(wait_list, sleepy);
-
-		mm_sleeplock_unlock(&wait_list->lock);
-	}
+	mm_sleeplock_lock(&wait_list->lock);
+	release_sleepy(wait_list, sleepy);
+	mm_sleeplock_unlock(&wait_list->lock);
 }
 
 mm_wait_list_t *mm_wait_list_create(atomic_uint_fast64_t *word)
@@ -58,7 +53,6 @@ mm_wait_list_t *mm_wait_list_create(atomic_uint_fast64_t *word)
 	mm_sleeplock_init(&wait_list->lock);
 
 	mm_list_init(&wait_list->sleepies);
-	atomic_init(&wait_list->sleepies_count, 0ULL);
 	wait_list->word = word;
 
 	return wait_list;
@@ -105,7 +99,7 @@ int mm_wait_list_wait(mm_wait_list_t *wait_list, uint32_t timeout_ms)
 	mm_sleeplock_lock(&wait_list->lock);
 
 	mm_list_append(&wait_list->sleepies, &this.link);
-	atomic_fetch_add(&wait_list->sleepies_count, 1);
+	++wait_list->sleepies_count;
 
 	mm_sleeplock_unlock(&wait_list->lock);
 
@@ -130,7 +124,7 @@ int mm_wait_list_compare_wait(mm_wait_list_t *wait_list, uint64_t expected,
 	init_sleepy(&this);
 
 	mm_list_append(&wait_list->sleepies, &this.link);
-	atomic_fetch_add(&wait_list->sleepies_count, 1);
+	++wait_list->sleepies_count;
 
 	mm_sleeplock_unlock(&wait_list->lock);
 
@@ -144,7 +138,7 @@ void mm_wait_list_notify(mm_wait_list_t *wait_list)
 {
 	mm_sleeplock_lock(&wait_list->lock);
 
-	if (atomic_load(&wait_list->sleepies_count) == 0ULL) {
+	if (wait_list->sleepies_count == 0ULL) {
 		mm_sleeplock_unlock(&wait_list->lock);
 		return;
 	}

--- a/third_party/machinarium/sources/wait_list.h
+++ b/third_party/machinarium/sources/wait_list.h
@@ -15,13 +15,13 @@ typedef struct mm_sleepy {
 	// we can store coroutine id and we will, in case of some debugging
 	uint64_t coro_id;
 
-	atomic_int released;
+	int released;
 } mm_sleepy_t;
 
 typedef struct mm_wait_list {
 	mm_sleeplock_t lock;
 	mm_list_t sleepies;
-	atomic_uint_fast64_t sleepies_count;
+	uint64_t sleepies_count;
 
 	/*
 	This field is analogous to a futex word.


### PR DESCRIPTION
1. The current implementation of mm_wait_list is non-linearizable because the mm_wait_list_notify_all function is not atomic with respect to other wait_list operations. This makes a wait list an extremely hard structure to reason about. It also makes the guarantees that a wait_list provides very unclear. This proposal changes the notify_all implementation, thus solving the problem.
2. The sleepy release optimization in mm_wait_list is hard to read. In a private discussion with @rkhapov, it was decided to remove it.
3. The sleepies_count field can be made non-atomic as it is used only when holding a wait_list's lock.