### PR TITLE
rewrite wait_group (use compare_wait, change done behaviour)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,7 +54,8 @@ set(od_test_src
     machinarium/test_wait_list_one_producer_multiple_consumers.c
     machinarium/test_wait_list_one_producer_multiple_consumers_threads.c
     machinarium/test_wait_list_notify_all.c
-    machinarium/test_wait_group.c
+    machinarium/test_wait_group_simple.c
+    machinarium/test_wait_group_timeout.c
     machinarium/test_getaddrinfo0.c
     machinarium/test_getaddrinfo1.c
     machinarium/test_getaddrinfo2.c

--- a/test/machinarium/test_wait_group_timeout.c
+++ b/test/machinarium/test_wait_group_timeout.c
@@ -1,0 +1,45 @@
+#include <machinarium.h>
+#include <odyssey_test.h>
+
+static inline void test_example_coroutine(void *arg)
+{
+	(void)arg;
+
+	// do something and forget to call done()
+	machine_sleep(0);
+	// machine_wait_group_t *wl = arg;
+	// machine_wait_group_done(wl);
+}
+
+static inline void test_wait_group_timeout(void *arg)
+{
+	(void)arg;
+
+	machine_wait_group_t *group = machine_wait_group_create();
+
+	machine_wait_group_add(group);
+	int id;
+	id = machine_create("machinarium_test_wait_group_timeout",
+			    test_wait_group_timeout, NULL);
+	test(id != -1);
+
+	test(machine_wait_group_wait(group, 10) == 1);
+
+	machine_wait_group_destroy(group);
+}
+
+void machinarium_test_wait_group_timeout()
+{
+	machinarium_init();
+
+	int id;
+	id = machine_create("machinarium_test_wait_group_timeout",
+			    test_wait_group_timeout, NULL);
+	test(id != -1);
+
+	int rc;
+	rc = machine_wait(id);
+	test(rc != -1);
+
+	machinarium_free();
+}

--- a/test/odyssey_test.c
+++ b/test/odyssey_test.c
@@ -96,7 +96,9 @@ extern void machinarium_test_wait_list_one_producer_multiple_consumers(void);
 extern void
 machinarium_test_wait_list_one_producer_multiple_consumers_threads(void);
 extern void machinarium_test_wait_list_notify_all(void);
-extern void machinarium_test_wait_group(void);
+extern void machinarium_test_wait_group_simple(void);
+extern void machinarium_test_wait_group_timeout(void);
+
 /* TODO: uncomment me
 extern void machinarium_test_mutex_threads(void);
 extern void machinarium_test_mutex_coroutines(void);
@@ -198,7 +200,8 @@ int main(int argc, char *argv[])
 	odyssey_test(
 		machinarium_test_wait_list_one_producer_multiple_consumers_threads);
 	odyssey_test(machinarium_test_wait_list_notify_all);
-	odyssey_test(machinarium_test_wait_group);
+	odyssey_test(machinarium_test_wait_group_simple);
+	odyssey_test(machinarium_test_wait_group_timeout);
 	/* TODO: uncomment me
 	odyssey_test(machinarium_test_mutex_threads);
 	odyssey_test(machinarium_test_mutex_coroutines);

--- a/third_party/machinarium/sources/wait_group.c
+++ b/third_party/machinarium/sources/wait_group.c
@@ -9,28 +9,45 @@
 
 mm_wait_group_t *mm_wait_group_create()
 {
-	mm_wait_list_t *waiters = mm_wait_list_create(NULL);
-	if (waiters == NULL) {
-		return NULL;
-	}
-
 	mm_wait_group_t *group = malloc(sizeof(mm_wait_group_t));
 	if (group == NULL) {
-		mm_wait_list_destroy(waiters);
 		return NULL;
 	}
-	memset(group, 0, sizeof(mm_wait_group_t));
 
+	mm_wait_list_t *waiters = mm_wait_list_create(&group->counter);
+	if (waiters == NULL) {
+		free(group);
+		return NULL;
+	}
 	group->waiters = waiters;
+
 	atomic_init(&group->counter, 0ULL);
+	atomic_init(&group->link_count, 1);
 
 	return group;
 }
 
-void mm_wait_group_destroy(mm_wait_group_t *group)
+static inline void mm_wait_group_destroy_now(mm_wait_group_t *group)
 {
 	mm_wait_list_destroy(group->waiters);
 	free(group);
+}
+
+static inline void mm_wait_group_link(mm_wait_group_t *group)
+{
+	atomic_fetch_add(&group->link_count, 1);
+}
+
+static inline void mm_wait_group_unlink(mm_wait_group_t *group)
+{
+	if (atomic_fetch_sub(&group->link_count, 1) == 1) {
+		mm_wait_group_destroy_now(group);
+	}
+}
+
+void mm_wait_group_destroy(mm_wait_group_t *group)
+{
+	mm_wait_group_unlink(group);
 }
 
 void mm_wait_group_add(mm_wait_group_t *group)
@@ -45,29 +62,34 @@ uint64_t mm_wait_group_count(mm_wait_group_t *group)
 
 void mm_wait_group_done(mm_wait_group_t *group)
 {
-	uint64_t old_counter = atomic_load(&group->counter);
-	for (;;) {
-		if (old_counter == 0ULL) {
-			return;
-		}
+	mm_wait_group_link(group);
 
-		if (atomic_compare_exchange_weak(&group->counter, &old_counter,
-						 old_counter - 1)) {
-			if (old_counter == 1ULL) {
-				mm_wait_list_notify_all(group->waiters);
-			}
-			return;
-		}
+	uint64_t old_counter = atomic_fetch_sub(&group->counter, 1);
+	if (old_counter == 0ULL) {
+		// the counter should not become negative
+		abort();
 	}
+	if (old_counter == 1ULL) {
+		mm_wait_list_notify_all(group->waiters);
+	}
+
+	mm_wait_group_unlink(group);
 }
 
 int mm_wait_group_wait(mm_wait_group_t *group, uint32_t timeout_ms)
 {
-	if (atomic_load(&group->counter) == 0ULL) {
-		return 0;
-	}
+	uint64_t start_ms = machine_time_ms();
+	do {
+		uint64_t old_counter = atomic_load(&group->counter);
+		if (old_counter == 0) {
+			return 0;
+		}
 
-	return mm_wait_list_wait(group->waiters, timeout_ms);
+		mm_wait_list_compare_wait(group->waiters, old_counter,
+					  timeout_ms);
+	} while (machine_time_ms() - start_ms < timeout_ms);
+
+	return 1;
 }
 
 MACHINE_API machine_wait_group_t *machine_wait_group_create()

--- a/third_party/machinarium/sources/wait_group.c
+++ b/third_party/machinarium/sources/wait_group.c
@@ -66,7 +66,7 @@ void mm_wait_group_done(mm_wait_group_t *group)
 
 	uint64_t old_counter = atomic_fetch_sub(&group->counter, 1);
 	if (old_counter == 0ULL) {
-		// the counter should not become negative
+		/* the counter should not become negative */
 		abort();
 	}
 	if (old_counter == 1ULL) {

--- a/third_party/machinarium/sources/wait_group.c
+++ b/third_party/machinarium/sources/wait_group.c
@@ -85,8 +85,12 @@ int mm_wait_group_wait(mm_wait_group_t *group, uint32_t timeout_ms)
 			return 0;
 		}
 
-		mm_wait_list_compare_wait(group->waiters, old_counter,
-					  timeout_ms);
+		int rc;
+		rc = mm_wait_list_compare_wait(group->waiters, old_counter,
+					       timeout_ms);
+		if (rc == MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL) {
+			return 1;
+		}
 	} while (machine_time_ms() - start_ms < timeout_ms);
 
 	return 1;

--- a/third_party/machinarium/sources/wait_group.h
+++ b/third_party/machinarium/sources/wait_group.h
@@ -9,6 +9,7 @@
 typedef struct mm_wait_group {
 	atomic_uint_fast64_t counter;
 	mm_wait_list_t *waiters;
+	atomic_uint link_count;
 } mm_wait_group_t;
 
 mm_wait_group_t *mm_wait_group_create();

--- a/third_party/machinarium/sources/wait_list.c
+++ b/third_party/machinarium/sources/wait_list.c
@@ -7,14 +7,14 @@
 #include <machinarium.h>
 #include <machinarium_private.h>
 
-// holding wait_list lock
+/* holding wait_list lock */
 static inline void add_sleepy(mm_wait_list_t *wait_list, mm_sleepy_t *sleepy)
 {
 	mm_list_append(&wait_list->sleepies, &sleepy->link);
 	++wait_list->sleepy_count;
 }
 
-// holding wait_list lock
+/* holding wait_list lock */
 static inline void release_sleepy(mm_wait_list_t *wait_list,
 				  mm_sleepy_t *sleepy)
 {
@@ -87,7 +87,7 @@ static inline int wait_sleepy(mm_wait_list_t *wait_list, mm_sleepy_t *sleepy,
 
 	release_sleepy_with_lock(wait_list, sleepy);
 
-	// timeout or cancel
+	/* timeout or cancel */
 	if (sleepy->event.call.status != 0) {
 		return MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL;
 	}

--- a/third_party/machinarium/sources/wait_list.h
+++ b/third_party/machinarium/sources/wait_list.h
@@ -12,7 +12,7 @@ typedef struct mm_sleepy {
 	mm_event_t event;
 	mm_list_t link;
 
-	// we can store coroutine id and we will, in case of some debugging
+	/* we can store coroutine id and we will, in case of some debugging */
 	uint64_t coro_id;
 
 	int released;


### PR DESCRIPTION
1. Use the wait_list's compare-and-wait functionality in the wait_group implementation. That fixes the potential presence of lost wake-ups.
2. Abort if mm_wait_group_done was called when a wait_group had a zero counter.
3. Add timeout test.