### PR TITLE
use return codes from errno.h in wait_list and wait_group

### DIFF
--- a/sources/global.h
+++ b/sources/global.h
@@ -69,6 +69,8 @@ static inline int od_global_wait_resumed(od_global_t *global, uint32_t timeout)
 	}
 
 	int rc = machine_wait_list_wait(global->resume_waiters, timeout);
-
-	return rc;
+	if (rc == 0) {
+		return 0;
+	}
+	return 1;
 }

--- a/test/machinarium/test_wait_group_timeout.c
+++ b/test/machinarium/test_wait_group_timeout.c
@@ -23,7 +23,7 @@ static inline void test_wait_group_timeout(void *arg)
 			    test_wait_group_timeout, NULL);
 	test(id != -1);
 
-	test(machine_wait_group_wait(group, 10) == 1);
+	test(machine_wait_group_wait(group, 10) == ETIMEDOUT);
 
 	machine_wait_group_destroy(group);
 }

--- a/test/machinarium/test_wait_list_compare_wait_timeout.c
+++ b/test/machinarium/test_wait_list_compare_wait_timeout.c
@@ -18,7 +18,7 @@ static inline void consumer(void *arg)
 	start = machine_time_ms();
 	rc = machine_wait_list_compare_wait(wl, 0, 100);
 	end = machine_time_ms();
-	test(rc == MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL);
+	test(rc == ETIMEDOUT);
 	total_time = end - start;
 	test(total_time >= 100);
 }

--- a/test/machinarium/test_wait_list_compare_wait_wrong_value.c
+++ b/test/machinarium/test_wait_list_compare_wait_wrong_value.c
@@ -20,7 +20,7 @@ static inline void consumer(void *arg)
 	start = machine_time_ms();
 	rc = machine_wait_list_compare_wait(wl, 0, 1000);
 	end = machine_time_ms();
-	test(rc == MACHINE_WAIT_LIST_ERR_AGAIN);
+	test(rc == EAGAIN);
 	total_time = end - start;
 	test(total_time < 5);
 }

--- a/test/machinarium/test_wait_list_without_notify.c
+++ b/test/machinarium/test_wait_list_without_notify.c
@@ -13,13 +13,13 @@ static inline void test_wait_without_notify_coroutine(void *arg)
 	int rc;
 	rc = machine_wait_list_wait(wait_list, 1000);
 	end = machine_time_ms();
-	test(rc == 1);
+	test(rc == ETIMEDOUT);
 	test(end - start >= 1000);
 
 	// notify without waiters should be ignored
 	machine_wait_list_notify(wait_list);
 	rc = machine_wait_list_wait(wait_list, 1000);
-	test(rc == 1);
+	test(rc == ETIMEDOUT);
 
 	machine_wait_list_destroy(wait_list);
 }

--- a/third_party/machinarium/sources/machinarium.h
+++ b/third_party/machinarium/sources/machinarium.h
@@ -334,12 +334,6 @@ Local progress is guaranteed (no coroutine starvation) but a FIFO ordering is no
 Spurious wake-ups are possible.  
 */
 
-enum {
-	MACHINE_WAIT_LIST_SUCCESS = 0,
-	MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL = 1,
-	MACHINE_WAIT_LIST_ERR_AGAIN = 2
-};
-
 /* 
 The `word` argument in create(...) is analogous to a futex word.
 Pass NULL if compare_wait functionality isn't needed.

--- a/third_party/machinarium/sources/wait_group.c
+++ b/third_party/machinarium/sources/wait_group.c
@@ -88,12 +88,12 @@ int mm_wait_group_wait(mm_wait_group_t *group, uint32_t timeout_ms)
 		int rc;
 		rc = mm_wait_list_compare_wait(group->waiters, old_counter,
 					       timeout_ms);
-		if (rc == MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL) {
-			return 1;
+		if (rc != EAGAIN && rc != 0) {
+			return rc;
 		}
 	} while (machine_time_ms() - start_ms < timeout_ms);
 
-	return 1;
+	return ETIMEDOUT;
 }
 
 MACHINE_API machine_wait_group_t *machine_wait_group_create()

--- a/third_party/machinarium/sources/wait_list.c
+++ b/third_party/machinarium/sources/wait_list.c
@@ -87,12 +87,7 @@ static inline int wait_sleepy(mm_wait_list_t *wait_list, mm_sleepy_t *sleepy,
 
 	release_sleepy_with_lock(wait_list, sleepy);
 
-	/* timeout or cancel */
-	if (sleepy->event.call.status != 0) {
-		return MACHINE_WAIT_LIST_ERR_TIMEOUT_OR_CANCEL;
-	}
-
-	return MACHINE_WAIT_LIST_SUCCESS;
+	return sleepy->event.call.status;
 }
 
 int mm_wait_list_wait(mm_wait_list_t *wait_list, uint32_t timeout_ms)
@@ -118,7 +113,7 @@ int mm_wait_list_compare_wait(mm_wait_list_t *wait_list, uint64_t expected,
 	if (atomic_load(wait_list->word) != expected) {
 		mm_sleeplock_unlock(&wait_list->lock);
 
-		return MACHINE_WAIT_LIST_ERR_AGAIN;
+		return EAGAIN;
 	}
 
 	mm_sleepy_t this;


### PR DESCRIPTION
The errno.h return codes are already used in the code as an event.call.status. It makes sense to use them in wait_list and wait_group also.