### PR TITLE
set machine errno in wait list and wait group

### DIFF
--- a/sources/route.h
+++ b/sources/route.h
@@ -205,10 +205,7 @@ static inline int od_route_wait(od_route_t *route, uint32_t time_ms)
 {
 	int rc;
 	rc = machine_wait_list_wait(route->wait_bus, time_ms);
-	if (rc == 0) {
-		return 0;
-	}
-	return -1;
+	return rc;
 }
 
 static inline int od_route_signal(od_route_t *route)

--- a/test/machinarium/test_wait_group_timeout.c
+++ b/test/machinarium/test_wait_group_timeout.c
@@ -23,7 +23,9 @@ static inline void test_wait_group_timeout(void *arg)
 			    test_wait_group_timeout, NULL);
 	test(id != -1);
 
-	test(machine_wait_group_wait(group, 10) == ETIMEDOUT);
+	int rc = machine_wait_group_wait(group, 10);
+	test(rc == -1);
+	test(machine_errno() == ETIMEDOUT);
 
 	machine_wait_group_destroy(group);
 }

--- a/test/machinarium/test_wait_list_compare_wait_timeout.c
+++ b/test/machinarium/test_wait_list_compare_wait_timeout.c
@@ -19,7 +19,9 @@ static inline void consumer(void *arg)
 	rc = machine_wait_list_compare_wait(wl, 0, 100);
 	end = machine_time_ms();
 	test(rc == -1);
-	test(machine_errno() == ETIMEDOUT) total_time = end - start;
+	test(machine_errno() == ETIMEDOUT);
+
+	total_time = end - start;
 	test(total_time >= 100);
 }
 

--- a/test/machinarium/test_wait_list_compare_wait_timeout.c
+++ b/test/machinarium/test_wait_list_compare_wait_timeout.c
@@ -18,8 +18,8 @@ static inline void consumer(void *arg)
 	start = machine_time_ms();
 	rc = machine_wait_list_compare_wait(wl, 0, 100);
 	end = machine_time_ms();
-	test(rc == ETIMEDOUT);
-	total_time = end - start;
+	test(rc == -1);
+	test(machine_errno() == ETIMEDOUT) total_time = end - start;
 	test(total_time >= 100);
 }
 

--- a/test/machinarium/test_wait_list_compare_wait_wrong_value.c
+++ b/test/machinarium/test_wait_list_compare_wait_wrong_value.c
@@ -20,7 +20,8 @@ static inline void consumer(void *arg)
 	start = machine_time_ms();
 	rc = machine_wait_list_compare_wait(wl, 0, 1000);
 	end = machine_time_ms();
-	test(rc == EAGAIN);
+	test(rc == -1);
+	test(machine_errno() == EAGAIN);
 	total_time = end - start;
 	test(total_time < 5);
 }

--- a/test/machinarium/test_wait_list_without_notify.c
+++ b/test/machinarium/test_wait_list_without_notify.c
@@ -13,13 +13,15 @@ static inline void test_wait_without_notify_coroutine(void *arg)
 	int rc;
 	rc = machine_wait_list_wait(wait_list, 1000);
 	end = machine_time_ms();
-	test(rc == ETIMEDOUT);
+	test(rc == -1);
+	test(machine_errno() == ETIMEDOUT);
 	test(end - start >= 1000);
 
 	// notify without waiters should be ignored
 	machine_wait_list_notify(wait_list);
 	rc = machine_wait_list_wait(wait_list, 1000);
-	test(rc == ETIMEDOUT);
+	test(rc == -1);
+	test(machine_errno() == ETIMEDOUT);
 
 	machine_wait_list_destroy(wait_list);
 }

--- a/third_party/machinarium/sources/wait_group.c
+++ b/third_party/machinarium/sources/wait_group.c
@@ -85,15 +85,15 @@ int mm_wait_group_wait(mm_wait_group_t *group, uint32_t timeout_ms)
 			return 0;
 		}
 
-		int rc;
-		rc = mm_wait_list_compare_wait(group->waiters, old_counter,
-					       timeout_ms);
-		if (rc != EAGAIN && rc != 0) {
-			return rc;
+		int rc = mm_wait_list_compare_wait(group->waiters, old_counter,
+						   timeout_ms);
+		if (rc != 0 && machine_errno() != EAGAIN) {
+			return -1;
 		}
 	} while (machine_time_ms() - start_ms < timeout_ms);
 
-	return ETIMEDOUT;
+	mm_errno_set(ETIMEDOUT);
+	return -1;
 }
 
 MACHINE_API machine_wait_group_t *machine_wait_group_create()

--- a/third_party/machinarium/sources/wait_list.c
+++ b/third_party/machinarium/sources/wait_list.c
@@ -99,10 +99,12 @@ int mm_wait_list_wait(mm_wait_list_t *wait_list, uint32_t timeout_ms)
 	add_sleepy(wait_list, &this);
 	mm_sleeplock_unlock(&wait_list->lock);
 
-	int rc;
-	rc = wait_sleepy(wait_list, &this, timeout_ms);
-
-	return rc;
+	int status = wait_sleepy(wait_list, &this, timeout_ms);
+	mm_errno_set(status);
+	if (status != 0) {
+		return -1;
+	}
+	return 0;
 }
 
 int mm_wait_list_compare_wait(mm_wait_list_t *wait_list, uint64_t expected,
@@ -113,7 +115,8 @@ int mm_wait_list_compare_wait(mm_wait_list_t *wait_list, uint64_t expected,
 	if (atomic_load(wait_list->word) != expected) {
 		mm_sleeplock_unlock(&wait_list->lock);
 
-		return EAGAIN;
+		mm_errno_set(EAGAIN);
+		return -1;
 	}
 
 	mm_sleepy_t this;
@@ -123,10 +126,12 @@ int mm_wait_list_compare_wait(mm_wait_list_t *wait_list, uint64_t expected,
 
 	mm_sleeplock_unlock(&wait_list->lock);
 
-	int rc;
-	rc = wait_sleepy(wait_list, &this, timeout_ms);
-
-	return rc;
+	int status = wait_sleepy(wait_list, &this, timeout_ms);
+	mm_errno_set(status);
+	if (status != 0) {
+		return -1;
+	}
+	return 0;
 }
 
 void mm_wait_list_notify(mm_wait_list_t *wait_list)


### PR DESCRIPTION
Instead of returning an error code directly, we should return -1 and use mm_errno_set.