### PR TITLE
sources/global.h: add global setter and getter

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -12,6 +12,7 @@ set(od_src
     config_reader.c
     dns.c
     router.c
+    global.c
     system.c
     cron.c
     worker.c

--- a/sources/global.c
+++ b/sources/global.c
@@ -1,0 +1,19 @@
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+ */
+
+#include <odyssey.h>
+
+od_global_t *current_global od_read_mostly = NULL;
+
+void od_global_set(od_global_t *global)
+{
+	current_global = global;
+}
+
+od_global_t *od_global_get()
+{
+	return current_global;
+}

--- a/sources/global.h
+++ b/sources/global.h
@@ -41,6 +41,10 @@ static inline int od_global_init(od_global_t *global, od_instance_t *instance,
 	return 0;
 }
 
+void od_global_set(od_global_t *global);
+
+od_global_t *od_global_get();
+
 static inline void od_global_destroy(od_global_t *global)
 {
 	machine_wait_list_destroy(global->resume_waiters);

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -167,6 +167,7 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv)
 			   &worker_pool, &extensions, &hba) != 0) {
 		goto error;
 	}
+	od_global_set(&global);
 
 	/* read config file */
 	od_error_t error;

--- a/sources/macro.h
+++ b/sources/macro.h
@@ -9,6 +9,8 @@
 #define od_likely(EXPR) __builtin_expect(!!(EXPR), 1)
 #define od_unlikely(EXPR) __builtin_expect(!!(EXPR), 0)
 
+#define od_read_mostly __attribute__((__section__(".data.read_mostly")))
+
 #define od_container_of(N, T, F) ((T *)((char *)(N) - __builtin_offsetof(T, F)))
 
 #define OK_RESPONSE 0


### PR DESCRIPTION
To use global variable at any places, where it cannot be extracted in easy way