### PR TITLE
sources/router.c: fix server_lifetime handling

### DIFF
--- a/docker/functional/tests/server-lifetime/pool_ttl.conf
+++ b/docker/functional/tests/server-lifetime/pool_ttl.conf
@@ -1,0 +1,49 @@
+storage "postgres_server" {
+	host "[127.0.0.1]:5432"
+	type "remote"
+}
+
+storage "console" {
+	type "local"
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+		pool_ttl 5
+	}
+}
+
+database "console" {
+	user "console" {
+		authentication "none"
+		storage "console"
+		pool "session"
+	}
+}
+
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}

--- a/docker/functional/tests/server-lifetime/runner.sh
+++ b/docker/functional/tests/server-lifetime/runner.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -x
+
+set -ex
+
+check_servers_expiration() {
+	pgbench 'host=localhost port=6432 user=postgres dbname=postgres' -T 2 -j 1 -c 5 --no-vacuum --progress 1 --select-only
+
+	date -R
+	# do not forget remove empty lines by sed
+	psql 'host=localhost port=6432 user=console dbname=console' -c 'show servers'
+	servers_count=`psql 'host=localhost port=6432 user=console dbname=console' -t -c 'show servers' | sed '/^$/d' | wc -l`
+	if [ $servers_count != 5 ]; then
+		echo 'there must be 5 servers'
+		cat /var/log/odyssey.log
+		exit 1
+	fi
+
+	sleep 2
+
+	date -R
+	# lifetime or pool_ttl not expired
+	psql 'host=localhost port=6432 user=console dbname=console' -c 'show servers'
+	servers_count=`psql 'host=localhost port=6432 user=console dbname=console' -t -c 'show servers' | sed '/^$/d' | wc -l`
+	if [ $servers_count != 5 ]; then
+		echo 'there must be 5 servers'
+		cat /var/log/odyssey.log
+		exit 1
+	fi
+
+	# wait for lifetime or pool_ttl to expire
+	# get some higher value than total lifetime, because closing connections
+	# gets some time
+	sleep 6
+
+	date -R
+	psql 'host=localhost port=6432 user=console dbname=console' -c 'show servers'
+	servers_count=`psql 'host=localhost port=6432 user=console dbname=console' -t -c 'show servers' | sed '/^$/d' | wc -l`
+	if [ $servers_count != 0 ]; then
+		echo 'there must be 0 servers, because of its lifetime'
+		cat /var/log/odyssey.log
+		exit 1
+	fi
+}
+
+/usr/bin/odyssey /tests/server-lifetime/pool_ttl.conf
+sleep 1
+
+check_servers_expiration || exit 1
+
+ody-stop
+
+/usr/bin/odyssey /tests/server-lifetime/server_lifetime.conf
+sleep 1
+
+check_servers_expiration || exit 1
+
+ody-stop

--- a/docker/functional/tests/server-lifetime/server_lifetime.conf
+++ b/docker/functional/tests/server-lifetime/server_lifetime.conf
@@ -1,0 +1,49 @@
+storage "postgres_server" {
+	host "[127.0.0.1]:5432"
+	type "remote"
+}
+
+storage "console" {
+	type "local"
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+		server_lifetime 5
+	}
+}
+
+database "console" {
+	user "console" {
+		authentication "none"
+		storage "console"
+		pool "session"
+	}
+}
+
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -710,7 +710,9 @@ database default {
 
 #
 #		Server lifetime - maximum number of seconds for a server connection to live. Prevents cache bloat.
+#		Server connection is deallocated only in idle state.
 #		Defaults to 3600 (1 hour)
+#		Use 0 to disable
 #
 
 		server_lifetime 3600

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -197,6 +197,11 @@ static inline void od_cron_expire(od_cron_t *cron)
 	od_list_t expire_list;
 	od_list_init(&expire_list);
 
+	/*
+	 * TODO: close connections in some other thread?
+	 * Now closing several connections at once can take some long time (why?)
+	 * and lead to pool_ttl or server_lifetime violation on the order of a seconds
+	 */
 	int rc;
 	rc = od_router_expire(router, &expire_list);
 	if (rc > 0) {


### PR DESCRIPTION
It values wasn't used without pool_ttl non-zero value