### PR TITLE
sources/client.h: od_client_free_extended

### DIFF
--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -201,7 +201,7 @@ int od_auth_query(od_client_t *client, char *peer)
 	rc = od_attach_extended(instance, "auth_query", router, auth_client);
 	if (rc != OK_RESPONSE) {
 		od_router_unroute(router, auth_client);
-		od_client_free(auth_client);
+		od_client_free_extended(auth_client);
 		goto error;
 	}
 
@@ -222,7 +222,7 @@ int od_auth_query(od_client_t *client, char *peer)
 		       "auth query returned empty msg");
 		od_router_close(router, auth_client);
 		od_router_unroute(router, auth_client);
-		od_client_free(auth_client);
+		od_client_free_extended(auth_client);
 		goto error;
 	}
 	rc = od_auth_parse_passwd_from_datarow(&instance->logger, msg,
@@ -233,7 +233,7 @@ int od_auth_query(od_client_t *client, char *peer)
 			 "auth query returned datarow in incompatible format");
 		od_router_close(router, auth_client);
 		od_router_unroute(router, auth_client);
-		od_client_free(auth_client);
+		od_client_free_extended(auth_client);
 		goto error;
 	}
 
@@ -249,6 +249,9 @@ int od_auth_query(od_client_t *client, char *peer)
 	cache_value->passwd_len = password->password_len;
 	cache_value->passwd = malloc(password->password_len);
 	if (cache_value->passwd == NULL) {
+		od_router_close(router, auth_client);
+		od_router_unroute(router, auth_client);
+		od_client_free_extended(auth_client);
 		goto error;
 	}
 	strncpy(cache_value->passwd, password->password,
@@ -259,7 +262,7 @@ int od_auth_query(od_client_t *client, char *peer)
 	/* detach and unroute */
 	od_router_detach(router, auth_client);
 	od_router_unroute(router, auth_client);
-	od_client_free(auth_client);
+	od_client_free_extended(auth_client);
 	od_hashmap_unlock_key(storage->acache, keyhash, &key);
 	return OK_RESPONSE;
 

--- a/sources/client.h
+++ b/sources/client.h
@@ -148,6 +148,18 @@ static inline void od_client_free(od_client_t *client)
 	free(client);
 }
 
+/*
+ * for service clients (auth, watchdog, etc) usage
+ *
+ * adds od_io_close which is performed in od_frontend_close and
+ * must be performed for service clients too
+ */
+static inline void od_client_free_extended(od_client_t *client)
+{
+	od_io_close(&client->io);
+	od_client_free(client);
+}
+
 static inline void od_client_kill(od_client_t *client)
 {
 	od_atomic_u64_set(&client->killed, 1UL);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -383,7 +383,7 @@ void od_rules_group_checker_run(void *arg)
 			od_debug(&instance->logger, "group_checker",
 				 group_checker_client, NULL,
 				 "deallocating obsolete group_checker");
-			od_client_free(group_checker_client);
+			od_client_free_extended(group_checker_client);
 			od_group_free(group);
 			return;
 		}

--- a/sources/storage.c
+++ b/sources/storage.c
@@ -382,7 +382,7 @@ od_storage_watchdog_prepare_client(od_storage_watchdog_t *watchdog)
 			 "route storage watchdog failed: %s",
 			 od_router_status_to_str(status));
 
-		od_client_free(watchdog_client);
+		od_client_free_extended(watchdog_client);
 
 		return NULL;
 	}
@@ -399,7 +399,7 @@ od_storage_watchdog_close_client(od_storage_watchdog_t *watchdog,
 
 	od_router_close(router, watchdog_client);
 	od_router_unroute(router, watchdog_client);
-	od_client_free(watchdog_client);
+	od_client_free_extended(watchdog_client);
 }
 
 static inline od_client_t *
@@ -422,7 +422,7 @@ od_storage_create_and_connect_watchdog_client(od_storage_watchdog_t *watchdog)
 	rc = od_attach_extended(instance, "watchdog", router, watchdog_client);
 	if (rc != OK_RESPONSE) {
 		od_router_unroute(router, watchdog_client);
-		od_client_free(watchdog_client);
+		od_client_free_extended(watchdog_client);
 
 		return NULL;
 	}


### PR DESCRIPTION
For every cases where client is destroyed and od_io_close is not performed (service clients)

Otherwise, there will be leak of machine_io