### PR TITLE
fix cron stop

### DIFF
--- a/sources/cron.h
+++ b/sources/cron.h
@@ -15,10 +15,10 @@ struct od_cron {
 	od_prom_metrics_t *metrics;
 #endif
 
-	pthread_mutex_t lock;
-	int online;
+	machine_wait_flag_t *can_be_freed;
+	atomic_int online;
 };
 
-void od_cron_init(od_cron_t *);
+od_retcode_t od_cron_init(od_cron_t *);
 int od_cron_start(od_cron_t *, od_global_t *);
 od_retcode_t od_cron_stop(od_cron_t *cron);

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -153,7 +153,13 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv)
 
 	od_system_init(&system);
 	od_router_init(&router, &global);
-	od_cron_init(&cron);
+
+	if (od_cron_init(&cron) != 0) {
+		od_error(&instance->logger, "config", NULL, NULL,
+			 "failed to init cron");
+		goto error;
+	}
+
 	od_worker_pool_init(&worker_pool);
 
 	if (od_extensions_init(&extensions) != 0) {


### PR DESCRIPTION
1. There is a data race in cron (`cron->online`). It was detected by ThreadSanitizer (see #901). 
2. The current implementation uses a mutex in `od_cron` and `od_cron_stop`. This approach is inefficient (because the mutex is provided by `pthreads`) and unclear (the mutex is never unlocked).

This pull request addresses both of these issues. It makes `cron->online` an atomic variable and replaces the mutex with a `wait_flag`.