### PR TITLE
Update rules.md catchup_checks "see link"

### DIFF
--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -497,6 +497,7 @@ See [catchup-timeout.md](../features/catchup-timeout.md) for more details
 
 Maximum amount of cachtup checks before closing
 the connection if host replication lag is too big
+See [catchup-timeout.md](../features/catchup-timeout.md) for more details
 
 `catchup_checks 10`
 


### PR DESCRIPTION
catchup_checks and catchup_timeout must have same "see link" option in case someone uses Ctrl + F for specific catchup_checks parameter only