### PR TITLE
Fix segfault in large packets

### DIFF
--- a/third_party/kiwi/kiwi/io.h
+++ b/third_party/kiwi/kiwi/io.h
@@ -178,6 +178,9 @@ KIWI_API static inline int kiwi_validate_header(char *data, uint32_t data_size,
 	if (kiwi_unlikely(*size < sizeof(uint32_t)))
 		return -1;
 
+	if(*size > INT_MAX - (uint32_t)sizeof(kiwi_header_t))
+		return -1;
+
 	/* check supported protocol message type */
 	if (kiwi_unlikely(header->type < 0x20))
 		return -1;


### PR DESCRIPTION
The segfault occurs due to a signed integer overflow (it becomes negative).
The integer overflow happens when the size of a received PostgreSQL protocol packet exceeds 0x80000000 (2 GB).

In the PostgreSQL wire protocol, the packet size is specified as a 4-byte integer, which theoretically allows sending packets up to 4 GB in size.
However, in practice, the Postgres server allocates memory blocks of up to 1 GB:
```
#define MaxAllocSize    ((Size) 0x3fffffff)
```
When receiving a packet, the server checks its length value, and if it exceeds 1 GB (0x3fffffff), it stops processing the packet and returns an error:
```
invalid message length
```
Therefore, to fix the segfault, it was decided to add a handler that ensures the packet size does not exceed 0x80000000 (2 GB).
