### PR TITLE
fix stack use after return

### DIFF
--- a/docker/functional/bin/start-pg
+++ b/docker/functional/bin/start-pg
@@ -9,5 +9,7 @@ service postgresql stop || true
 
 sudo -u postgres /usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/main/ start
 
-sudo -u postgres /usr/bin/pg_basebackup -D /var/lib/postgresql/16/repl --checkpoint=fast -R -Fp -Xs -P -h localhost -p 5432
-sudo -u postgres /usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/repl/ -o '-p 5433' start
+if [ "$1" = "-r" ]; then
+    sudo -u postgres /usr/bin/pg_basebackup -D /var/lib/postgresql/16/repl --checkpoint=fast -R -Fp -Xs -P -h localhost -p 5432
+    sudo -u postgres /usr/lib/postgresql/16/bin/pg_ctl -D /var/lib/postgresql/16/repl/ -o '-p 5433' start
+fi

--- a/docker/functional/test_functional.py
+++ b/docker/functional/test_functional.py
@@ -24,7 +24,7 @@ def get_test_folders():
 
 @pytest.fixture(scope="session", autouse=True)
 def prepare_postgres():
-    result = subprocess.run([START_PG_PATH], timeout=2 * 60)
+    result = subprocess.run([START_PG_PATH, '-r'], timeout=2 * 60)
     if result.returncode != 0:
         pytest.exit(
             f"Failed to prepare environment, code {result.returncode}\n",

--- a/docker/functional/tests/hba/runner.sh
+++ b/docker/functional/tests/hba/runner.sh
@@ -7,6 +7,7 @@ set -ex
 #
 
 /usr/bin/odyssey /tests/hba/tcp.conf
+sleep 1
 
 PGPASSWORD=correct_password psql -h ip4-localhost -p 6432 -U user_allow -c "SELECT 1" hba_db > /dev/null 2>&1 || {
   echo "ERROR: failed auth with hba trust, correct password and plain password in config"
@@ -57,6 +58,7 @@ PGPASSWORD=correct_password psql -h ip4-localhost -p 6432 -U user_unknown -c "SE
 }  
 
 kill -s HUP $(pgrep odyssey)
+sleep 1
 PGPASSWORD=correct_password PGCONNECT_TIMEOUT=5 psql -h ip4-localhost -p 6432 -U user_allow -c "SELECT 1" hba_db > /dev/null 2>&1 || {
   echo "ERROR: unable to connect after SIGHUP"
 
@@ -75,6 +77,7 @@ ody-stop
 #
 
 /usr/bin/odyssey /tests/hba/unix.conf
+sleep 1
 
 PGPASSWORD=correct_password psql -h /tmp -p 6432 -U user_allow -c "SELECT 1" hba_db > /dev/null 2>&1 || {
     echo "ERROR: failed auth with hba trust, correct password and plain password in config"

--- a/sources/config.c
+++ b/sources/config.c
@@ -98,6 +98,9 @@ void od_config_free(od_config_t *config)
 		listen = od_container_of(i, od_config_listen_t, link);
 		od_config_listen_free(listen);
 	}
+	if (config->unix_socket_mode) {
+		od_free(config->unix_socket_mode);
+	}
 	if (config->log_file)
 		od_free(config->log_file);
 	if (config->log_format)

--- a/sources/extension.h
+++ b/sources/extension.h
@@ -18,15 +18,36 @@ static inline od_retcode_t od_extensions_init(od_extension_t *extensions)
 	return OK_RESPONSE;
 }
 
+static inline od_extension_t *od_extensions_create()
+{
+	od_extension_t *e = od_malloc(sizeof(od_extension_t));
+	if (e == NULL) {
+		return NULL;
+	}
+
+	if (od_extensions_init(e)) {
+		od_free(e);
+		return NULL;
+	}
+
+	return e;
+}
+
 static inline od_retcode_t od_extension_free(od_logger_t *l,
 					     od_extension_t *extensions)
 {
+	if (extensions == NULL) {
+		return OK_RESPONSE;
+	}
+
 	if (extensions->modules) {
 		od_modules_unload(l, extensions->modules);
 	}
 
 	od_free(extensions->modules);
 	extensions->modules = NULL;
+
+	od_free(extensions);
 
 	return OK_RESPONSE;
 }

--- a/sources/global.c
+++ b/sources/global.c
@@ -34,6 +34,27 @@ int od_global_init(od_global_t *global, od_instance_t *instance,
 	return 0;
 }
 
+od_global_t *od_global_create(od_instance_t *instance, od_system_t *system,
+			      od_router_t *router, od_cron_t *cron,
+			      od_worker_pool_t *worker_pool,
+			      od_extension_t *extensions, od_hba_t *hba)
+{
+	od_global_t *g = od_malloc(sizeof(od_global_t));
+	if (g == NULL) {
+		return NULL;
+	}
+
+	if (od_global_init(g, instance, system, router, cron, worker_pool,
+			   extensions, hba)) {
+		od_free(g);
+		return NULL;
+	}
+
+	od_global_set(g);
+
+	return g;
+}
+
 void od_global_set(od_global_t *global)
 {
 	current_global = global;

--- a/sources/global.h
+++ b/sources/global.h
@@ -23,6 +23,11 @@ struct od_global {
 	machine_wait_list_t *resume_waiters;
 };
 
+od_global_t *od_global_create(od_instance_t *instance, od_system_t *system,
+			      od_router_t *router, od_cron_t *cron,
+			      od_worker_pool_t *worker_pool,
+			      od_extension_t *extensions, od_hba_t *hba);
+
 int od_global_init(od_global_t *global, od_instance_t *instance,
 		   od_system_t *system, od_router_t *router, od_cron_t *cron,
 		   od_worker_pool_t *worker_pool, od_extension_t *extensions,
@@ -37,6 +42,8 @@ od_logger_t *od_global_get_logger();
 static inline void od_global_destroy(od_global_t *global)
 {
 	machine_wait_list_destroy(global->resume_waiters);
+	od_free(global);
+	od_global_set(NULL);
 }
 
 static inline uint64_t od_global_is_paused(od_global_t *global)

--- a/sources/grac_shutdown_worker.c
+++ b/sources/grac_shutdown_worker.c
@@ -157,6 +157,9 @@ void od_grac_shutdown_worker(void *arg)
 			 "failed to create a message in grac_shutdown_worker");
 	}
 
+	od_system_free(system);
+	od_global_destroy(global);
+
 	machine_msg_set_type(msg, OD_MSG_GRAC_SHUTDOWN_FINISHED);
 	machine_channel_write(channel, msg);
 }

--- a/sources/instance.h
+++ b/sources/instance.h
@@ -18,6 +18,6 @@ struct od_instance {
 	int64_t shutdown_worker_id;
 };
 
-void od_instance_init(od_instance_t *);
+od_instance_t *od_instance_create();
 void od_instance_free(od_instance_t *);
 int od_instance_main(od_instance_t *, int, char **);

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -537,6 +537,12 @@ void od_logger_shutdown(od_logger_t *logger)
 	machine_channel_write(logger->task_channel, msg);
 }
 
+void od_logger_wait_finish(od_logger_t *logger)
+{
+	machine_wait(logger->machine);
+	machine_channel_free(logger->task_channel);
+}
+
 void od_logger_write(od_logger_t *logger, od_logger_level_t level,
 		     char *context, void *client, void *server, char *fmt,
 		     va_list args)

--- a/sources/logger.h
+++ b/sources/logger.h
@@ -59,6 +59,8 @@ extern void od_logger_write(od_logger_t *, od_logger_level_t, char *, void *,
 extern void od_logger_write_plain(od_logger_t *, od_logger_level_t, char *,
 				  void *, void *, char *);
 
+void od_logger_wait_finish(od_logger_t *);
+
 static inline void od_log(od_logger_t *logger, char *context, void *client,
 			  void *server, char *fmt, ...)
 {

--- a/sources/main.c
+++ b/sources/main.c
@@ -10,16 +10,15 @@
 
 int main(int argc, char *argv[])
 {
-	od_instance_t odyssey;
-	od_instance_init(&odyssey);
-	odyssey.orig_argv_ptr = argv[0];
+	od_instance_t *odyssey = od_instance_create();
+	odyssey->orig_argv_ptr = argv[0];
 
-	int rc = od_instance_main(&odyssey, argc, argv);
+	int rc = od_instance_main(odyssey, argc, argv);
 	if (rc == -1) {
 		rc = EXIT_FAILURE;
 	} else {
 		rc = EXIT_SUCCESS;
 	}
-	od_instance_free(&odyssey);
+
 	return rc;
 }

--- a/sources/sighandler.c
+++ b/sources/sighandler.c
@@ -249,6 +249,9 @@ void od_system_signal_handler(void *arg)
 	machine_channel_free(channel);
 
 	od_logger_shutdown(&instance->logger);
+	od_logger_wait_finish(&instance->logger);
+
+	od_instance_free(instance);
 
 	exit(0);
 }

--- a/sources/system.c
+++ b/sources/system.c
@@ -599,3 +599,20 @@ int od_system_start(od_system_t *system, od_global_t *global)
 	}
 	return 0;
 }
+
+od_system_t *od_system_create()
+{
+	od_system_t *s = od_malloc(sizeof(od_system_t));
+	if (s == NULL) {
+		return NULL;
+	}
+
+	od_system_init(s);
+
+	return s;
+}
+
+void od_system_free(od_system_t *system)
+{
+	od_free(system);
+}

--- a/sources/system.h
+++ b/sources/system.h
@@ -29,6 +29,8 @@ struct od_system {
 	od_global_t *global;
 };
 
+od_system_t *od_system_create();
 void od_system_init(od_system_t *);
 int od_system_start(od_system_t *, od_global_t *);
 void od_system_config_reload(od_system_t *);
+void od_system_free(od_system_t *system);


### PR DESCRIPTION
Global objects are used in grace shutdown worker, but can be destroyed after instance_main function exit, that triggers asan