### PR TITLE
stress.sh: fix pg common options

### DIFF
--- a/docker/stress/stress.sh
+++ b/docker/stress/stress.sh
@@ -113,7 +113,7 @@ unstable_load() {
     local kill_after=$(( RANDOM % ($UNSTABLE_MAX-$UNSTABLE_MIN+1) + $UNSTABLE_MIN ))
     [ $kill_after -gt $left ] && kill_after=$left
     echo "[`date` $NAME] Starting unstable $i"
-    PGOPTIONS="$PGBENCH_OPTIONS" pgbench "$PG_CONNECTION_STRING" -c $UNSTABLE_CLIENTS -j $UNSTABLE_THREADS -T 100500 > "$LOG_DIR/unstable_$i.log" 2>&1 &
+    PGOPTIONS="$PGBENCH_OPTIONS" pgbench "$PG_CONNECTION_STRING" -c $UNSTABLE_CLIENTS -j $UNSTABLE_THREADS -T 100500 $PGBENCH_COMMON_OPTIONS > "$LOG_DIR/unstable_$i.log" 2>&1 &
     local pid=$!
     sleep $kill_after
     kill -9 $pid 2>/dev/null


### PR DESCRIPTION
with vacuum this test falls to
replica-1  | 2025-11-05 14:51:30.519 UTC [181] ERROR:  canceling statement due to conflict with recovery replica-1  | 2025-11-05 14:51:30.519 UTC [181] DETAIL:  User query might have needed to see row versions that must be removed. replica-1  | 2025-11-05 14:51:30.519 UTC [181] STATEMENT:  SELECT abalance FROM pgbench_accounts WHERE aid = 174706;