### PR TITLE
chore: Fix typos

### DIFF
--- a/docs/features/tsa.md
+++ b/docs/features/tsa.md
@@ -19,7 +19,7 @@ In every places, where you specify target session attrs, you can specify one of 
 ## You will need several hosts in your storage
 
 To allow Odyssey select host by TSA, you will need several hosts in your storage.
-This can be achived by config that looks like:
+This can be achieved by config that looks like:
 ```plaintext
 storage "postgres" {
     host "primary:5432,standby:5432"

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -48,7 +48,7 @@ VIRTUAL_DB_NAME="console"
 VIRTUAL_DB_USER_NAME="console"
 ```
 
-Antoher way is to use volume to start with your own config file. Simply replace PATH_TO_YOUR_CONFIG with the path to your configuration file and run this command:
+Another way is to use volume to start with your own config file. Simply replace PATH_TO_YOUR_CONFIG with the path to your configuration file and run this command:
 ```bash
 docker run -d \
 		--rm \

--- a/third_party/kiwi/kiwi/fe_write.h
+++ b/third_party/kiwi/kiwi/fe_write.h
@@ -321,7 +321,7 @@ KIWI_API static inline machine_msg_t *kiwi_fe_write_sync(machine_msg_t *msg)
 	return msg;
 }
 
-/* support for mulit-param stmts */
+/* support for multi-param stmts */
 KIWI_API static inline machine_msg_t *
 kiwi_fe_write_prep_stmt(machine_msg_t *msg, char *query, char *param)
 {

--- a/third_party/machinarium/sources/backtrace.c
+++ b/third_party/machinarium/sources/backtrace.c
@@ -20,7 +20,7 @@ MACHINE_API int machine_get_backtrace(void **entries, int max)
 #define MM_BACKTRACE_STRING_N_ENTRIES 15
 
 __thread char backtrace_string[MM_BACKTRACE_STRING_N_ENTRIES * 40];
-const char *od_alpine_warning = "WARNING: Bactrace is not supproted!";
+const char *od_alpine_warning = "WARNING: Bactrace is not supported!";
 
 MACHINE_API const char *machine_get_backtrace_string()
 {

--- a/third_party/machinarium/sources/io.c
+++ b/third_party/machinarium/sources/io.c
@@ -453,7 +453,7 @@ static inline int format_inet_socket_addr(struct sockaddr *sa, socklen_t sa_len,
 
 static inline int format_unix_socket_addr(char *buf, size_t buflen)
 {
-	/* TODO: implement unix sock name formating */
+	/* TODO: implement unix sock name formatting */
 	snprintf(buf, buflen, "unix");
 
 	return 0;


### PR DESCRIPTION
Fixed some typos:

achived → achieved (in TSA documentation)
Antoher → Another (in quick-start guide)
mulit → multi (in kiwi write support comment)
Suppported → Supported (in backtrace warning message)
formating → formatting (in code comment)