### PR TITLE
https://github.com/yandex/odyssey/issues/282 Return numeric port for Unix sockets in console output

### DIFF
--- a/docker/functional/tests/show-unix-socket-ports/conf.conf
+++ b/docker/functional/tests/show-unix-socket-ports/conf.conf
@@ -1,0 +1,49 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/var/run/postgresql"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}
+
+storage "postgres_server" {
+	type "remote"
+	port 5432
+}
+
+storage "local" {
+	type "local"
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+	}
+}
+
+database "console" {
+	user default {
+		authentication "none"
+		role "admin"
+		pool "session"
+		storage "local"
+	}
+}

--- a/docker/functional/tests/show-unix-socket-ports/runner.sh
+++ b/docker/functional/tests/show-unix-socket-ports/runner.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+/usr/bin/odyssey /tests/show-unix-socket-ports/conf.conf
+sleep 1
+
+# Warm up: create some traffic so that servers/clients appear
+psql 'host=localhost port=6432 user=postgres dbname=postgres' \
+  --quiet --no-align --tuples-only -c 'SELECT 1' > /dev/null 2>&1
+
+# show servers: columns are type,user,database,state,addr,port,local_addr,local_port,...
+psql 'host=localhost port=6432 user=postgres dbname=console' \
+  --quiet --no-align --tuples-only -F '|' -c 'show servers' | \
+  awk -F '|' 'NF>0 {
+    port=$6; lport=$8;
+    if (port !~ /^-?[0-9]+$/)  { print "non-numeric servers.port: " port  > "/dev/stderr";  exit 1 }
+    if (lport !~ /^-?[0-9]+$/) { print "non-numeric servers.local_port: " lport > "/dev/stderr"; exit 1 }
+  }'
+
+# show clients: columns are type,user,database,state,storage_user,addr,port,local_addr,local_port,...
+psql 'host=localhost port=6432 user=postgres dbname=console' \
+  --quiet --no-align --tuples-only -F '|' -c 'show clients' | \
+  awk -F '|' 'NF>0 {
+    port=$7; lport=$9;
+    if (port !~ /^-?[0-9]+$/)  { print "non-numeric clients.port: " port  > "/dev/stderr";  exit 1 }
+    if (lport !~ /^-?[0-9]+$/) { print "non-numeric clients.local_port: " lport > "/dev/stderr"; exit 1 }
+  }'
+
+ody-stop

--- a/sources/dns.c
+++ b/sources/dns.c
@@ -37,7 +37,11 @@ int od_getsockaddrname(struct sockaddr *sa, char *buf, int size, int add_addr,
 		return 0;
 	}
 	if (sa->sa_family == AF_UNIX) {
-		od_snprintf(buf, size, "<unix socket>");
+		if (!add_addr && add_port) {
+			od_snprintf(buf, size, "-1");
+		} else {
+			od_snprintf(buf, size, "<unix socket>");
+		}
 		return 0;
 	}
 	od_snprintf(buf, size, "%s", "");


### PR DESCRIPTION
Fix of problem: ```The columns port and local_port are declared as integers in the console commands "show servers" and "show clients"but they can return a string sometimes: <unix socket>```.

Test written to check code correctness.

ChangeType: bugfix