### PR TITLE
docs: fix typos in docs

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -51,7 +51,7 @@ for all Odyssey rules.
 | `online_restart_drop_options.drop_enabled` | int (bool)       | `yes`       | runtime | Drop old connections gradually                        |
 | `bindwith_reuseport`                       | int (bool)       | `no`        | restart | Use SO\_REUSEPORT for binding                         |
 | `max_sigterms_to_die`                      | int              | `3`         | SIGHUP  | Max SIGTERMs before hard exit                         |
-| `enable_host_watcher`                      | int(bool)        | `3`         | restart | Start host cpu and mem consumtion watcher thread      |
+| `enable_host_watcher`                      | int(bool)        | `3`         | restart | Start host cpu and mem consumption watcher thread      |
 
 
 ## **include**
@@ -462,7 +462,7 @@ Maximum SIGTERM count before hard exit(1)
 ## **enable_host_watcher**
 *yes/no*
 
-Start thread to watch host CPU and memory consumtion. Makes `show host_utilization` works.
+Start thread to watch host CPU and memory consumption. Makes `show host_utilization` works.
 
 `enable_host_watcher yes`
 

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -11,7 +11,7 @@ $ ls build/packages
 odyssey-dbgsym_1.4rc-2276-d458212f_amd64.ddeb odyssey_1.4rc-2276-d458212f_amd64.deb
 ```
 
-For more convinient way to build package, consider use `dpkg-buildpackage`. Some example can be run by `package-*` targets:
+For more convenient way to build package, consider use `dpkg-buildpackage`. Some example can be run by `package-*` targets:
 ```sh
 make package-bionic
 

--- a/docs/features/balancing.md
+++ b/docs/features/balancing.md
@@ -15,7 +15,7 @@ and reliability without requiring application-level logic changes.
 
 ----
 
-## Configration
+## Configuration
 
 You will simply need to specify several hosts in your storage section:
 ```plaintext

--- a/docs/features/catchup-timeout.md
+++ b/docs/features/catchup-timeout.md
@@ -40,7 +40,7 @@ storage "postgres_server" {
 }
 ```
 
-The most intresting part is `watchdog_lag_query` parameter.
+The most interesting part is `watchdog_lag_query` parameter.
 Watchdog will execute this query to get underlying server lag.
 Consider something like `now() - pg_last_xact_replay_timestamp()` or
 [repl_mon](https://github.com/man-brain/repl_mon) for production  usages

--- a/docs/features/pooling.md
+++ b/docs/features/pooling.md
@@ -10,7 +10,7 @@ ensures scalability, stability, and optimal database resource utilization.
 Odyssey is _really good at pooling_ and allows you to create
 large production setups.
 
-Pooling is controled by rules in your configuration file.
+Pooling is controlled by rules in your configuration file.
 For full pooling parameters see [rules configuration](../configuration/rules.md)
 
 There are two types of pooling: session pooling and transaction pooling.


### PR DESCRIPTION
Fix typos in docs:
- consumtion→ consumption
- convinient→ convenient
- Configration→ Configuration
- intresting → interesting 
- controled→ controlled