### PR TITLE
 ci: add prometheus/exporter to dependabot and fix workflow name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     directory: /benchmarks/client_max_routing/
     schedule:
       interval: daily
+  - package-ecosystem: gomod
+    directory: /prometheus/exporter/
+    schedule:
+      interval: daily
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/jemalloc.yml
+++ b/.github/workflows/jemalloc.yml
@@ -1,4 +1,4 @@
-name: Jemalloc compatibility test tests
+name: Jemalloc compatibility test
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
 Fixes two CI config inconsistencies:

  1. **dependabot.yml**: Added missing `prometheus/exporter/` directory. Currently tracking 4 Go modules
  (docker/config-validation, docker/ody_integration_test, docker/prep_stmts, benchmarks/client_max_routing) but
  missing prometheus/exporter which also has go.mod (go 1.24.5). This leaves it without automated dependency
  updates.

  2. **jemalloc.yml**: Fixed workflow name "Jemalloc compatibility test tests" → "Jemalloc compatibility test"
  (removed duplicate "tests").