### PR TITLE
fix vrb pointers moving

### DIFF
--- a/sources/machinarium/ds/vrb.c
+++ b/sources/machinarium/ds/vrb.c
@@ -151,6 +151,11 @@ void mm_virtual_rbuf_read_commit(mm_virtual_rbuf_t *vrb, size_t len)
 	}
 
 	vrb->rpos += len;
+
+	if (vrb->rpos == vrb->wpos) {
+		vrb->rpos = 0;
+		vrb->wpos = 0;
+	}
 }
 
 size_t mm_virtual_rbuf_read(mm_virtual_rbuf_t *vrb, void *out, size_t count)


### PR DESCRIPTION
theoretically, it is possible to break vrb with many of writings (thousand of exabytes)

also this will help reduce cache misses