### PR TITLE
Fix SCRAM base64 pointer signedness for PG18 headers

### DIFF
--- a/sources/auth.c
+++ b/sources/auth.c
@@ -647,7 +647,7 @@ od_auth_frontend_scram_sha_256_internal(od_client_t *client,
 
 	char *final_nonce;
 	size_t final_nonce_size;
-	char *client_proof;
+	uint8_t *client_proof;
 	rc = od_scram_read_client_final_message(client->io.io, scram_state,
 						auth_data, auth_data_size,
 						&final_nonce, &final_nonce_size,

--- a/sources/postgres.h
+++ b/sources/postgres.h
@@ -17,6 +17,10 @@
 
 #define pg_attribute_noreturn() _NORETURN
 
+#ifndef pg_nodiscard
+#define pg_nodiscard __attribute__((warn_unused_result))
+#endif
+
 #define FRONTEND
 
 #include <pg_config.h>

--- a/sources/scram.h
+++ b/sources/scram.h
@@ -173,7 +173,7 @@ int od_scram_verify_final_nonce(od_scram_state_t *scram_state,
 				char *final_nonce, size_t final_nonce_size);
 
 int od_scram_verify_client_proof(od_scram_state_t *scram_state,
-				 char *client_proof);
+				 uint8_t *client_proof);
 
 int od_scram_parse_verifier(od_scram_state_t *scram_state, char *verifier);
 
@@ -188,4 +188,4 @@ int od_scram_read_client_final_message(machine_io_t *io,
 				       char *auth_data, size_t auth_data_size,
 				       char **final_nonce_ptr,
 				       size_t *final_nonce_size_ptr,
-				       char **proof_ptr);
+				       uint8_t **proof_ptr);


### PR DESCRIPTION
  ## Summary

  - Align SCRAM base64 buffers and parameters with PostgreSQL 18 headers: switch from char* to uint8_t* for salt, keys, proofs, and signatures to satisfy pg_b64_encode/pg_b64_decode and SCRAM APIs.
  - Encode channel-binding data using unsigned input to match encoder expectations.
  - Add a fallback pg_nodiscard macro definition for compatibility with PG headers.

  ## Why
  Building against PostgreSQL 18 server headers fails with -Werror=pointer-sign because the PG base64 functions expect uint8_t* while the current code passes char*. These type fixes remove the
  signedness warnings and restore a clean build.

  ## Behavior
  No functional changes; this is a type/compatibility fix.

  ## Testing

  - docker build --platform linux/amd64 -f docker/quickstart/Dockerfile . --tag=odyssey
  ```
  14.46 [ 38%] Building C object sources/CMakeFiles/odyssey.dir/mdb_iamproxy.c.o
  14.55 [ 38%] Building C object sources/CMakeFiles/odyssey.dir/external_auth.c.o
  14.73 [ 39%] Building C object sources/CMakeFiles/odyssey.dir/group.c.o
  14.94 [ 39%] Building C object sources/CMakeFiles/odyssey.dir/query_processing.c.o
  14.96 [ 40%] Building C object sources/CMakeFiles/odyssey.dir/scram.c.o
  15.33 In file included from /odyssey/sources/odyssey.h:93,
  15.33                  from /odyssey/sources/scram.c:10:
  15.33 /odyssey/sources/scram.c: In function 'od_scram_parse_verifier':
  15.33 /odyssey/sources/scram.c:66:55: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.33    66 |                 od_b64_decode(salt_raw, salt_raw_len, salt, salt_dst_len);
  15.33       |                                                       ^~~~
  15.33       |                                                       |
  15.33       |                                                       char *
  15.33 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.33    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.33       |                                     ^~~
  15.34 In file included from /odyssey/sources/postgres.h:29,
  15.34                  from /odyssey/sources/odyssey.h:19:
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.34 /odyssey/sources/scram.c:84:44: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.34    84 |                                            stored_key, stored_key_dst_len);
  15.34       |                                            ^~~~~~~~~~
  15.34       |                                            |
  15.34       |                                            char *
  15.34 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.34    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.34       |                                     ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.34 /odyssey/sources/scram.c:97:44: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.34    97 |                                            server_key, server_key_dst_len);
  15.34       |                                            ^~~~~~~~~~
  15.34       |                                            |
  15.34       |                                            char *
  15.34 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.34    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.34       |                                     ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.34 /odyssey/sources/scram.c: In function 'od_scram_init_from_plain_password':
  15.34 /odyssey/sources/scram.c:144:45: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.34   144 |         int base64_salt_len = od_b64_encode(salt, sizeof(salt),
  15.34       |                                             ^~~~
  15.34       |                                             |
  15.34       |                                             char *
  15.34 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.34    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.34       |                       ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.34       |                                       ~~~~~~~~~~~~~^~~
  15.34 /odyssey/sources/scram.c:152:43: error: pointer targets in passing argument 4 of 'scram_SaltedPassword' differ in signedness [-Werror=pointer-sign]
  15.34   152 |         od_scram_SaltedPassword(password, salt, sizeof(salt),
  15.34       |                                           ^~~~
  15.34       |                                           |
  15.34       |                                           char *
  15.34 /odyssey/sources/scram.h:73:74: note: in definition of macro 'od_scram_SaltedPassword'
  15.34    73 |         scram_SaltedPassword(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, salt, \
  15.34       |                                                                          ^~~~
  15.34 In file included from /odyssey/sources/postgres.h:32:
  15.34 /usr/include/postgresql/18/server/common/scram-common.h:54:79: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    54 |                                                                  const uint8 *salt, int saltlen, int iterations,
  15.34       |                                                                  ~~~~~~~~~~~~~^~~~
  15.34 /odyssey/sources/scram.c: In function 'od_scram_create_client_first_message':
  15.34 /odyssey/sources/scram.c:185:31: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.34   185 |                 od_b64_encode((char *)nonce, SCRAM_RAW_NONCE_LEN,
  15.34       |                               ^~~~~~~~~~~~~
  15.34       |                               |
  15.34       |                               char *
  15.34 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.34    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.34       |                       ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.34       |                                       ~~~~~~~~~~~~~^~~
  15.34 /odyssey/sources/scram.c: In function 'read_server_first_message':
  15.34 /odyssey/sources/scram.c:252:69: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.34   252 |         int salt_len = od_b64_decode(base64_salt, base64_salt_size, salt,
  15.34       |                                                                     ^~~~
  15.34       |                                                                     |
  15.34       |                                                                     char *
  15.34 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.34    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.34       |                                     ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.34 /odyssey/sources/scram.c: In function 'calculate_client_proof':
  15.34 /odyssey/sources/scram.c:313:52: error: pointer targets in passing argument 4 of 'scram_SaltedPassword' differ in signedness [-Werror=pointer-sign]
  15.34   313 |         od_scram_SaltedPassword(prepared_password, salt, SCRAM_DEFAULT_SALT_LEN,
  15.34       |                                                    ^~~~
  15.34       |                                                    |
  15.34       |                                                    const char *
  15.34 /odyssey/sources/scram.h:73:74: note: in definition of macro 'od_scram_SaltedPassword'
  15.34    73 |         scram_SaltedPassword(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, salt, \
  15.34       |                                                                          ^~~~
  15.34 /usr/include/postgresql/18/server/common/scram-common.h:54:79: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'const char *'
  15.34    54 |                                                                  const uint8 *salt, int saltlen, int iterations,
  15.34       |                                                                  ~~~~~~~~~~~~~^~~~
  15.34 /odyssey/sources/scram.c: In function 'calculate_server_signature':
  15.34 /odyssey/sources/scram.c:375:31: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.34   375 |                 od_b64_encode((char *)server_signature, OD_SCRAM_MAX_KEY_LEN,
  15.34       |                               ^~~~~~~~~~~~~~~~~~~~~~~~
  15.34       |                               |
  15.34       |                               char *
  15.34 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.34    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.34       |                       ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.34       |                                       ~~~~~~~~~~~~~^~~
  15.34 /odyssey/sources/scram.c: In function 'od_scram_create_client_final_message':
  15.34 /odyssey/sources/scram.c:428:31: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.34   428 |         size += od_b64_encode((char *)client_proof, OD_SCRAM_MAX_KEY_LEN,
  15.34       |                               ^~~~~~~~~~~~~~~~~~~~
  15.34       |                               |
  15.34       |                               char *
  15.34 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.34    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.34       |                       ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.34       |                                       ~~~~~~~~~~~~~^~~
  15.34 /odyssey/sources/scram.c: In function 'read_server_final_message':
  15.34 /odyssey/sources/scram.c:465:58: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.34   465 |                 od_b64_decode(signature, signature_size, decoded_signature,
  15.34       |                                                          ^~~~~~~~~~~~~~~~~
  15.34       |                                                          |
  15.34       |                                                          char *
  15.34 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.34    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.34       |                                     ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.34 /odyssey/sources/scram.c: In function 'od_scram_read_client_final_message':
  15.34 /odyssey/sources/scram.c:712:49: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.34   712 |                 b64_message_len = od_b64_encode(cbind_input, cbind_input_len,
  15.34       |                                                 ^~~~~~~~~~~
  15.34       |                                                 |
  15.34       |                                                 char *
  15.34 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.34    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.34       |                       ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.34    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.34       |                                       ~~~~~~~~~~~~~^~~
  15.34 /odyssey/sources/scram.c:754:72: error: pointer targets in passing argument 3 of 'pg_b64_decode' differ in signedness [-Werror=pointer-sign]
  15.34   754 |         int proof_len = od_b64_decode(base64_proof, base64_proof_size, proof,
  15.34       |                                                                        ^~~~~
  15.34       |                                                                        |
  15.34       |                                                                        char *
  15.34 /odyssey/sources/scram.h:21:37: note: in definition of macro 'od_b64_decode'
  15.34    21 |         pg_b64_decode(src, src_len, dst, dst_len);
  15.34       |                                     ^~~
  15.34 /usr/include/postgresql/18/server/common/base64.h:15:72: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'char *'
  15.34    15 | pg_nodiscard extern int pg_b64_decode(const char *src, int len, uint8 *dst, int dstlen);
  15.35 /odyssey/sources/scram.c: In function 'od_scram_create_server_first_message':
  15.35 /odyssey/sources/scram.c:819:31: error: pointer targets in passing argument 1 of 'pg_b64_encode' differ in signedness [-Werror=pointer-sign]
  15.35   819 |                 od_b64_encode((char *)nonce, SCRAM_RAW_NONCE_LEN,
  15.35       |                               ^~~~~~~~~~~~~
  15.35       |                               |
  15.35       |                               char *
  15.35 /odyssey/sources/scram.h:19:23: note: in definition of macro 'od_b64_encode'
  15.35    19 |         pg_b64_encode(src, src_len, dst, dst_len);
  15.35       |                       ^~~
  15.35 /usr/include/postgresql/18/server/common/base64.h:14:52: note: expected 'const uint8_t *' {aka 'const unsigned char *'} but argument is of type 'char *'
  15.35    14 | pg_nodiscard extern int pg_b64_encode(const uint8 *src, int len, char *dst, int dstlen);
  15.35       |                                       ~~~~~~~~~~~~~^~~
  16.04 cc1: all warnings being treated as errors
  16.05 make[3]: *** [sources/CMakeFiles/odyssey.dir/build.make:961: sources/CMakeFiles/odyssey.dir/scram.c.o] Error 1
  16.05 make[2]: *** [CMakeFiles/Makefile2:292: sources/CMakeFiles/odyssey.dir/all] Error 2
  16.05 make[1]: *** [Makefile:156: all] Error 2
  16.05 make[1]: Leaving directory '/odyssey/build'
  16.05 make: *** [Makefile:63: build_release] Error 2
  ------
  Dockerfile:20
  --------------------
    18 |     COPY . ./
    19 |
    20 | >>> RUN make clean && make build_release
    21 |
    22 |     FROM alpine:latest
  --------------------
  ERROR: failed to build: failed to solve: process "/bin/sh -c make clean && make build_release" did not complete successfully: exit code: 2
```
