### PR TITLE
fix misleading description in the exporter

### DIFF
--- a/prometheus/exporter/exporter.go
+++ b/prometheus/exporter/exporter.go
@@ -108,7 +108,7 @@ var (
 
 	clientPoolWaitingRouteDescription = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "client_pool", "waiting_route"),
-		"Clients waiting for a server connection on the route",
+		"Clients connected to the route but idle (not actively using a server)",
 		[]string{"user", "database"}, nil,
 	)
 


### PR DESCRIPTION
The current description "Clients waiting for a server connection" implies they're blocked or queued, which isn't accurate. They're simply in a parked state until they send their first query.

