### PR TITLE
Bullseye openssl fix

### DIFF
--- a/sources/include/od_postgres.h
+++ b/sources/include/od_postgres.h
@@ -24,6 +24,18 @@
 #define FRONTEND
 
 #include <pg_config.h>
+
+/*
+ * Undefine OPENSSL_API_COMPAT to prevent conflicts with system OpenSSL headers.
+ * PostgreSQL's pg_config.h defines this, but on OpenSSL 1.1.x, the system headers
+ * define it differently (as OPENSSL_MIN_API), causing redefinition errors.
+ * This is only needed for OpenSSL < 3.0.
+ */
+#include <openssl/opensslv.h>
+#if defined(OPENSSL_API_COMPAT) && OPENSSL_VERSION_NUMBER < 0x30000000L
+#undef OPENSSL_API_COMPAT
+#endif
+
 #include <string.h>
 
 #include <common/base64.h>

--- a/sources/scram.c
+++ b/sources/scram.c
@@ -7,6 +7,9 @@
 
 #include <odyssey.h>
 
+/* Include od_postgres.h before OpenSSL headers to handle OPENSSL_API_COMPAT properly */
+#include <od_postgres.h>
+
 #include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
@@ -19,7 +22,6 @@
 #include <attribute.h>
 #include <scram.h>
 #include <util.h>
-#include <od_postgres.h>
 
 #if PG_VERSION_NUM >= 160000
 #define OD_SCRAM_MAX_KEY_LEN SCRAM_MAX_KEY_LEN


### PR DESCRIPTION
old ssl version had isues with building odyssey
```
[ 99%] Building C object sources/CMakeFiles/odyssey_test.dir/ldap.c.o
In file included from /usr/scratch/evgeny/odyssey/sources/include/od_postgres.h:26,
                 from /usr/scratch/evgeny/odyssey/sources/scram.c:22:
/usr/include/postgresql/17/server/pg_config.h:587: error: "OPENSSL_API_COMPAT" redefined [-Werror]
  587 | #define OPENSSL_API_COMPAT 0x10002000L
      |
In file included from /usr/include/openssl/e_os2.h:13,
                 from /usr/include/openssl/ossl_typ.h:19,
                 from /usr/include/openssl/rand.h:14,
                 from /usr/scratch/evgeny/odyssey/sources/scram.c:10:
/usr/include/x86_64-linux-gnu/openssl/opensslconf.h:144: note: this is the location of the previous definition
  144 | # define OPENSSL_API_COMPAT OPENSSL_MIN_API
      |
cc1: all warnings being treated as errors
make[3]: *** [sources/CMakeFiles/odyssey_test.dir/build.make:2876: sources/CMakeFiles/odyssey_test.dir/scram.c.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/usr/scratch/evgeny/odyssey/build'
make[2]: *** [CMakeFiles/Makefile2:181: sources/CMakeFiles/odyssey_test.dir/all] Error 2
make[2]: Leaving directory '/usr/scratch/evgeny/odyssey/build'
make[1]: *** [Makefile:156: all] Error 2
make[1]: Leaving directory '/usr/scratch/evgeny/odyssey/build'
make: *** [Makefile:63: build_release] Error 2
```