### PR TITLE
debian/control: remove conflict section

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Homepage: https://github.com/yandex/odyssey
 
 Package: odyssey
 Architecture: any
-Conflicts: pgbouncer
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Scalable PostgreSQL connection pooler.
  Advanced multi-threaded PostgreSQL connection pooler and request router.


### PR DESCRIPTION
Actually, there is no default config in debian package, so there is no any conflicts with pgbouncer