### PR TITLE
pass pthread_self into pthread_setname_np

### DIFF
--- a/sources/include/machinarium/thread.h
+++ b/sources/include/machinarium/thread.h
@@ -20,5 +20,5 @@ struct mm_thread {
 
 int mm_thread_create(mm_thread_t *, int, mm_thread_function_t, void *);
 int mm_thread_join(mm_thread_t *);
-int mm_thread_set_name(mm_thread_t *, char *);
+int mm_thread_set_name(char *);
 int mm_thread_disable_cancel(void);

--- a/sources/machinarium/machine.c
+++ b/sources/machinarium/machine.c
@@ -62,7 +62,7 @@ static void *machine_main(void *arg)
 
 	/* set thread name */
 	if (machine->name) {
-		mm_thread_set_name(&machine->thread, machine->name);
+		mm_thread_set_name(machine->name);
 	}
 #ifdef HAVE_TSAN
 	char name[256];

--- a/sources/machinarium/thread.c
+++ b/sources/machinarium/thread.c
@@ -41,10 +41,10 @@ int mm_thread_join(mm_thread_t *thread)
 	return rc;
 }
 
-int mm_thread_set_name(mm_thread_t *thread, char *name)
+int mm_thread_set_name(char *name)
 {
 	int rc;
-	rc = pthread_setname_np(thread->id, name);
+	rc = pthread_setname_np(pthread_self(), name);
 	return rc;
 }
 


### PR DESCRIPTION
More portable, have issues for musl

Due to race between setting thread->id and thread start
Thread 4 "odyssey" received signal SIGSEGV, Segmentation fault.
[Switching to LWP 18]
pthread_setname_np (thread=0x0, name=0x7f0454098e60 "system")
    at src/thread/pthread_setname_np.c:20
pthread_setname_np (thread=0x0, name=0x7f0454098e60 "system") at src/thread/pthread_setname_np.c:20
mm_thread_set_name (thread=0x7f045405cd38, name=0x7f0454098e60 "system") at /odyssey/sources/machinarium/thread.c:47
machine_main (arg=0x7f045405cd10) at /odyssey/sources/machinarium/machine.c:65

See https://git.musl-libc.org/cgit/musl/tree/src/thread/pthread_create.c#n389