### PR TITLE
relay.c: signal on_read when attach

### DIFF
--- a/sources/relay.c
+++ b/sources/relay.c
@@ -385,6 +385,7 @@ od_frontend_status_t od_relay_step(od_relay_t *relay, bool await_read)
 		 * if KIWI_FE_QUERY, try to parse attach-time hint
 		 */
 		if (relay->dst == NULL) {
+			machine_cond_signal(relay->src->on_read);
 			return OD_ATTACH;
 		}
 	}


### PR DESCRIPTION
This fixes leftover after 126dd22,
non-signalling on_read can lead to connection stuck