### PR TITLE
add dtor to hashmap

### DIFF
--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -24,6 +24,17 @@
 #include <instance.h>
 #include <query.h>
 
+static inline void free_cache_value(od_hashmap_list_item_t *it)
+{
+	od_auth_cache_value_t *p = it->value.data;
+	od_free(p->passwd);
+}
+
+od_hashmap_t *od_auth_query_create_cache(size_t sz)
+{
+	return od_hashmap_create_with_dtor(sz, free_cache_value);
+}
+
 static inline int od_auth_parse_passwd_from_datarow(od_logger_t *logger,
 						    machine_msg_t *msg,
 						    kiwi_password_t *result)
@@ -145,7 +156,6 @@ int od_auth_query(od_client_t *client, char *peer)
 		/* one-time initialize */
 		value->len = sizeof(od_auth_cache_value_t);
 		value->data = od_malloc(value->len);
-		/* OOM */
 		if (value->data == NULL) {
 			goto error;
 		}

--- a/sources/hashmap.c
+++ b/sources/hashmap.c
@@ -76,6 +76,7 @@ od_hashmap_t *od_hashmap_create(size_t sz)
 	}
 
 	hm->size = sz;
+	hm->dtor = NULL;
 	hm->buckets = od_malloc(sz * sizeof(od_hashmap_bucket_t *));
 
 	if (hm->buckets == NULL) {
@@ -94,6 +95,16 @@ od_hashmap_t *od_hashmap_create(size_t sz)
 	return hm;
 }
 
+od_hashmap_t *od_hashmap_create_with_dtor(size_t sz, od_hashmap_item_cb_t dtor)
+{
+	od_hashmap_t *hm = od_hashmap_create(sz);
+	if (hm != NULL) {
+		hm->dtor = dtor;
+	}
+
+	return hm;
+}
+
 od_retcode_t od_hashmap_free(od_hashmap_t *hm)
 {
 	for (size_t i = 0; i < hm->size; ++i) {
@@ -103,6 +114,9 @@ od_retcode_t od_hashmap_free(od_hashmap_t *hm)
 		{
 			od_hashmap_list_item_t *it;
 			it = od_container_of(j, od_hashmap_list_item_t, link);
+			if (hm->dtor) {
+				hm->dtor(it);
+			}
 			od_hashmap_list_item_free(it);
 		}
 
@@ -126,6 +140,9 @@ od_retcode_t od_hashmap_empty(od_hashmap_t *hm)
 		{
 			od_hashmap_list_item_t *it;
 			it = od_container_of(j, od_hashmap_list_item_t, link);
+			if (hm->dtor != NULL) {
+				hm->dtor(it);
+			}
 			od_hashmap_list_item_free(it);
 		}
 

--- a/sources/include/auth_query.h
+++ b/sources/include/auth_query.h
@@ -7,7 +7,10 @@
  */
 
 #include <types.h>
+#include <hashmap.h>
 
 #define ODYSSEY_AUTH_QUERY_MAX_PASSWORD_LEN 4096
+
+od_hashmap_t *od_auth_query_create_cache(size_t sz);
 
 int od_auth_query(od_client_t *, char *);

--- a/sources/include/hashmap.h
+++ b/sources/include/hashmap.h
@@ -14,6 +14,12 @@ typedef struct od_hashmap_list_item od_hashmap_list_item_t;
  value
  */
 
+/*
+ * TODO: make hashmap more simple in impl
+ * for ex.: remove double pointer to buckets
+ * and do not require hashing at user-side
+ */
+
 /* header, first keylen bytes is key, other is value */
 typedef struct {
 	void *data;
@@ -40,13 +46,18 @@ typedef struct od_hashmap_bucket {
 
 typedef struct od_hashmap od_hashmap_t;
 
+typedef void (*od_hashmap_item_cb_t)(od_hashmap_list_item_t *item);
+
 struct od_hashmap {
 	size_t size;
+	od_hashmap_item_cb_t dtor;
 	/* ISO C99 flexible array member */
 	od_hashmap_bucket_t **buckets;
 };
 
 extern od_hashmap_t *od_hashmap_create(size_t sz);
+extern od_hashmap_t *od_hashmap_create_with_dtor(size_t sz,
+						 od_hashmap_item_cb_t dtor);
 extern od_retcode_t od_hashmap_free(od_hashmap_t *hm);
 od_hashmap_elt_t *od_hashmap_find(od_hashmap_t *hm, od_hash_t keyhash,
 				  od_hashmap_elt_t *key);

--- a/sources/storage.c
+++ b/sources/storage.c
@@ -16,6 +16,7 @@
 #include <query.h>
 #include <attach.h>
 #include <router.h>
+#include <auth_query.h>
 #include <internal_client.h>
 
 void od_storage_endpoint_status_init(od_storage_endpoint_status_t *status)
@@ -181,8 +182,8 @@ od_rule_storage_t *od_rules_storage_allocate(void)
 	atomic_init(&storage->rr_counter, 0);
 
 #define OD_STORAGE_DEFAULT_HASHMAP_SZ 420u
-
-	storage->acache = od_hashmap_create(OD_STORAGE_DEFAULT_HASHMAP_SZ);
+	storage->acache =
+		od_auth_query_create_cache(OD_STORAGE_DEFAULT_HASHMAP_SZ);
 
 	od_list_init(&storage->link);
 	return storage;


### PR DESCRIPTION
Helps to fix memleaks for auth cache
in storage, when exit or cfg reload.