### PR TITLE
fix: show rule identity instead of backend identity in SHOW POOLS

### DIFF
--- a/sources/console.c
+++ b/sources/console.c
@@ -643,13 +643,13 @@ static inline int od_console_show_pools_add_cb(od_route_t *route, void **argv)
 
 	od_route_lock(route);
 	int rc;
-	rc = kiwi_be_write_data_row_add(stream, offset, route->id.database,
-					route->id.database_len - 1);
+	rc = kiwi_be_write_data_row_add(stream, offset, route->rule->db_name,
+					route->rule->db_name_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
-	rc = kiwi_be_write_data_row_add(stream, offset, route->id.user,
-					route->id.user_len - 1);
+	rc = kiwi_be_write_data_row_add(stream, offset, route->rule->user_name,
+					route->rule->user_name_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}


### PR DESCRIPTION
## Problem                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  `SHOW POOLS` and `SHOW POOLS_EXTENDED` report `route->id.database` and                                                                                                                                           
  `route->id.user` in the `database` and `user` columns. These fields
  represent the **backend** connection identity — they are overridden by                                                                                                                                           
  `storage_db` / `storage_user` directives during routing.                                                                                                                                                         
                                                                                                                                                                                                                   
  When multiple frontend routing rules map to the same backend credentials,                                                                                                                                        
  all affected routes produce rows with identical `(database, user)` values,                                                                                                                                       
  making them indistinguishable. This causes two concrete problems:                                                                                                                                                
                                                                                                                                                                                                                   
  1. **Observability gap** — operators cannot correlate pool metrics back to                                                                                                                                       
     specific routing rules.                                                                                                                                                                                       
  2. **Prometheus label collision** — duplicate label sets corrupt metric                                                                                                                                          
     series and break scraping.                                                                                                                                                                                    
                                                                                                                                                                                                                   
  ## Fix                                                                                                                                                                                                           
                                                                                                                                                                                                                   
  Replace `route->id.database` / `route->id.user` with
  `route->rule->db_name` / `route->rule->user_name` in
  `od_console_show_pools_add_cb()` (`sources/console.c`).                                                                                                                                                          
                                                                                                                                                                                                                   
  These fields always hold the **frontend rule identity** (the name as                                                                                                                                             
  written in the config file), which is unique per route. For `default`                                                                                                                                            
  rules they resolve to the literal strings `"default_db"` /                                                                                                                                                       
  `"default_user"`.                                                                                                                                                                                                
                                                                                                                                                                                                                   
  The length fields are updated accordingly: `rule->db_name_len` and                                                                                                                                               
  `rule->user_name_len` are assigned via `strlen()` and do not include the
  null terminator, so the previous `- 1` adjustment is dropped.                                                                                                                                                    
                                                                                                                                                                                                                   
  ## Behaviour change                                                                                                                                                                                              
                                                                                                                                                                                                                   
  | Scenario | Before | After |                                                                                                                                                                                    
  |---|---|---|
  | No `storage_db` / `storage_user` | client DB / user | rule DB / user (same) |                                                                                                                                  
  | `storage_user = backend_user` configured | `backend_user` | rule user name |                                                                                                                                   
  | Multiple rules → same backend | duplicate rows | distinct rows per rule |                                                                                                                                      
                                                                                                                                                                                                                   
  Operators who relied on `SHOW POOLS` to inspect the actual backend                                                                                                                                               
  credentials should use `SHOW SERVERS` instead, which continues to reflect                                                                                                                                        
  the real backend connection identity.                                                                                                                                                                            
                                                                                                                                                                                                                   
  Fixes #1279.