### PR TITLE
fix potential use after free in sources/config_reader.c

### DIFF
--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1708,8 +1708,8 @@ od_config_reader_ldap_storage_credentials(od_config_reader_t *reader,
 						lsc_current->name);
 					goto error;
 				}
-				od_rule_ldap_storage_credentials_add(rule,
-								     lsc_current);
+				od_rule_ldap_storage_credentials_add(
+					rule, lsc_current);
 				od_ldap_storage_credentials_free(lsc_current);
 				return OK_RESPONSE;
 			}

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1681,10 +1681,6 @@ od_config_reader_ldap_storage_credentials(od_config_reader_t *reader,
 		goto error;
 	}
 
-	od_rule_ldap_storage_credentials_add(rule, lsc_current);
-
-	od_ldap_storage_credentials_free(lsc_current);
-
 	/* { */
 	if (!od_config_reader_symbol(reader, '{')) {
 		goto error;
@@ -1712,6 +1708,9 @@ od_config_reader_ldap_storage_credentials(od_config_reader_t *reader,
 						lsc_current->name);
 					goto error;
 				}
+				od_rule_ldap_storage_credentials_add(rule,
+								     lsc_current);
+				od_ldap_storage_credentials_free(lsc_current);
 				return OK_RESPONSE;
 			}
 			/* fall through */
@@ -1727,7 +1726,7 @@ od_config_reader_ldap_storage_credentials(od_config_reader_t *reader,
 		if (keyword == NULL) {
 			od_config_reader_error(reader, &token,
 					       "unknown parameter");
-			return NOT_OK_RESPONSE;
+			goto error;
 		}
 
 		switch (keyword->id) {


### PR DESCRIPTION
```
CID 642778: (#4 of 4): Use after free (USE_AFTER_FREE)
14. pass_freed_arg: Passing freed pointer lsc_current->name as an argument to od_config_reader_error.
1754                                od_config_reader_error(
1755                                        reader, &token,
1756                                        "lsc_password in ldap_storage_credentials '%s' cannot be empty",
1757                                        lsc_current->name);
1758                                goto error;
1759                        }
```