### PR TITLE
router.c: fix uneven attaching

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -2250,9 +2250,9 @@ void od_frontend(void *arg)
 
 			od_route_lock(srv_route);
 			od_server_cancel_end(cancel.server);
-			od_route_unlock(srv_route);
 			/* signal about possible free connection */
-			od_route_signal(srv_route);
+			od_route_signal_locked(srv_route, NULL);
+			od_route_unlock(srv_route);
 
 			od_router_cancel_free(&cancel);
 		}

--- a/sources/include/multi_pool.h
+++ b/sources/include/multi_pool.h
@@ -31,6 +31,7 @@ struct od_multi_pool_key {
 struct od_multi_pool_element {
 	od_multi_pool_key_t key;
 	od_server_pool_t pool;
+	mm_wait_list_t wait_bus;
 	od_list_t link;
 };
 
@@ -41,7 +42,6 @@ struct od_multi_pool {
 	od_server_pool_free_fn_t pool_free_fn;
 	pthread_spinlock_t lock;
 
-	mm_wait_list_t *wait_bus;
 	/* should increase every time servers in the route's pool are changed */
 	atomic_uint_fast64_t version;
 };
@@ -61,21 +61,12 @@ static inline uint64_t od_multi_pool_version(od_multi_pool_t *mpool)
 	return atomic_load(&mpool->version);
 }
 
-static inline void *od_multi_pool_signal(od_multi_pool_t *mpool,
-					 mm_wl_private_cb_t cb, void *arg)
-{
-	atomic_fetch_add(&mpool->version, 1);
-	return mm_wait_list_notify_cb(mpool->wait_bus, cb, arg);
-}
+void od_multi_pool_signal_locked(od_multi_pool_t *mpool,
+				 od_multi_pool_element_t *el,
+				 od_server_t *server);
 
-static inline int od_multi_pool_wait(od_multi_pool_t *mpool, void *private,
-				     uint64_t version, uint32_t timeout_ms)
-{
-	int rc;
-	rc = mm_wait_list_compare_wait(mpool->wait_bus, private, version,
-				       timeout_ms);
-	return rc;
-}
+int od_multi_pool_wait(od_multi_pool_element_t *el, od_client_t *client,
+		       uint64_t version, uint32_t timeout_ms);
 
 od_multi_pool_t *od_multi_pool_create(od_server_pool_free_fn_t pool_free_fn);
 void od_multi_pool_destroy(od_multi_pool_t *mpool);

--- a/sources/include/route.h
+++ b/sources/include/route.h
@@ -320,20 +320,11 @@ static inline uint64_t od_route_pools_version(od_route_t *route)
 	return od_multi_pool_version(mpool);
 }
 
-static inline int od_route_wait(od_route_t *route, void *private,
-				uint64_t version, uint32_t timeout_ms)
-{
-	od_multi_pool_t *mpool = od_route_server_pools(route);
+int od_route_wait(od_route_t *route, od_client_t *client,
+		  const od_address_t *address, uint64_t version,
+		  uint32_t timeout_ms);
 
-	return od_multi_pool_wait(mpool, private, version, timeout_ms);
-}
-
-static inline void *od_route_signal(od_route_t *route)
-{
-	od_multi_pool_t *mpool = od_route_server_pools(route);
-
-	return od_multi_pool_signal(mpool, NULL, NULL);
-}
+void od_route_signal_locked(od_route_t *route, od_server_t *server);
 
 int od_route_server_pool_can_add_locked(od_route_t *route,
 					od_multi_pool_element_t *el);

--- a/sources/multi_pool.c
+++ b/sources/multi_pool.c
@@ -89,7 +89,8 @@ static inline int key_cmp(const od_multi_pool_key_t *a,
 	return od_address_cmp(&a->address, &b->address);
 }
 
-static inline od_multi_pool_element_t *od_multi_pool_element_create(void)
+static inline od_multi_pool_element_t *
+od_multi_pool_element_create(atomic_uint_fast64_t *version)
 {
 	od_multi_pool_element_t *element =
 		od_malloc(sizeof(od_multi_pool_element_t));
@@ -100,6 +101,7 @@ static inline od_multi_pool_element_t *od_multi_pool_element_create(void)
 	key_init(&element->key);
 	od_server_pool_init(&element->pool);
 	od_list_init(&element->link);
+	mm_wait_list_init(&element->wait_bus, version);
 
 	return element;
 }
@@ -109,6 +111,7 @@ static inline void od_multi_pool_element_free(od_multi_pool_element_t *element,
 {
 	key_destroy(&element->key);
 	free_fn(&element->pool);
+	mm_wait_list_destroy(&element->wait_bus);
 	od_free(element);
 }
 
@@ -120,12 +123,6 @@ od_multi_pool_t *od_multi_pool_create(od_server_pool_free_fn_t free_fn)
 	}
 
 	atomic_init(&mpool->version, 0);
-
-	mpool->wait_bus = mm_wait_list_create(&mpool->version);
-	if (mpool->wait_bus == NULL) {
-		od_free(mpool);
-		return NULL;
-	}
 
 	mpool->pool_free_fn = free_fn;
 	od_list_init(&mpool->pools);
@@ -142,10 +139,6 @@ void od_multi_pool_destroy(od_multi_pool_t *mpool)
 		el = od_container_of(i, od_multi_pool_element_t, link);
 		od_list_unlink(&el->link);
 		od_multi_pool_element_free(el, mpool->pool_free_fn);
-	}
-
-	if (mpool->wait_bus) {
-		mm_wait_list_free(mpool->wait_bus);
 	}
 
 	pthread_spin_destroy(&mpool->lock);
@@ -178,7 +171,7 @@ od_multi_pool_get_or_create_locked(od_multi_pool_t *mpool,
 
 	if (el == NULL) {
 		od_multi_pool_element_t *new_el =
-			od_multi_pool_element_create();
+			od_multi_pool_element_create(&mpool->version);
 		if (key_copy(&new_el->key, key) != 0) {
 			od_multi_pool_element_free(new_el, mpool->pool_free_fn);
 			return NULL;
@@ -294,4 +287,56 @@ od_server_t *od_multi_pool_peek_any_locked(od_multi_pool_t *mpool,
 	}
 
 	return server;
+}
+
+typedef struct {
+	od_client_t *client;
+} server_awaiter_t;
+
+static void attach_freed_server_now(void *private, void *arg)
+{
+	server_awaiter_t *awaiter = private;
+	od_server_t *server = arg;
+
+	if (awaiter == NULL || server == NULL) {
+		return;
+	}
+
+	if (server->state != OD_SERVER_IDLE) {
+		return;
+	}
+
+	od_client_t *client = awaiter->client;
+	od_server_attach_client(server, client);
+}
+
+void od_multi_pool_signal_locked(od_multi_pool_t *mpool,
+				 od_multi_pool_element_t *e,
+				 od_server_t *server)
+{
+	if (e != NULL && server != NULL && server->state != OD_SERVER_UNDEF) {
+		atomic_fetch_add(&mpool->version, 1);
+		mm_wait_list_notify_cb(&e->wait_bus, attach_freed_server_now,
+				       server);
+		return;
+	}
+
+	od_list_t *i;
+	od_list_foreach (&mpool->pools, i) {
+		od_multi_pool_element_t *el =
+			od_container_of(i, od_multi_pool_element_t, link);
+
+		atomic_fetch_add(&mpool->version, 1);
+		mm_wait_list_notify(&el->wait_bus);
+	}
+}
+
+int od_multi_pool_wait(od_multi_pool_element_t *el, od_client_t *client,
+		       uint64_t version, uint32_t timeout_ms)
+{
+	server_awaiter_t awaiter;
+	awaiter.client = client;
+
+	return mm_wait_list_compare_wait(&el->wait_bus, &awaiter, version,
+					 timeout_ms);
 }

--- a/sources/route.c
+++ b/sources/route.c
@@ -164,3 +164,29 @@ int od_route_server_pool_can_add_locked(od_route_t *route,
 	/* shared pool can't have size of 0 */
 	return total < route->shared_pool->pool_size;
 }
+
+int od_route_wait(od_route_t *route, od_client_t *client,
+		  const od_address_t *address, uint64_t version,
+		  uint32_t timeout_ms)
+{
+	od_route_lock(route);
+	od_multi_pool_element_t *mpel =
+		od_route_get_server_pool_element_locked(route, address);
+	od_route_unlock(route);
+
+	return od_multi_pool_wait(mpel, client, version, timeout_ms);
+}
+
+void od_route_signal_locked(od_route_t *route, od_server_t *server)
+{
+	od_multi_pool_element_t *el = NULL;
+
+	if (server != NULL) {
+		const od_address_t *address = od_server_pool_address(server);
+		el = od_route_get_server_pool_element_locked(route, address);
+	}
+
+	od_multi_pool_t *mpool = od_route_server_pools(route);
+
+	od_multi_pool_signal_locked(mpool, el, server);
+}

--- a/sources/router.c
+++ b/sources/router.c
@@ -305,13 +305,14 @@ static inline int od_router_expire_cb(od_route_t *route, void **argv)
 	od_route_server_pool_foreach_locked(
 		route, OD_SERVER_IDLE, od_router_expire_server_tick_cb, argv);
 
-	od_route_unlock(route);
-
 	/*
 	 * maybe we have closed expired IDLE
 	 * connection and pool state has been changed
 	 */
-	od_route_signal(route);
+	od_route_signal_locked(route, NULL);
+
+	od_route_unlock(route);
+
 	return 0;
 }
 
@@ -1110,20 +1111,6 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 			notice_sent = 1;
 		}
 
-		/*
-		 * no need to check return value
-		 * 
-		 * in case it returns 0 - the server pool has changed
-		 * and now we can retry attach attempt
-		 * 
-		 * in case it return -1 and errno = EAGAIN,
-		 * the pool has changed between attach attempt and
-		 * wait begin - need to retry attach
-		 * 
-		 * in case it timedout - nothig to do than to retry
-		 * attach ot exit with timeout
-		 * (the general timeout will be checked in cycle condition)
-		 */
 		uint32_t until_notice = 1000;
 		if (notice_sending && !notice_sent) {
 			until_notice =
@@ -1131,8 +1118,20 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 				       notice_deadline - machine_time_ms());
 		}
 
-		od_route_wait(route, client, version,
+		od_route_wait(route, client, address, version,
 			      od_min(end_time_ms - now_ms, until_notice));
+		if (client->server != NULL) {
+			/* someone attached freed server directly to us */
+			od_route_lock(route);
+			od_client_pool_set(&route->client_pool, client,
+					   OD_CLIENT_ACTIVE);
+			od_route_unlock(route);
+			if (client->server->io.io) {
+				od_io_attach(&client->server->io);
+			}
+			status = OD_ROUTER_OK;
+			break;
+		}
 
 		/* client disconnected while awaiting for attaching */
 		if (!od_io_connected(&client->io)) {
@@ -1185,6 +1184,7 @@ void od_router_detach(od_router_t *router, od_client_t *client)
 			od_backend_close_connection(server);
 			od_server_set_pool_state(server, OD_SERVER_UNDEF);
 			od_backend_close(server);
+			server = NULL;
 		}
 	} else {
 		od_instance_t *instance = server->global->instance;
@@ -1194,16 +1194,13 @@ void od_router_detach(od_router_t *router, od_client_t *client)
 		od_backend_close_connection(server);
 		od_server_set_pool_state(server, OD_SERVER_UNDEF);
 		od_backend_close(server);
+		server = NULL;
 	}
 	od_client_pool_set(&route->client_pool, client, OD_CLIENT_PENDING);
 
-	od_route_unlock(route);
+	od_route_signal_locked(route, server);
 
-	void *awaiter = od_route_signal(route);
-	if (awaiter != NULL) {
-		/* TODO: proper use of awaiter */
-		machine_sleep(0);
-	}
+	od_route_unlock(route);
 }
 
 void od_router_close(od_router_t *router, od_client_t *client)
@@ -1223,12 +1220,12 @@ void od_router_close(od_router_t *router, od_client_t *client)
 	od_server_set_pool_state(server, OD_SERVER_UNDEF);
 	server->route = NULL;
 
+	od_route_signal_locked(route, NULL);
+
 	od_route_unlock(route);
 
 	assert(server->io.io == NULL);
 	od_server_free(server);
-
-	od_route_signal(route);
 }
 
 static inline int od_router_cancel_cmp(od_server_t *server, void **argv)

--- a/test/functional/tests/tsa_ports/odyssey.conf
+++ b/test/functional/tests/tsa_ports/odyssey.conf
@@ -13,6 +13,8 @@ log_config yes
 log_session no
 log_stats no
 
+workers 2
+
 coroutine_stack_size 24
 
 listen {

--- a/test/stress/entrypoint.sh
+++ b/test/stress/entrypoint.sh
@@ -19,7 +19,7 @@ sleep 1
 
 /stester -dsn 'postgres://tuser:postgres@localhost:6432/postgres?sslmode=disable' \
   -duration 10m \
-  -startup-stagger-max 10s \
+  -startup-stagger-max 30s \
   -fail-fast=true \
   -connect-timeout 1s \
   -reconnect-prob 0.5 \


### PR DESCRIPTION
There was no garantee to attach freed server
to the first client in queue, which can lead
to error of pool_size reached in simple cases like pool_size = 1 and -c = 2

This patch adds passing the server directly from
just detached client to the waken up client
in attaching queue.