### PR TITLE
fix for client_max 0 behaviour according to the docs

### DIFF
--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1973,7 +1973,9 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 						     &rule->client_max)) {
 				return NOT_OK_RESPONSE;
 			}
-			rule->client_max_set = 1;
+			if (config->client_max > 0) {
+                config->client_max_set = 1;
+            }
 			continue;
 		/* client_fwd_error */
 		case OD_LCLIENT_FWD_ERROR:
@@ -3353,7 +3355,9 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 						     &config->client_max)) {
 				goto error;
 			}
-			config->client_max_set = 1;
+			if (config->client_max > 0) {
+                config->client_max_set = 1;
+            }
 			continue;
 		/* client_max_routing */
 		case OD_LCLIENT_MAX_ROUTING:

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -1973,9 +1973,9 @@ static int od_config_reader_rule_settings(od_config_reader_t *reader,
 						     &rule->client_max)) {
 				return NOT_OK_RESPONSE;
 			}
-			if (config->client_max > 0) {
-                config->client_max_set = 1;
-            }
+			if (rule->client_max > 0) {
+				rule->client_max_set = 1;
+			}
 			continue;
 		/* client_fwd_error */
 		case OD_LCLIENT_FWD_ERROR:
@@ -3356,8 +3356,8 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 				goto error;
 			}
 			if (config->client_max > 0) {
-                config->client_max_set = 1;
-            }
+				config->client_max_set = 1;
+			}
 			continue;
 		/* client_max_routing */
 		case OD_LCLIENT_MAX_ROUTING:


### PR DESCRIPTION
In the documentation client_max set to 0 means the same as commenting it out. In reality it hurts
https://github.com/yandex/odyssey/blob/master/docs/configuration/global.md?plain=1#L44
