### PR TITLE
remove unnecessary od_group fields. second attempt

### DIFF
--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -2727,8 +2727,6 @@ static int od_config_reader_group(od_config_reader_t *reader, char *db_name,
 	od_free(group_name);
 
 	/* force several settings */
-	group->storage_db = od_strdup(rule->storage_db);
-	group->storage_user = od_strdup(rule->storage_user);
 	rule->pool->routing = OD_RULE_POOL_CLIENT_VISIBLE;
 	rule->users_in_group = 0;
 	rule->user_names = NULL;

--- a/sources/group.c
+++ b/sources/group.c
@@ -24,12 +24,6 @@ int od_group_free(od_group_t *group)
 	if (group->route_db) {
 		od_free(group->route_db);
 	}
-	if (group->storage_user) {
-		od_free(group->storage_user);
-	}
-	if (group->storage_db) {
-		od_free(group->storage_db);
-	}
 	if (group->group_name) {
 		od_free(group->group_name);
 	}

--- a/sources/include/group.h
+++ b/sources/include/group.h
@@ -17,8 +17,6 @@ struct od_group {
 	char *route_usr;
 	char *route_db;
 
-	char *storage_user;
-	char *storage_db;
 	char *group_name;
 
 	char *group_query;


### PR DESCRIPTION
The fields `storage_user` and `storage_db` in the `od_group` structure and not necessary.  
https://github.com/yandex/odyssey/blob/708c5f6f52372a9a1ca28e32eda62c25c7e29ab6/sources/include/group.h#L20-L21

storage_user and storage_db rule fields  are configured here if defined
https://github.com/yandex/odyssey/blob/708c5f6f52372a9a1ca28e32eda62c25c7e29ab6/sources/config_reader.c#L2242-L2255

At the same time, Odyssey crashes with a core dump if these fields are not used. I propose to remove these fields.

this second attempt to fix this Segmentation fault

prev: https://github.com/yandex/odyssey/pull/1336
reverted here: https://github.com/yandex/odyssey/pull/1339

Now functional tests pass without errors.
```
odyssey_1    | ======================== 44 passed in 993.39s (0:16:33) ========================
Exception in thread Thread-6 (watch_events):
Traceback (most recent call last):
functional_odyssey_1 exited with code 0
```

### Segmentation fault detail
```
./build/sources/odyssey --version
odyssey 1.5.1-rc5 (git cf4fe120) debug -pam -ldap -systemd -prom
compiled by gcc-11.4.0, 64-bit
```
```
git diff ./test/functional/tests/group/config.conf
diff --git a/test/functional/tests/group/config.conf b/test/functional/tests/group/config.conf
index c3b7e4df..b75c5230 100644
--- a/test/functional/tests/group/config.conf
+++ b/test/functional/tests/group/config.conf
@@ -27,8 +27,8 @@ database "group_db" {
             password "password1"

             storage "postgres_server"
-            storage_db "postgres"
-            storage_user "postgres"
+            # storage_db "postgres"
+            # storage_user "postgres"

             pool_routing "client_visible"
             pool "session"
```
```
./build/sources/odyssey ./test/functional/tests/group/config.conf
36057 2026-04-17T21:00:48Z info (startup) none Starting Odyssey
Segmentation fault (core dumped)

gdb ./build/sources/odyssey --core /var/cores/core.odyssey.36057
...
Core was generated by `./build/sources/odyssey ./test/functional/tests/group/config.conf'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
74	../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x000055600706e8d2 in mm_strdup (s=0x0) at /home/duser/odyssey/sources/machinarium/memory.c:187
#2  0x000055600707607d in od_strdup (s=0x0) at /home/duser/odyssey/sources/od_memory.c:28
#3  0x00005560070877c8 in od_config_reader_group (reader=0x7ffc11627e90, db_name=0x55603a1d81e0 "group_db", db_is_default=0, group=0x55603a1d8360, extensions=0x55603a1576c0) at /home/duser/odyssey/sources/config_reader.c:2728
#4  0x0000556007087e12 in od_config_reader_database (reader=0x7ffc11627e90, extensions=0x55603a1576c0) at /home/duser/odyssey/sources/config_reader.c:3071
#5  0x0000556007088b11 in od_config_reader_parse (reader=0x7ffc11627e90, extensions=0x55603a1576c0) at /home/duser/odyssey/sources/config_reader.c:3640
#6  0x0000556007088ed9 in od_config_reader_import (config=0x55603a156318, rules=0x7ffc11628128, error=0x7ffc11628200, extensions=0x55603a1576c0, global=0x55603a1d31a0, hba_rules=0x7ffc116280e8,
    config_file=0x55603a156900 "./test/functional/tests/group/config.conf") at /home/duser/odyssey/sources/config_reader.c:3731
#7  0x00005560070c0ace in od_instance_main (instance=0x55603a1562a0, argc=2, argv=0x7ffc11628678, envp=0x7ffc11628690) at /home/duser/odyssey/sources/instance.c:374
#8  0x00005560070df094 in main (argc=2, argv=0x7ffc11628678, envp=0x7ffc11628690) at /home/duser/odyssey/sources/main.c:62
(gdb) j 3
The program is not being run.
(gdb) f 3
#3  0x00005560070877c8 in od_config_reader_group (reader=0x7ffc11627e90, db_name=0x55603a1d81e0 "group_db", db_is_default=0, group=0x55603a1d8360, extensions=0x55603a1576c0) at /home/duser/odyssey/sources/config_reader.c:2728
2728		group->storage_db = od_strdup(rule->storage_db);
(gdb) p group->storage_db
$1 = 0x0
(gdb) p group->storage_user
$2 = 0x0
```