### PR TITLE
Cond refactoring

### DIFF
--- a/sources/include/machinarium/call.h
+++ b/sources/include/machinarium/call.h
@@ -16,7 +16,7 @@ typedef struct mm_call mm_call_t;
 typedef void (*mm_cancel_t)(void *, void *arg);
 
 typedef enum {
-	MM_CALL_NONE,
+	MM_CALL_NONE = 0,
 	MM_CALL_SIGNAL,
 	MM_CALL_EVENT,
 	MM_CALL_SLEEP,
@@ -30,7 +30,6 @@ typedef enum {
 struct mm_call {
 	mm_calltype_t type;
 	mm_coroutine_t *coroutine;
-	mm_timer_t timer;
 	mm_cancel_t cancel_function;
 	void *arg;
 	void *data;

--- a/sources/include/machinarium/cond.h
+++ b/sources/include/machinarium/cond.h
@@ -13,6 +13,7 @@
 #include <machinarium/call.h>
 #include <machinarium/scheduler.h>
 #include <machinarium/machine.h>
+#include <machinarium/list.h>
 
 typedef struct mm_cond mm_cond_t;
 
@@ -22,8 +23,13 @@ enum {
 	MM_COND_WAIT_OK_PROPAGATED = 1
 };
 
-struct mm_cond {
+typedef struct {
+	mm_list_t link;
 	mm_call_t call;
+} mm_cond_awaiter_t;
+
+struct mm_cond {
+	mm_list_t awaiters;
 	mm_cond_t *propagate;
 	/* is signal came directly or as for propagated cond? */
 	int propagated;
@@ -33,7 +39,7 @@ static inline void mm_cond_init(mm_cond_t *cond)
 {
 	cond->propagate = NULL;
 	cond->propagated = 0;
-	memset(&cond->call, 0, sizeof(cond->call));
+	mm_list_init(&cond->awaiters);
 }
 
 void mm_cond_signal(mm_cond_t *cond, mm_scheduler_t *sched);
@@ -43,23 +49,8 @@ static inline void mm_cond_propagate(mm_cond_t *src, mm_cond_t *dst)
 	src->propagate = dst;
 }
 
-static inline int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
-{
-	mm_errno_set(0);
-	if (cond->call.type != MM_CALL_NONE) {
-		mm_errno_set(EINPROGRESS);
-		return MM_COND_WAIT_FAIL;
-	}
-	cond->propagated = 0;
-	mm_call(&cond->call, MM_CALL_COND, time_ms);
-	if (cond->call.status != 0) {
-		return MM_COND_WAIT_FAIL;
-	}
-
-	if (cond->propagated) {
-		cond->propagated = 0;
-		return MM_COND_WAIT_OK_PROPAGATED;
-	}
-
-	return MM_COND_WAIT_OK;
-}
+/*
+ * spirious wakeups are possible
+ * (when awaiting one cond from several coroutines)
+ */
+int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms);

--- a/sources/include/machinarium/cond.h
+++ b/sources/include/machinarium/cond.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <errno.h>
+#include <assert.h>
 
 #include <machinarium/call.h>
 #include <machinarium/scheduler.h>
@@ -33,6 +34,15 @@ struct mm_cond {
 	mm_cond_t *propagate;
 	/* is signal came directly or as for propagated cond? */
 	int propagated;
+#ifndef NDEBUG
+	/*
+	 * Cond must always be used from one machine (one cooperative
+	 * scheduler). Set on first mm_cond_wait, cleared when the awaiters
+	 * list empties so the cond can migrate to another machine after
+	 * od_io_detach / od_io_attach.
+	 */
+	mm_machine_t *owner;
+#endif
 };
 
 static inline void mm_cond_init(mm_cond_t *cond)
@@ -40,6 +50,9 @@ static inline void mm_cond_init(mm_cond_t *cond)
 	cond->propagate = NULL;
 	cond->propagated = 0;
 	mm_list_init(&cond->awaiters);
+#ifndef NDEBUG
+	cond->owner = NULL;
+#endif
 }
 
 void mm_cond_signal(mm_cond_t *cond, mm_scheduler_t *sched);
@@ -50,7 +63,7 @@ static inline void mm_cond_propagate(mm_cond_t *src, mm_cond_t *dst)
 }
 
 /*
- * spirious wakeups are possible
- * (when awaiting one cond from several coroutines)
+ * Spurious wakeups are possible when awaiting one cond from several
+ * coroutines.
  */
 int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms);

--- a/sources/include/machinarium/cond.h
+++ b/sources/include/machinarium/cond.h
@@ -27,13 +27,12 @@ enum {
 typedef struct {
 	mm_list_t link;
 	mm_call_t call;
+	int propagated;
 } mm_cond_awaiter_t;
 
 struct mm_cond {
 	mm_list_t awaiters;
 	mm_cond_t *propagate;
-	/* is signal came directly or as for propagated cond? */
-	int propagated;
 #ifndef NDEBUG
 	/*
 	 * Cond must always be used from one machine (one cooperative
@@ -48,7 +47,6 @@ struct mm_cond {
 static inline void mm_cond_init(mm_cond_t *cond)
 {
 	cond->propagate = NULL;
-	cond->propagated = 0;
 	mm_list_init(&cond->awaiters);
 #ifndef NDEBUG
 	cond->owner = NULL;

--- a/sources/machinarium/call.c
+++ b/sources/machinarium/call.c
@@ -15,6 +15,11 @@
 static void mm_call_timer_cb(mm_timer_t *handle)
 {
 	mm_call_t *call = handle->arg;
+
+	if (call->type == MM_CALL_NONE) {
+		return;
+	}
+
 	call->timedout = 1;
 	call->status = ETIMEDOUT;
 	if (call->coroutine) {
@@ -26,6 +31,11 @@ static void mm_call_cancel_cb(void *obj, void *arg)
 {
 	mm_call_t *call = arg;
 	(void)obj;
+
+	if (call->type == MM_CALL_NONE) {
+		return;
+	}
+
 	call->status = ECANCELED;
 	if (call->coroutine) {
 		mm_scheduler_wakeup(&mm_self->scheduler, call->coroutine);
@@ -60,12 +70,13 @@ void mm_call(mm_call_t *call, mm_calltype_t type, uint32_t time_ms)
 		return;
 	}
 
-	mm_timer_init(&call->timer, mm_call_timer_cb, call, time_ms);
+	mm_timer_t timer;
+	mm_timer_init(&timer, mm_call_timer_cb, call, time_ms);
 	if (time_ms != UINT32_MAX) {
-		mm_timer_start(clock, &call->timer);
+		mm_timer_start(clock, &timer);
 	}
 	mm_scheduler_yield(scheduler);
-	mm_timer_stop(&call->timer);
+	mm_timer_stop(&timer);
 
 	call->type = MM_CALL_NONE;
 	call->coroutine = NULL;

--- a/sources/machinarium/cond.c
+++ b/sources/machinarium/cond.c
@@ -89,6 +89,9 @@ static inline void signal_impl(mm_cond_t *cond, mm_scheduler_t *sched,
 
 void mm_cond_signal(mm_cond_t *cond, mm_scheduler_t *sched)
 {
+#ifndef NDEBUG
+	assert(cond->owner == NULL || cond->owner == mm_self);
+#endif
 	mm_cond_t *history[32];
 
 	signal_impl(cond, sched, 0, history, 0,
@@ -97,6 +100,10 @@ void mm_cond_signal(mm_cond_t *cond, mm_scheduler_t *sched)
 
 int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
 {
+#ifndef NDEBUG
+	assert(cond->owner == NULL || cond->owner == mm_self);
+	cond->owner = mm_self;
+#endif
 	mm_errno_set(0);
 	cond->propagated = 0;
 
@@ -109,6 +116,12 @@ int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
 	mm_call(&awaiter.call, MM_CALL_COND, time_ms);
 
 	mm_list_unlink(&awaiter.link);
+
+#ifndef NDEBUG
+	/* allow migration to another machine after detach/attach cycle */
+	if (cond->awaiters.next == &cond->awaiters)
+		cond->owner = NULL;
+#endif
 
 	if (awaiter.call.status != 0) {
 		return MM_COND_WAIT_FAIL;

--- a/sources/machinarium/cond.c
+++ b/sources/machinarium/cond.c
@@ -76,8 +76,8 @@ static inline void signal_impl(mm_cond_t *cond, mm_scheduler_t *sched,
 		}
 	}
 
-	mm_list_t *i;
-	mm_list_foreach (&cond->awaiters, i) {
+	mm_list_t *i, *n;
+	mm_list_foreach_safe (&cond->awaiters, i, n) {
 		mm_cond_awaiter_t *awaiter;
 		awaiter = mm_container_of(i, mm_cond_awaiter_t, link);
 

--- a/sources/machinarium/cond.c
+++ b/sources/machinarium/cond.c
@@ -76,13 +76,12 @@ static inline void signal_impl(mm_cond_t *cond, mm_scheduler_t *sched,
 		}
 	}
 
-	cond->propagated = propagated;
-
 	mm_list_t *i;
 	mm_list_foreach (&cond->awaiters, i) {
 		mm_cond_awaiter_t *awaiter;
 		awaiter = mm_container_of(i, mm_cond_awaiter_t, link);
 
+		awaiter->propagated = propagated;
 		mm_scheduler_wakeup(sched, awaiter->call.coroutine);
 	}
 }
@@ -126,8 +125,7 @@ int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
 		return MM_COND_WAIT_FAIL;
 	}
 
-	if (cond->propagated) {
-		cond->propagated = 0;
+	if (awaiter.propagated) {
 		return MM_COND_WAIT_OK_PROPAGATED;
 	}
 

--- a/sources/machinarium/cond.c
+++ b/sources/machinarium/cond.c
@@ -105,7 +105,6 @@ int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
 	cond->owner = mm_self;
 #endif
 	mm_errno_set(0);
-	cond->propagated = 0;
 
 	mm_cond_awaiter_t awaiter;
 	memset(&awaiter, 0, sizeof(mm_cond_awaiter_t));

--- a/sources/machinarium/cond.c
+++ b/sources/machinarium/cond.c
@@ -44,11 +44,6 @@ MACHINE_API void machine_cond_signal(machine_cond_t *obj)
 MACHINE_API int machine_cond_wait(machine_cond_t *obj, uint32_t time_ms)
 {
 	mm_cond_t *cond = mm_cast(mm_cond_t *, obj);
-	mm_errno_set(0);
-	if (cond->call.type != MM_CALL_NONE) {
-		mm_errno_set(EINPROGRESS);
-		return -1;
-	}
 	return mm_cond_wait(cond, time_ms);
 }
 
@@ -80,9 +75,15 @@ static inline void signal_impl(mm_cond_t *cond, mm_scheduler_t *sched,
 				    history, depth, max);
 		}
 	}
+
 	cond->propagated = propagated;
-	if (cond->call.type == MM_CALL_COND) {
-		mm_scheduler_wakeup(sched, cond->call.coroutine);
+
+	mm_list_t *i;
+	mm_list_foreach (&cond->awaiters, i) {
+		mm_cond_awaiter_t *awaiter;
+		awaiter = mm_container_of(i, mm_cond_awaiter_t, link);
+
+		mm_scheduler_wakeup(sched, awaiter->call.coroutine);
 	}
 }
 
@@ -92,4 +93,31 @@ void mm_cond_signal(mm_cond_t *cond, mm_scheduler_t *sched)
 
 	signal_impl(cond, sched, 0, history, 0,
 		    sizeof(history) / sizeof(history[0]));
+}
+
+int mm_cond_wait(mm_cond_t *cond, uint32_t time_ms)
+{
+	mm_errno_set(0);
+	cond->propagated = 0;
+
+	mm_cond_awaiter_t awaiter;
+	memset(&awaiter, 0, sizeof(mm_cond_awaiter_t));
+	mm_list_init(&awaiter.link);
+
+	mm_list_append(&cond->awaiters, &awaiter.link);
+
+	mm_call(&awaiter.call, MM_CALL_COND, time_ms);
+
+	mm_list_unlink(&awaiter.link);
+
+	if (awaiter.call.status != 0) {
+		return MM_COND_WAIT_FAIL;
+	}
+
+	if (cond->propagated) {
+		cond->propagated = 0;
+		return MM_COND_WAIT_OK_PROPAGATED;
+	}
+
+	return MM_COND_WAIT_OK;
 }

--- a/sources/tests/machinarium/test_condition0.c
+++ b/sources/tests/machinarium/test_condition0.c
@@ -1,5 +1,7 @@
 
 #include <machinarium/machinarium.h>
+#include <machinarium/cond.h>
+#include <machinarium/wait_flag.h>
 #include <tests/odyssey_test.h>
 
 static machine_cond_t *condition = NULL;
@@ -29,10 +31,8 @@ static void test_waiter(void *arg)
 	machine_stop_current();
 }
 
-void machinarium_test_condition0(void)
+static void test_simple(void)
 {
-	machinarium_init();
-
 	int id;
 	id = machine_create("test", test_waiter, NULL);
 	test(id != -1);
@@ -40,6 +40,152 @@ void machinarium_test_condition0(void)
 	int rc;
 	rc = machine_wait(id);
 	test(rc != -1);
+}
+
+atomic_uint_fast64_t success_counter;
+atomic_uint_fast64_t timeout_counter;
+
+static void awaiter_success(void *arg)
+{
+	mm_cond_t *cond = arg;
+
+	int rc = mm_cond_wait(cond, UINT32_MAX);
+	test(rc == 0);
+
+	atomic_fetch_add(&success_counter, 1);
+}
+
+typedef struct {
+	mm_cond_t *cond;
+	mm_wait_flag_t *end_flag;
+} timeout_arg_t;
+
+static void awaiter_timeout(void *arg)
+{
+	timeout_arg_t *a = arg;
+	mm_cond_t *cond = a->cond;
+
+	int rc = mm_cond_wait(cond, 100);
+	test(rc == -1 && machine_errno() == ETIMEDOUT);
+
+	atomic_fetch_add(&timeout_counter, 1);
+
+	mm_wait_flag_set(a->end_flag);
+}
+
+static void several_awaiters(void *a)
+{
+	(void)a;
+
+	mm_cond_t cond;
+	mm_cond_init(&cond);
+
+	atomic_init(&success_counter, 0);
+
+	int64_t a1;
+	a1 = machine_coroutine_create(awaiter_success, &cond);
+	test(a1 != -1);
+	machine_sleep(0);
+
+	int64_t a2;
+	a2 = machine_coroutine_create(awaiter_success, &cond);
+	test(a2 != -1);
+	machine_sleep(0);
+
+	int64_t a3;
+	a3 = machine_coroutine_create(awaiter_success, &cond);
+	test(a3 != -1);
+	machine_sleep(0);
+
+	mm_cond_signal(&cond, &mm_self->scheduler);
+
+	int rc = machine_join(a1);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a2);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a3);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+
+	test(atomic_load(&success_counter) == 3);
+}
+
+static void test_several_awaiters(void)
+{
+	int id;
+	id = machine_create("several_awaiter", several_awaiters, NULL);
+	test(id != -1);
+
+	int rc;
+	rc = machine_wait(id);
+	test(rc != -1);
+}
+
+static void several_awaiters_timeout(void *a)
+{
+	(void)a;
+
+	mm_cond_t cond;
+	mm_cond_init(&cond);
+
+	atomic_init(&success_counter, 0);
+	atomic_init(&timeout_counter, 0);
+
+	timeout_arg_t targ;
+	targ.cond = &cond;
+	targ.end_flag = mm_wait_flag_create();
+
+	int64_t a1;
+	a1 = machine_coroutine_create(awaiter_timeout, &targ);
+	test(a1 != -1);
+	machine_sleep(0);
+
+	int64_t a2;
+	a2 = machine_coroutine_create(awaiter_success, &cond);
+	test(a2 != -1);
+	machine_sleep(0);
+
+	int64_t a3;
+	a3 = machine_coroutine_create(awaiter_success, &cond);
+	test(a3 != -1);
+	machine_sleep(0);
+
+	mm_wait_flag_wait(targ.end_flag, UINT32_MAX);
+
+	mm_cond_signal(&cond, &mm_self->scheduler);
+
+	int rc = machine_join(a1);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a2);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a3);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+
+	test(atomic_load(&success_counter) == 2);
+	test(atomic_load(&timeout_counter) == 1);
+
+	mm_wait_flag_destroy(targ.end_flag);
+}
+
+static void test_several_awaiters_timeout(void)
+{
+	int id;
+	id = machine_create("several_awaiter", several_awaiters_timeout, NULL);
+	test(id != -1);
+
+	int rc;
+	rc = machine_wait(id);
+	test(rc != -1);
+}
+
+void machinarium_test_condition0(void)
+{
+	machinarium_init();
+
+	test_simple();
+
+	test_several_awaiters();
+
+	test_several_awaiters_timeout();
 
 	machinarium_free();
 }

--- a/sources/tests/machinarium/test_condition0.c
+++ b/sources/tests/machinarium/test_condition0.c
@@ -177,6 +177,73 @@ static void test_several_awaiters_timeout(void)
 	test(rc != -1);
 }
 
+atomic_uint_fast64_t propagated_counter;
+
+static void awaiter_propagated(void *arg)
+{
+	mm_cond_t *cond = arg;
+
+	int rc = mm_cond_wait(cond, UINT32_MAX);
+	test(rc == MM_COND_WAIT_OK_PROPAGATED);
+
+	atomic_fetch_add(&propagated_counter, 1);
+}
+
+/*
+ * Signal src cond that propagates to dst; several coroutines wait on dst.
+ * All of them must receive MM_COND_WAIT_OK_PROPAGATED, not MM_COND_WAIT_OK.
+ *
+ * This exercises the bug where cond->propagated is a single shared flag:
+ * the first waiter to run resets it to 0, so subsequent waiters see 0 and
+ * return MM_COND_WAIT_OK instead of MM_COND_WAIT_OK_PROPAGATED.
+ */
+static void several_awaiters_propagated(void *a)
+{
+	(void)a;
+
+	mm_cond_t src, dst;
+	mm_cond_init(&src);
+	mm_cond_init(&dst);
+	mm_cond_propagate(&src, &dst);
+
+	atomic_init(&propagated_counter, 0);
+
+	int64_t a1 = machine_coroutine_create(awaiter_propagated, &dst);
+	test(a1 != -1);
+	machine_sleep(0);
+
+	int64_t a2 = machine_coroutine_create(awaiter_propagated, &dst);
+	test(a2 != -1);
+	machine_sleep(0);
+
+	int64_t a3 = machine_coroutine_create(awaiter_propagated, &dst);
+	test(a3 != -1);
+	machine_sleep(0);
+
+	mm_cond_signal(&src, &mm_self->scheduler);
+
+	int rc = machine_join(a1);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a2);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+	rc = machine_join(a3);
+	test(rc == 0 || (rc == -1 && machine_errno() == ENOENT));
+
+	test(atomic_load(&propagated_counter) == 3);
+}
+
+static void test_several_awaiters_propagated(void)
+{
+	int id;
+	id = machine_create("several_awaiter_propagated",
+			    several_awaiters_propagated, NULL);
+	test(id != -1);
+
+	int rc;
+	rc = machine_wait(id);
+	test(rc != -1);
+}
+
 void machinarium_test_condition0(void)
 {
 	machinarium_init();
@@ -186,6 +253,8 @@ void machinarium_test_condition0(void)
 	test_several_awaiters();
 
 	test_several_awaiters_timeout();
+
+	test_several_awaiters_propagated();
 
 	machinarium_free();
 }


### PR DESCRIPTION
Replace the single embedded mm_call_t in mm_cond_t with a linked list of
mm_cond_awaiter_t, each holding its own mm_call_t on the waiter stack.
mm_cond_signal now broadcasts to all awaiters. Spurious wakeups are
possible when several coroutines share one cond.

Also move mm_timer_t out of mm_call_t onto the stack of mm_call() to
reduce struct size. Add MM_CALL_NONE = 0 for zero-init compatibility and
guards in timer/cancel callbacks against double-wakeup (signal + timeout
in the same event-loop tick).

Known limitation: cond->propagated is a single flag shared across all
awaiters; with N waiters only the first to run after a propagated signal
returns MM_COND_WAIT_OK_PROPAGATED, the rest get MM_COND_WAIT_OK.

Signed-off-by: roman khapov <r.khapov@ya.ru>