### PR TITLE
preallocate slots for async logging

### DIFF
--- a/sources/config.c
+++ b/sources/config.c
@@ -31,6 +31,8 @@ void od_config_init(od_config_t *config)
 	config->log_query = 0;
 	config->log_file = NULL;
 	config->log_stats = 1;
+	config->log_async = 1;
+	config->log_queue_depth = 30000;
 	config->log_general_stats_prom = 0;
 	config->log_route_stats_prom = 0;
 	config->stats_interval = 3;

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -47,6 +47,8 @@ typedef enum {
 	OD_LLOG_FILE,
 	OD_LLOG_FORMAT,
 	OD_LLOG_STATS,
+	OD_LLOG_ASYNC,
+	OD_LLOG_QUEUE_DEPTH,
 
 	/* Prometheus */
 	OD_LLOG_GENERAL_STATS_PROM,
@@ -248,6 +250,8 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("log_file", OD_LLOG_FILE),
 	od_keyword("log_format", OD_LLOG_FORMAT),
 	od_keyword("log_stats", OD_LLOG_STATS),
+	od_keyword("log_async", OD_LLOG_ASYNC),
+	od_keyword("log_queue_depth", OD_LLOG_QUEUE_DEPTH),
 	od_keyword("log_syslog", OD_LLOG_SYSLOG),
 	od_keyword("log_syslog_ident", OD_LLOG_SYSLOG_IDENT),
 	od_keyword("log_syslog_facility", OD_LLOG_SYSLOG_FACILITY),
@@ -3373,6 +3377,20 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 		case OD_LLOG_STATS:
 			if (!od_config_reader_yes_no(reader,
 						     &config->log_stats)) {
+				goto error;
+			}
+			continue;
+		/* log_async */
+		case OD_LLOG_ASYNC:
+			if (!od_config_reader_yes_no(reader,
+						     &config->log_async)) {
+				goto error;
+			}
+			continue;
+		/* log_queue_depth */
+		case OD_LLOG_QUEUE_DEPTH:
+			if (!od_config_reader_number(
+				    reader, &config->log_queue_depth)) {
 				goto error;
 			}
 			continue;

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -82,8 +82,9 @@ static int od_cron_stat_cb(od_route_t *route, od_stat_t *current,
 		if (instance->config.log_route_stats_prom) {
 			char *prom_log =
 				(char *)od_prom_metrics_get_stat_cb(metrics);
-			od_logger_write_plain(&instance->logger, OD_LOG,
-					      "stats", NULL, NULL, prom_log);
+			va_list empty_va = { 0 };
+			od_logger_write(&instance->logger, OD_LOG, "stats",
+					NULL, NULL, prom_log, empty_va);
 			od_free(prom_log);
 		}
 	}
@@ -115,7 +116,7 @@ static inline void send_msg_stat(machine_channel_t *chan)
 
 static inline void request_logger_stats(od_logger_t *logger)
 {
-	send_msg_stat(logger->task_channel);
+	od_logger_stat(logger);
 }
 
 static inline void request_worker_stats(od_worker_pool_t *worker_pool)
@@ -156,8 +157,9 @@ static inline void od_cron_stat(od_cron_t *cron)
 				count_coroutine, count_coroutine_cache);
 			char *prom_log =
 				(char *)od_prom_metrics_get_stat(cron->metrics);
-			od_logger_write_plain(&instance->logger, OD_LOG,
-					      "stats", NULL, NULL, prom_log);
+			va_list empty_va = { 0 };
+			od_logger_write(&instance->logger, OD_LOG, "stats",
+					NULL, NULL, prom_log, va_list);
 			od_free(prom_log);
 		}
 #endif

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -64,6 +64,8 @@ struct od_config {
 	int log_config;
 	int log_session;
 	int log_query;
+	int log_queue_depth;
+	int log_async;
 	char *log_file;
 	char *log_format;
 	int log_stats;

--- a/sources/include/logger.h
+++ b/sources/include/logger.h
@@ -6,9 +6,11 @@
  * Scalable PostgreSQL connection pooler.
  */
 
-#include <machinarium/machinarium.h>
+#include <machinarium/ds/queue.h>
+#include <machinarium/wait_list.h>
 
 #include <types.h>
+#include <list.h>
 #include <pid.h>
 
 #define OD_LOGLINE_MAXLEN 1024
@@ -24,25 +26,45 @@ typedef enum {
 	OD_LOGGER_FORMAT_JSON
 } od_logger_format_type_t;
 
+typedef struct {
+	od_logger_level_t level;
+	od_list_t link;
+	size_t len;
+	char text[OD_LOGLINE_MAXLEN];
+} od_logger_slot_t;
+
 struct od_logger {
 	od_pid_t *pid;
 	int log_debug;
 	int log_stdout;
 	int log_syslog;
+	int async;
+	int queue_depth;
 	char *format;
 	int format_len;
 	od_logger_format_type_t format_type;
 
 	int fd;
 
-	int loaded;
+	atomic_uint_fast64_t loaded;
 	int64_t machine;
-	/* makes sense only with use_asynclog option on */
-	machine_channel_t *task_channel;
+
+	od_logger_slot_t *slots;
+	mm_queue_t tasks;
+
+	od_list_t free_slots;
+	size_t free_slots_count;
+	pthread_spinlock_t free_slots_lock;
+
+	mm_wait_list_t notifier;
+
+	atomic_uint_fast64_t dropped_lines;
 };
 
 extern od_retcode_t od_logger_init(od_logger_t *, od_pid_t *);
 extern od_retcode_t od_logger_load(od_logger_t *logger);
+
+void od_logger_stat(od_logger_t *logger);
 
 static inline void od_logger_set_debug(od_logger_t *logger, int enable)
 {
@@ -67,6 +89,21 @@ static inline void od_logger_set_format(od_logger_t *logger, char *format)
 	}
 }
 
+static inline void od_logger_set_async(od_logger_t *logger, int async)
+{
+	logger->async = async;
+}
+
+static inline void od_logger_set_queue_depth(od_logger_t *logger,
+					     int queue_depth)
+{
+	if (queue_depth <= 0) {
+		queue_depth = 30000;
+	}
+
+	logger->queue_depth = queue_depth;
+}
+
 extern int od_logger_open(od_logger_t *, char *);
 extern int od_logger_reopen(od_logger_t *, char *);
 extern int od_logger_open_syslog(od_logger_t *, char *, char *);
@@ -74,8 +111,6 @@ extern void od_logger_shutdown(od_logger_t *);
 extern void od_logger_close(od_logger_t *);
 extern void od_logger_write(od_logger_t *, od_logger_level_t, char *, void *,
 			    void *, char *, va_list);
-extern void od_logger_write_plain(od_logger_t *, od_logger_level_t, char *,
-				  void *, void *, char *);
 
 void od_logger_wait_finish(od_logger_t *);
 

--- a/sources/include/machinarium/ds/queue.h
+++ b/sources/include/machinarium/ds/queue.h
@@ -38,6 +38,8 @@ int mm_queue_init(mm_queue_t *queue, size_t capacity, size_t elsize,
 void mm_queue_destroy(mm_queue_t *queue);
 
 int mm_queue_push(mm_queue_t *queue, const void *val);
+/* return -1 if no place for value, new number of elements otherwise */
+int mm_queue_push_extended(mm_queue_t *queue, const void *val);
 int mm_queue_pop(mm_queue_t *queue, void *val);
 
 size_t mm_queue_pop_batch(mm_queue_t *queue, void *dst, size_t max);

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -463,6 +463,9 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv,
 	od_logger_set_format(&instance->logger, instance->config.log_format);
 	od_logger_set_debug(&instance->logger, instance->config.log_debug);
 	od_logger_set_stdout(&instance->logger, instance->config.log_to_stdout);
+	od_logger_set_async(&instance->logger, instance->config.log_async);
+	od_logger_set_queue_depth(&instance->logger,
+				  instance->config.log_queue_depth);
 
 	/* syslog */
 	if (instance->config.log_syslog) {

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -58,7 +58,17 @@ od_retcode_t od_logger_init(od_logger_t *logger, od_pid_t *pid)
 	logger->format_len = 0;
 	logger->format_type = OD_LOGGER_FORMAT_TEXT;
 	logger->fd = -1;
-	logger->loaded = 0;
+	atomic_init(&logger->loaded, 0);
+
+	memset(&logger->tasks, 0, sizeof(mm_queue_t));
+	logger->slots = NULL;
+
+	atomic_init(&logger->dropped_lines, 0);
+
+	od_list_init(&logger->free_slots);
+	pthread_spin_init(&logger->free_slots_lock, PTHREAD_PROCESS_PRIVATE);
+
+	mm_wait_list_init(&logger->notifier, NULL);
 
 	/* set temporary format */
 	od_logger_set_format(logger, "%p %t %l (%c) %h %m\n");
@@ -72,26 +82,47 @@ static inline void od_logger(void *arg);
 
 od_retcode_t od_logger_load(od_logger_t *logger)
 {
-	/* we should do this in separate function, after config read and machinauim initialization */
-	logger->task_channel = machine_channel_create();
-	if (logger->task_channel == NULL) {
+	if (!logger->async) {
+		return OK_RESPONSE;
+	}
+
+	if (atomic_load(&logger->loaded) == 1) {
 		return NOT_OK_RESPONSE;
 	}
 
-	machine_channel_assign_limit_policy(logger->task_channel,
-					    OD_LOGGER_TASK_CHANNEL_LIMIT,
-					    MM_CHANNEL_LIMIT_SOFT);
+	int rc = mm_queue_init(&logger->tasks, (size_t)logger->queue_depth,
+			       sizeof(od_logger_slot_t *), NULL);
+	if (rc != 0) {
+		return NOT_OK_RESPONSE;
+	}
+
+	logger->slots =
+		od_malloc(logger->queue_depth * sizeof(od_logger_slot_t));
+	if (logger->slots == NULL) {
+		mm_queue_destroy(&logger->tasks);
+		return NOT_OK_RESPONSE;
+	}
+
+	size_t n = (size_t)logger->queue_depth;
+	for (size_t i = 0; i < n; ++i) {
+		od_logger_slot_t *slot = &logger->slots[i];
+		memset(slot, 0, sizeof(od_logger_slot_t));
+		od_list_init(&slot->link);
+
+		od_list_append(&logger->free_slots, &slot->link);
+	}
+	logger->free_slots_count = n;
 
 	char name[32];
 	od_snprintf(name, sizeof(name), "logger");
 	logger->machine = machine_create(name, od_logger, logger);
 
 	if (logger->machine == -1) {
-		machine_channel_free(logger->task_channel);
+		od_free(logger->slots);
+		mm_queue_destroy(&logger->tasks);
 		return NOT_OK_RESPONSE;
 	}
 
-	logger->loaded = 1;
 	return OK_RESPONSE;
 }
 
@@ -464,15 +495,31 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 	return dst_pos - output;
 }
 
-typedef struct {
-	od_logger_level_t lvl;
-	char msg[FLEXIBLE_ARRAY_MEMBER];
-} _od_log_entry;
-
 static inline size_t od_log_entry_req_size(size_t msg_len)
 {
 	return sizeof(od_logger_level_t) +
 	       sizeof(char) * (msg_len + /* NULL */ 1);
+}
+
+static inline void _od_logger_write_batch(od_logger_t *l,
+					  od_logger_slot_t *slots[],
+					  struct iovec *iovecs, size_t n)
+{
+	int rc;
+	if (l->fd != -1) {
+		rc = writev(l->fd, iovecs, n);
+	}
+	if (l->log_stdout) {
+		rc = writev(STDOUT_FILENO, iovecs, n);
+	}
+	if (l->log_syslog) {
+		for (size_t i = 0; i < n; ++i) {
+			syslog(od_log_syslog_level[slots[i]->level], "%.*s",
+			       (int)iovecs[i].iov_len,
+			       (char *)iovecs[i].iov_base);
+		}
+	}
+	(void)rc;
 }
 
 static inline void _od_logger_write(od_logger_t *l, char *data, int len,
@@ -505,87 +552,69 @@ static inline void log_machine_stats(od_logger_t *logger)
 	od_log(logger, "stats", NULL, NULL,
 	       "logger: msg (%" PRIu64 " allocated, %" PRIu64
 	       " cached, %" PRIu64 " freed, %" PRIu64 " cache_size), "
-	       "coroutines (%" PRIu64 " active, %" PRIu64 " cached)",
+	       "coroutines (%" PRIu64 " active, %" PRIu64 " cached), "
+	       "dropped lines %" PRIu64 ", queue size %" PRIu64,
 	       msg_allocated, msg_cache_count, msg_cache_gc_count,
-	       msg_cache_size, count_coroutine, count_coroutine_cache);
+	       msg_cache_size, count_coroutine, count_coroutine_cache,
+	       atomic_load(&logger->dropped_lines),
+	       mm_queue_size(&logger->tasks));
+}
+
+void od_logger_stat(od_logger_t *logger)
+{
+	log_machine_stats(logger);
 }
 
 static inline void od_logger(void *arg)
 {
 	od_logger_t *logger = arg;
 
-	bool run = true;
+	atomic_store(&logger->loaded, 1);
 
-	while (run) {
-		uint32_t task_wait_timeout_ms = 10 * 1000;
+	while (atomic_load(&logger->loaded) == 1) {
+		static od_logger_slot_t *slot_buf[IOV_MAX];
+		static struct iovec iovecs[IOV_MAX];
+		size_t nmsg =
+			mm_queue_pop_batch(&logger->tasks, slot_buf, IOV_MAX);
 
-		machine_msg_t *msg;
-		msg = machine_channel_read(logger->task_channel,
-					   task_wait_timeout_ms);
-		if (msg == NULL) {
-			od_debug(logger, "logger", NULL, NULL,
-				 "logger: no new messages for %u ms",
-				 task_wait_timeout_ms);
-			continue;
+		for (size_t i = 0; i < nmsg; ++i) {
+			iovecs[i].iov_base = slot_buf[i]->text;
+			iovecs[i].iov_len = slot_buf[i]->len;
 		}
 
-		od_msg_t msg_type;
-		msg_type = machine_msg_type(msg);
-		switch (msg_type) {
-		case OD_MSG_LOG: {
-			_od_log_entry *le = machine_msg_data(msg);
-			int len = strlen(le->msg);
+		_od_logger_write_batch(logger, slot_buf, iovecs, nmsg);
 
-			_od_logger_write(logger, le->msg, len, le->lvl);
-		} break;
-		case OD_MSG_STAT: {
-			log_machine_stats(logger);
-			break;
+		pthread_spin_lock(&logger->free_slots_lock);
+		for (size_t i = 0; i < nmsg; ++i) {
+			od_list_append(&logger->free_slots,
+				       &(slot_buf[i]->link));
 		}
-		case OD_MSG_SHUTDOWN: {
-			/*
-			 * TODO: here we might loose some log message in channel
-			 * that follows shutdown message.
-			 * We will fix that after adding channel half-closing
-			 */
-			run = false;
-			logger->loaded = 0;
-			break;
-		}
-		default: {
-			assert(0);
-		} break;
-		}
+		logger->free_slots_count += nmsg;
+		pthread_spin_unlock(&logger->free_slots_lock);
 
-		machine_msg_free(msg);
+		if (mm_queue_size(&logger->tasks) == 0) {
+			mm_wait_list_wait(&logger->notifier, NULL, 1000);
+		}
 	}
 }
 
 void od_logger_shutdown(od_logger_t *logger)
 {
-	/*
-	 * TODO: for now it is useless function, because there is no
-	 * logger closing waiting in graceful shutdown.
-	 * But after OD_MSG_SHUTDOWN handling will be fully fixed
-	 * there must be a waiting for the full task_channel flushing in the od_logger
-	 */
-
-	if (!logger->loaded) {
-		return;
-	}
-
-	machine_msg_t *msg;
-	msg = machine_msg_create(0);
-	machine_msg_set_type(msg, OD_MSG_SHUTDOWN);
-	machine_channel_write(logger->task_channel, msg);
+	atomic_store(&logger->loaded, 0);
 }
 
 void od_logger_wait_finish(od_logger_t *logger)
 {
+	if (!logger->async) {
+		return;
+	}
+
 	if (machine_wait(logger->machine)) {
 		abort();
 	}
-	machine_channel_free(logger->task_channel);
+	mm_wait_list_destroy(&logger->notifier);
+	mm_queue_destroy(&logger->tasks);
+	od_free(logger->slots);
 }
 
 static char od_logger_json_escape_tab[256] = {
@@ -881,79 +910,55 @@ void od_logger_write(od_logger_t *logger, od_logger_level_t level,
 		}
 	}
 
-	char output[OD_LOGLINE_MAXLEN];
 	int len;
+	char *output;
+	size_t output_max;
+	od_logger_slot_t *async_slot = NULL;
+
+	uint64_t async = atomic_load(&logger->loaded);
+
+	if (async) {
+		pthread_spin_lock(&logger->free_slots_lock);
+		if (logger->free_slots_count > 0) {
+			od_list_t *i = od_list_pop(&logger->free_slots);
+			async_slot = od_container_of(i, od_logger_slot_t, link);
+			logger->free_slots_count--;
+		}
+		pthread_spin_unlock(&logger->free_slots_lock);
+
+		if (async_slot == NULL) {
+			/* silently drop lines for overloaded logger */
+			atomic_fetch_add(&logger->dropped_lines, 1);
+			return;
+		}
+
+		output = async_slot->text;
+		output_max = sizeof(async_slot->text);
+	} else {
+		static OD_THREAD_LOCAL char localoutput[OD_LOGLINE_MAXLEN];
+		output = localoutput;
+		output_max = sizeof(localoutput);
+	}
 
 	/* Choose formatter based on format type */
 	if (logger->format_type == OD_LOGGER_FORMAT_JSON) {
 		len = od_logger_format_json(logger, level, context, client,
 					    server, fmt, args, output,
-					    sizeof(output));
+					    output_max);
 	} else {
 		len = od_logger_format(logger, level, context, client, server,
-				       fmt, args, output, sizeof(output));
+				       fmt, args, output, output_max);
 	}
 
-	if (logger->loaded) {
-		/* create new log event and pass it to logger pool */
-		machine_msg_t *msg;
-		msg = machine_msg_create(od_log_entry_req_size(len));
+	if (async_slot) {
+		async_slot->len = (size_t)len;
+		async_slot->text[len] = '\0';
+		async_slot->level = level;
 
-		machine_msg_set_type(msg, OD_MSG_LOG);
-		_od_log_entry *le = machine_msg_data(msg);
-		strncpy(le->msg, output, len);
-		le->msg[len] = '\0';
-		le->lvl = level;
-
-		machine_channel_write(logger->task_channel, msg);
-	} else {
-		_od_logger_write(logger, output, len, level);
-	}
-}
-
-extern void od_logger_write_plain(od_logger_t *logger, od_logger_level_t level,
-				  char *context, void *client, void *server,
-				  char *string)
-{
-	if (logger->fd == -1 && !logger->log_stdout && !logger->log_syslog) {
-		return;
-	}
-
-	if (level == OD_DEBUG) {
-		int is_debug = logger->log_debug;
-		if (!is_debug) {
-			od_client_t *client_ref = client;
-			od_server_t *server_ref = server;
-			if (client_ref && client_ref->rule) {
-				is_debug = client_ref->rule->log_debug;
-			} else if (server_ref && server_ref->route) {
-				od_route_t *route = server_ref->route;
-				is_debug = route->rule->log_debug;
-			}
+		if (mm_queue_push(&logger->tasks, &async_slot) == 1) {
+			/* we are the first who put the message, lets signal the logger thread */
+			mm_wait_list_notify(&logger->notifier);
 		}
-		if (!is_debug) {
-			return;
-		}
-	}
-
-	int len = strlen(string);
-	char output[len + OD_LOGLINE_MAXLEN];
-	va_list empty_va_list = { 0 };
-	len = od_logger_format(logger, level, context, client, server, string,
-			       empty_va_list, output, len + 100);
-
-	if (logger->loaded) {
-		/* create new log event and pass it to logger pool */
-		machine_msg_t *msg;
-		msg = machine_msg_create(od_log_entry_req_size(len));
-
-		machine_msg_set_type(msg, OD_MSG_LOG);
-		_od_log_entry *le = machine_msg_data(msg);
-		strncpy(le->msg, output, len);
-		le->msg[len] = '\0';
-		le->lvl = level;
-
-		machine_channel_write(logger->task_channel, msg);
 	} else {
 		_od_logger_write(logger, output, len, level);
 	}

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -78,8 +78,6 @@ od_retcode_t od_logger_init(od_logger_t *logger, od_pid_t *pid)
 
 static inline void od_logger(void *arg);
 
-#define OD_LOGGER_TASK_CHANNEL_LIMIT 1 << 8
-
 od_retcode_t od_logger_load(od_logger_t *logger)
 {
 	if (!logger->async) {
@@ -493,12 +491,6 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 	}
 
 	return dst_pos - output;
-}
-
-static inline size_t od_log_entry_req_size(size_t msg_len)
-{
-	return sizeof(od_logger_level_t) +
-	       sizeof(char) * (msg_len + /* NULL */ 1);
 }
 
 static inline void _od_logger_write_batch(od_logger_t *l,

--- a/sources/machinarium/ds/queue.c
+++ b/sources/machinarium/ds/queue.c
@@ -74,6 +74,8 @@ void mm_queue_destroy(mm_queue_t *q)
 
 	pthread_spin_destroy(&q->lock);
 	mm_free(q->buf);
+
+	q->buf = NULL;
 }
 
 int mm_queue_push(mm_queue_t *q, const void *val)
@@ -90,6 +92,26 @@ int mm_queue_push(mm_queue_t *q, const void *val)
 		++q->size;
 
 		rc = 1;
+	}
+
+	queue_unlock(q);
+
+	return rc;
+}
+
+int mm_queue_push_extended(mm_queue_t *q, const void *val)
+{
+	int rc = -1;
+
+	queue_lock(q);
+
+	if (q->size < q->cap) {
+		void *dst = &q->buf[q->tail];
+		memcpy(dst, val, q->elsize);
+		q->tail += q->elsize;
+		q->tail &= q->mask;
+
+		rc = (int)(++q->size);
 	}
 
 	queue_unlock(q);


### PR DESCRIPTION
    Each line for log required an allocation of msg,
    which leads to performance degradation.
    
    This patch adds preallocated slots for logger
    (count of that slots can be configures with log_queue_depth)
    and writing batch of logs with writev, which increases performance
    for log-intensive cases, ex with log_debug on:
    
    Before:
    progress: 19.0 s, 11585.7 tps, lat 0.172 ms stddev 0.029, 0 failed
    progress: 20.0 s, 12315.0 tps, lat 0.162 ms stddev 0.025, 0 failed
    progress: 21.0 s, 10755.8 tps, lat 0.186 ms stddev 0.033, 0 failed
    
    After:
    progress: 5.0 s, 14295.0 tps, lat 0.140 ms stddev 0.033, 0 failed
    progress: 6.0 s, 14906.0 tps, lat 0.134 ms stddev 0.027, 0 failed
    progress: 7.0 s, 15060.8 tps, lat 0.133 ms stddev 0.032, 0 failed
    
    Signed-off-by: roman khapov <r.khapov@ya.ru>