### PR TITLE
fix: correctly parse SASL mechanism list for TLS connections

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -246,6 +246,7 @@ set(od_test_src
     tests/odyssey_test.c
     tests/kiwi/test_kiwi_enquote.c
     tests/kiwi/test_kiwi_pgoptions.c
+    tests/kiwi/test_kiwi_fe_read_auth.c
     tests/machinarium/test_init.c
     tests/machinarium/test_create0.c
     tests/machinarium/test_create1.c

--- a/sources/include/kiwi/fe_read.h
+++ b/sources/include/kiwi/fe_read.h
@@ -102,12 +102,24 @@ KIWI_API static inline int kiwi_fe_read_auth(char *data, uint32_t size,
 		{
 			char *mechanism = pos;
 			int found = 0;
-			while (*mechanism && (size_t)(mechanism - pos) < pos_size) {
+			size_t offset = 0;
+			while (offset < pos_size && mechanism[0] != '\0') {
+				/* Find the end of this mechanism string safely */
+				size_t len = 0;
+				while (offset + len < pos_size &&
+				       mechanism[len] != '\0') {
+					len++;
+				}
+				/* Check if we found null terminator within bounds */
+				if (offset + len >= pos_size) {
+					break;
+				}
 				if (strcmp(mechanism, "SCRAM-SHA-256") == 0) {
 					found = 1;
 					break;
 				}
-				mechanism += strlen(mechanism) + 1;
+				offset += len + 1;
+				mechanism += len + 1;
 			}
 			if (!found) {
 				return -1;

--- a/sources/include/kiwi/fe_read.h
+++ b/sources/include/kiwi/fe_read.h
@@ -95,10 +95,23 @@ KIWI_API static inline int kiwi_fe_read_auth(char *data, uint32_t size,
 		return 0;
 	/* AuthenticationSASL */
 	case 10:
-		/* SCRAM-SHA-256 is the only implemented SASL mechanism in
-			 * PostgreSQL, at the moment */
-		if (strcmp(pos, "SCRAM-SHA-256") != 0) {
-			return -1;
+		/* PostgreSQL sends a list of SASL mechanisms as null-terminated
+		 * strings. When TLS is enabled, PostgreSQL sends the list:
+		 * ["SCRAM-SHA-256-PLUS", "SCRAM-SHA-256", ""].
+		 * We need to iterate through the list to find SCRAM-SHA-256. */
+		{
+			char *mechanism = pos;
+			int found = 0;
+			while (*mechanism && (size_t)(mechanism - pos) < pos_size) {
+				if (strcmp(mechanism, "SCRAM-SHA-256") == 0) {
+					found = 1;
+					break;
+				}
+				mechanism += strlen(mechanism) + 1;
+			}
+			if (!found) {
+				return -1;
+			}
 		}
 		return 0;
 	/* AuthenticationSASLContinue */

--- a/sources/tests/kiwi/test_kiwi_fe_read_auth.c
+++ b/sources/tests/kiwi/test_kiwi_fe_read_auth.c
@@ -196,6 +196,43 @@ void test_sasl_scram_sha_256_third(void)
 	test(type == 10);
 }
 
+/* Test: Malformed packet - no null terminator within bounds (should fail safely) */
+void test_sasl_malformed_no_null_terminator(void)
+{
+	char buf[128];
+
+	/* Build a malformed message manually - mechanism string without null */
+	buf[0] = KIWI_BE_AUTHENTICATION;
+
+	/* Length = 4 + 4 + 10 (no null terminator in mechanism) */
+	uint32_t len = 4 + 4 + 10;
+	buf[1] = (len >> 24) & 0xFF;
+	buf[2] = (len >> 16) & 0xFF;
+	buf[3] = (len >> 8) & 0xFF;
+	buf[4] = len & 0xFF;
+
+	/* Auth type = 10 */
+	buf[5] = 0;
+	buf[6] = 0;
+	buf[7] = 0;
+	buf[8] = 10;
+
+	/* Mechanism data without null terminator - just fill with 'A' */
+	memset(buf + 9, 'A', 10);
+
+	uint32_t total_len = 1 + 4 + 4 + 10;
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	/* Should fail safely without reading past buffer */
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == -1);
+}
+
 void kiwi_test_fe_read_auth(void)
 {
 	test_sasl_single_scram_sha_256();
@@ -205,4 +242,5 @@ void kiwi_test_fe_read_auth(void)
 	test_sasl_scram_sha_256_plus_only();
 	test_sasl_empty_list();
 	test_sasl_scram_sha_256_third();
+	test_sasl_malformed_no_null_terminator();
 }

--- a/sources/tests/kiwi/test_kiwi_fe_read_auth.c
+++ b/sources/tests/kiwi/test_kiwi_fe_read_auth.c
@@ -1,0 +1,208 @@
+/*
+ * Test for kiwi_fe_read_auth SASL mechanism list parsing.
+ *
+ * PostgreSQL sends a list of SASL mechanisms as null-terminated strings
+ * in the AuthenticationSASL message. When TLS is enabled, PostgreSQL
+ * sends: ["SCRAM-SHA-256-PLUS", "SCRAM-SHA-256", ""].
+ *
+ * This test verifies that the parser correctly handles:
+ * 1. Single mechanism (SCRAM-SHA-256 only)
+ * 2. Multiple mechanisms with SCRAM-SHA-256 first
+ * 3. Multiple mechanisms with SCRAM-SHA-256-PLUS first (TLS case)
+ * 4. Unsupported mechanisms only
+ */
+
+#include <kiwi/kiwi.h>
+#include <tests/odyssey_test.h>
+
+/*
+ * Helper to build an AuthenticationSASL message.
+ * Format: 'R' (1 byte) + length (4 bytes, big-endian) + type (4 bytes) + mechanisms
+ */
+static void build_auth_sasl_message(char *buf, uint32_t *total_len,
+				    const char *mechanisms, size_t mech_len)
+{
+	/* Message type */
+	buf[0] = KIWI_BE_AUTHENTICATION;
+
+	/* Length = 4 (length itself) + 4 (auth type) + mechanism data */
+	uint32_t len = 4 + 4 + mech_len;
+	buf[1] = (len >> 24) & 0xFF;
+	buf[2] = (len >> 16) & 0xFF;
+	buf[3] = (len >> 8) & 0xFF;
+	buf[4] = len & 0xFF;
+
+	/* Auth type = 10 (AuthenticationSASL) */
+	buf[5] = 0;
+	buf[6] = 0;
+	buf[7] = 0;
+	buf[8] = 10;
+
+	/* Mechanism list */
+	memcpy(buf + 9, mechanisms, mech_len);
+
+	*total_len = 1 + 4 + 4 + mech_len;
+}
+
+/* Test: Single SCRAM-SHA-256 mechanism (should succeed) */
+void test_sasl_single_scram_sha_256(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-256\0" */
+	const char mechanisms[] = "SCRAM-SHA-256";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == 0);
+	test(type == 10);
+}
+
+/* Test: Multiple mechanisms with SCRAM-SHA-256 first (should succeed) */
+void test_sasl_scram_sha_256_first(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-256\0SCRAM-SHA-256-PLUS\0\0" */
+	const char mechanisms[] = "SCRAM-SHA-256\0SCRAM-SHA-256-PLUS\0";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == 0);
+	test(type == 10);
+}
+
+/* Test: SCRAM-SHA-256-PLUS first, then SCRAM-SHA-256 (TLS case - should succeed) */
+void test_sasl_scram_sha_256_plus_first(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-256-PLUS\0SCRAM-SHA-256\0\0" - this is what PostgreSQL sends with TLS */
+	const char mechanisms[] = "SCRAM-SHA-256-PLUS\0SCRAM-SHA-256\0";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == 0);
+	test(type == 10);
+}
+
+/* Test: Only unsupported mechanisms (should fail) */
+void test_sasl_unsupported_only(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-512\0UNKNOWN\0\0" - no supported mechanism */
+	const char mechanisms[] = "SCRAM-SHA-512\0UNKNOWN\0";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == -1);
+}
+
+/* Test: SCRAM-SHA-256-PLUS only without SCRAM-SHA-256 (should fail) */
+void test_sasl_scram_sha_256_plus_only(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-256-PLUS\0\0" - channel binding only, no plain SCRAM */
+	const char mechanisms[] = "SCRAM-SHA-256-PLUS\0";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == -1);
+}
+
+/* Test: Empty mechanism list (should fail) */
+void test_sasl_empty_list(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "\0" - empty list */
+	const char mechanisms[] = "";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == -1);
+}
+
+/* Test: SCRAM-SHA-256 as third mechanism (should succeed) */
+void test_sasl_scram_sha_256_third(void)
+{
+	char buf[128];
+	uint32_t total_len;
+
+	/* "SCRAM-SHA-256-PLUS\0SCRAM-SHA-512\0SCRAM-SHA-256\0\0" */
+	const char mechanisms[] =
+		"SCRAM-SHA-256-PLUS\0SCRAM-SHA-512\0SCRAM-SHA-256\0";
+	build_auth_sasl_message(buf, &total_len, mechanisms,
+				sizeof(mechanisms));
+
+	uint32_t type;
+	char salt[4];
+	char *auth_data;
+	size_t auth_data_size;
+
+	int rc = kiwi_fe_read_auth(buf, total_len, &type, salt, &auth_data,
+				   &auth_data_size);
+	test(rc == 0);
+	test(type == 10);
+}
+
+void kiwi_test_fe_read_auth(void)
+{
+	test_sasl_single_scram_sha_256();
+	test_sasl_scram_sha_256_first();
+	test_sasl_scram_sha_256_plus_first();
+	test_sasl_unsupported_only();
+	test_sasl_scram_sha_256_plus_only();
+	test_sasl_empty_list();
+	test_sasl_scram_sha_256_third();
+}

--- a/sources/tests/odyssey_test.c
+++ b/sources/tests/odyssey_test.c
@@ -22,6 +22,7 @@ char test_substring[1024] = { 0 };
 /* KIWI */
 extern void kiwi_test_enquote(void);
 extern void kiwi_test_pgoptions(void);
+extern void kiwi_test_fe_read_auth(void);
 
 /* MACHINARIUM */
 extern void machinarium_test_init(void);
@@ -140,6 +141,7 @@ int main(int argc, char *argv[])
 
 	odyssey_test(kiwi_test_enquote);
 	odyssey_test(kiwi_test_pgoptions);
+	odyssey_test(kiwi_test_fe_read_auth);
 	odyssey_test(machinarium_test_init);
 	odyssey_test(machinarium_test_create0);
 	odyssey_test(machinarium_test_create1);


### PR DESCRIPTION
## Summary

This PR fixes a bug in SASL mechanism parsing that causes authentication failures when connecting to PostgreSQL servers with TLS enabled.

## The Problem

In `sources/include/kiwi/fe_read.h`, the `kiwi_fe_read_auth()` function at case 10 (AuthenticationSASL) uses `strcmp(pos, "SCRAM-SHA-256")` to check if the SASL mechanism is supported.

However, according to the [PostgreSQL protocol documentation](https://www.postgresql.org/docs/current/protocol-message-formats.html), the AuthenticationSASL message contains a **list** of SASL mechanisms as null-terminated strings, not a single mechanism.

When TLS is enabled, PostgreSQL sends the mechanisms in this order:
1. `SCRAM-SHA-256-PLUS` (channel binding variant, preferred with TLS)
2. `SCRAM-SHA-256` (standard SCRAM)
3. Empty string (list terminator)

The strcmp only compared against the **first** mechanism in the list (`SCRAM-SHA-256-PLUS`), which doesn't match `SCRAM-SHA-256`, causing the authentication to incorrectly fail.

## The Fix

Replace the simple strcmp with a loop that iterates through the null-terminated list of mechanisms to find `SCRAM-SHA-256`:

```c
/* AuthenticationSASL */
case 10:
    /* PostgreSQL sends a list of SASL mechanisms as null-terminated
     * strings. When TLS is enabled, PostgreSQL sends the list:
     * ["SCRAM-SHA-256-PLUS", "SCRAM-SHA-256", ""].
     * We need to iterate through the list to find SCRAM-SHA-256. */
    {
        char *mechanism = pos;
        int found = 0;
        while (*mechanism && (size_t)(mechanism - pos) < pos_size) {
            if (strcmp(mechanism, "SCRAM-SHA-256") == 0) {
                found = 1;
                break;
            }
            mechanism += strlen(mechanism) + 1;
        }
        if (!found) {
            return -1;
        }
    }
    return 0;
```

## Affected Systems

This bug affects connections to:
- **AWS RDS PostgreSQL** with SSL/TLS enabled (the default)
- **Azure Database for PostgreSQL** with SSL enabled
- Any PostgreSQL server version 11+ with `ssl = on` that advertises channel binding

## Testing

Added unit tests in `sources/tests/kiwi/test_kiwi_fe_read_auth.c` that verify:
- Single SCRAM-SHA-256 mechanism (original working case)
- SCRAM-SHA-256 first in list (should succeed)
- SCRAM-SHA-256-PLUS first, then SCRAM-SHA-256 (TLS case - the bug scenario, should now succeed)
- Only unsupported mechanisms (should fail)
- SCRAM-SHA-256-PLUS only without SCRAM-SHA-256 (should fail)
- Empty mechanism list (should fail)
- SCRAM-SHA-256 as third mechanism in list (should succeed)

## References

- [PostgreSQL Protocol Message Formats - AuthenticationSASL](https://www.postgresql.org/docs/current/protocol-message-formats.html)
- [RFC 5802 - SCRAM](https://tools.ietf.org/html/rfc5802)
- [PostgreSQL SCRAM Authentication](https://www.postgresql.org/docs/current/auth-password.html)