### PR TITLE
auth_query: do password update in background

### DIFF
--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -115,14 +115,13 @@ error:
 }
 
 static od_client_t *create_auth_client(od_global_t *global,
-				       od_instance_t *instance, od_rule_t *rule,
-				       od_client_t *orig_client)
+				       od_instance_t *instance, od_rule_t *rule)
 {
 	od_router_t *router = global->router;
 
 	od_client_t *client = od_client_allocate_internal(global, "auth-query");
 	if (client == NULL) {
-		od_error(&instance->logger, "auth_query", orig_client, NULL,
+		od_error(&instance->logger, "auth_query", NULL, NULL,
 			 "can't allocate auth client");
 		return NULL;
 	}
@@ -152,63 +151,42 @@ static od_client_t *create_auth_client(od_global_t *global,
 	return client;
 }
 
-static int do_auth_query(od_instance_t *instance, od_rule_t *rule,
-			 od_route_t *route, od_client_t *client,
-			 od_client_t *orig_client, char *peer)
+static int do_auth_query(od_instance_t *instance, od_client_t *client,
+			 char *user, const char *query,
+			 kiwi_password_t *password)
 {
 	od_server_t *server = client->server;
 	assert(server != NULL);
 
-	kiwi_var_t *user = &orig_client->startup.user;
-
-	char query[OD_QRY_MAX_SZ];
-	char *format_pos = rule->auth_query;
-	char *format_end = rule->auth_query + strlen(rule->auth_query);
-	od_query_format(format_pos, format_end, user, peer, query,
-			sizeof(query));
-
 	machine_msg_t *msg =
-		od_query_do(server, "auth_query", query, user->value, 500);
+		od_query_do(server, "auth_query", query, user, 500);
 	if (msg == NULL) {
 		od_error(&instance->logger, "auth_query", client, server,
 			 "auth query returned empty msg");
 		return NOT_OK_RESPONSE;
 	}
 
-	kiwi_password_t password;
 	int rc = od_auth_parse_passwd_from_datarow(&instance->logger, msg,
-						   &password);
+						   password);
 	machine_msg_free(msg);
 
-	if (rc != OK_RESPONSE) {
-		return rc;
-	}
-
-	od_free(route->auth_query_cache.password);
-	route->auth_query_cache.password = password.password;
-	route->auth_query_cache.valid_until_ms = machine_time_ms() + 10 * 1000;
-
-	return OK_RESPONSE;
+	return rc;
 }
 
-static int do_update_auth_cache(od_global_t *global, od_instance_t *instance,
-				od_rule_t *rule, od_route_t *route,
-				od_client_t *orig_client, char *peer)
+static int get_password_from_auth_query(od_global_t *global,
+					od_instance_t *instance,
+					od_rule_t *rule, char *user,
+					const char *auth_query,
+					kiwi_password_t *password)
 {
 	od_router_t *router = global->router;
 
-	od_client_t *client =
-		create_auth_client(global, instance, rule, orig_client);
+	od_client_t *client = create_auth_client(global, instance, rule);
 	if (client == NULL) {
 		return NOT_OK_RESPONSE;
 	}
 
-	od_debug(&instance->logger, "auth_query", orig_client, NULL,
-		 "got auth client %s%.*s", client->id.id_prefix,
-		 (int)sizeof(client->id.id), client->id.id);
-
-	int rc =
-		do_auth_query(instance, rule, route, client, orig_client, peer);
+	int rc = do_auth_query(instance, client, user, auth_query, password);
 
 	od_router_close(router, client);
 	od_router_unroute(router, client);
@@ -217,33 +195,100 @@ static int do_update_auth_cache(od_global_t *global, od_instance_t *instance,
 	return rc;
 }
 
-static int get_password_route_locked(od_global_t *global,
-				     od_instance_t *instance, od_rule_t *rule,
-				     od_route_t *route, od_client_t *client,
-				     char *peer)
+typedef struct {
+	od_global_t *global;
+	od_instance_t *instance;
+	od_rule_t *rule;
+	od_route_t *route;
+	char user[KIWI_MAX_VAR_SIZE];
+	char query[OD_QRY_MAX_SZ];
+} refresh_arg_t;
+
+static void pswd_update_task(void *a)
 {
-	uint64_t now_ms = machine_time_ms();
+	refresh_arg_t *arg = a;
 
-	if (route->auth_query_cache.valid_until_ms < now_ms) {
-		od_debug(&instance->logger, "auth_query", client, NULL,
-			 "need to update cached password");
+	od_global_t *global = arg->global;
+	od_instance_t *instance = arg->instance;
+	od_rule_t *rule = arg->rule;
+	od_route_t *route = arg->route;
 
-		int rc = do_update_auth_cache(global, instance, rule, route,
-					      client, peer);
-		if (rc != OK_RESPONSE) {
-			return rc;
+	kiwi_password_t password;
+	memset(&password, 0, sizeof(password));
+	int rc = get_password_from_auth_query(global, instance, rule, arg->user,
+					      arg->query, &password);
+
+	uint64_t jitter = ((uint64_t)machine_lrand48()) % 5000;
+	uint64_t until = machine_time_ms() + 10 * 1000 + jitter;
+
+	od_route_lock(route);
+
+	route->auth_query_cache.valid_until_ms = machine_time_ms() + 1000;
+
+	if (rc == OK_RESPONSE) {
+		od_route_pswd_t *new = od_route_pswd_create(password.password);
+		od_free(password.password);
+		if (new != NULL) {
+			od_route_pswd_unref(route->auth_query_cache.password);
+			route->auth_query_cache.password = new;
+			route->auth_query_cache.valid_until_ms = until;
 		}
 	}
 
-	client->password.password = od_strdup(route->auth_query_cache.password);
-	if (client->password.password == NULL) {
-		od_error(&instance->logger, "auth_query", client, NULL,
-			 "can't reuse password: OOM");
-		return -1;
+	route->auth_query_cache.refresh_in_progress = 0;
+
+	mm_wait_flag_set(route->auth_query_cache.ready);
+
+	od_route_unlock(route);
+
+	od_rules_unref(rule);
+	od_free(arg);
+}
+
+static int run_refresh_task(od_global_t *global, od_instance_t *instance,
+			    od_rule_t *rule, od_route_t *route,
+			    od_client_t *client, char *peer)
+{
+	route->auth_query_cache.refresh_in_progress = 1;
+
+	od_rules_ref(rule);
+
+	refresh_arg_t *arg = od_malloc(sizeof(refresh_arg_t));
+	if (arg == NULL) {
+		goto error;
 	}
-	client->password.password_len = strlen(client->password.password) + 1;
+	memset(arg, 0, sizeof(refresh_arg_t));
+
+	kiwi_var_t *user = &client->startup.user;
+
+	arg->global = global;
+	arg->instance = instance;
+	arg->route = route;
+	arg->rule = rule;
+	strcpy(arg->user, user->value);
+
+	char *format_pos = rule->auth_query;
+	char *format_end = rule->auth_query + strlen(rule->auth_query);
+	od_query_format(format_pos, format_end, user, peer, arg->query,
+			sizeof(arg->query));
+
+	int64_t coroid = machine_coroutine_create_named(pswd_update_task, arg,
+							"auth-query");
+	if (coroid == -1) {
+		goto error;
+	}
 
 	return 0;
+
+error:
+	od_rules_unref(rule);
+	od_free(arg);
+	route->auth_query_cache.refresh_in_progress = 0;
+	int err = mm_errno_get();
+	od_error(&instance->logger, "auth_query", client, NULL,
+		 "can't run auth query coroutine: %d (%s)", err, strerror(err));
+
+	return -1;
 }
 
 int od_auth_query(od_client_t *client, char *peer)
@@ -257,9 +302,59 @@ int od_auth_query(od_client_t *client, char *peer)
 	assert(rule->auth_query != NULL);
 
 	od_route_lock(route);
-	int rc = get_password_route_locked(global, instance, rule, route,
-					   client, peer);
+
+	od_route_pswd_t *cached =
+		od_route_pswd_ref(route->auth_query_cache.password);
+	if (cached != NULL) {
+		/*
+		 * password was queried at least once
+		 * reuse it and maybe run refresh coro in background
+		 */
+		uint64_t now_ms = machine_time_ms();
+		int outdated = route->auth_query_cache.valid_until_ms < now_ms;
+		if (outdated && !route->auth_query_cache.refresh_in_progress) {
+			(void)run_refresh_task(global, instance, rule, route,
+					       client, peer);
+		}
+	} else {
+		/*
+		 * this is the first time password is acquired
+		 *
+		 * if no one run the refresh - do it, and the wait for ready
+		 */
+
+		int rc = 0;
+		if (!route->auth_query_cache.refresh_in_progress) {
+			rc = run_refresh_task(global, instance, rule, route,
+					      client, peer);
+		}
+
+		if (rc == 0) {
+			od_route_unlock(route);
+			mm_wait_flag_wait(route->auth_query_cache.ready, 500);
+			od_route_lock(route);
+		}
+
+		cached = od_route_pswd_ref(route->auth_query_cache.password);
+		if (cached == NULL) {
+			od_error(
+				&instance->logger, "auth_query", client, NULL,
+				"timeout on wait for password to become available or other error");
+			od_route_unlock(route);
+			return -1;
+		}
+	}
+
 	od_route_unlock(route);
 
-	return rc;
+	client->password.password = od_strdup(cached->value);
+	od_route_pswd_unref(cached);
+	if (client->password.password == NULL) {
+		od_error(&instance->logger, "auth_query", client, NULL,
+			 "can't reuse password: OOM");
+		return -1;
+	}
+	client->password.password_len = strlen(client->password.password) + 1;
+
+	return 0;
 }

--- a/sources/include/route.h
+++ b/sources/include/route.h
@@ -7,6 +7,7 @@
  */
 
 #include <machinarium/mutex.h>
+#include <machinarium/wait_flag.h>
 
 #include <stdatomic.h>
 
@@ -20,6 +21,15 @@
 #include <id.h>
 #include <shared_pool.h>
 #include <od_memory.h>
+
+typedef struct {
+	atomic_int_fast64_t refs;
+	char value[];
+} od_route_pswd_t;
+
+od_route_pswd_t *od_route_pswd_create(const char *value);
+od_route_pswd_t *od_route_pswd_ref(od_route_pswd_t *p);
+void od_route_pswd_unref(od_route_pswd_t *p);
 
 struct od_route {
 	od_rule_t *rule;
@@ -49,8 +59,11 @@ struct od_route {
 	od_list_t link;
 
 	struct {
-		char *password;
+		od_route_pswd_t *password;
 		uint64_t valid_until_ms;
+		/* password was set at least once */
+		mm_wait_flag_t *ready;
+		int refresh_in_progress;
 	} auth_query_cache;
 };
 
@@ -201,6 +214,12 @@ static inline int od_route_init(od_route_t *route,
 
 	memset(&route->auth_query_cache, 0, sizeof(route->auth_query_cache));
 
+	route->auth_query_cache.ready = mm_wait_flag_create();
+	if (route->auth_query_cache.ready == NULL) {
+		od_multi_pool_destroy(route->exclusive_pool);
+		return NOT_OK_RESPONSE;
+	}
+
 	od_stat_init(&route->stats);
 	od_stat_init(&route->stats_prev);
 	kiwi_params_lock_init(&route->params);
@@ -235,7 +254,8 @@ static inline void od_route_free(od_route_t *route)
 		route->err_logger = NULL;
 	}
 
-	od_free(route->auth_query_cache.password);
+	od_route_pswd_unref(route->auth_query_cache.password);
+	mm_wait_flag_destroy(route->auth_query_cache.ready);
 
 	mm_mutex_destroy(&route->lock);
 	od_free(route);

--- a/sources/route.c
+++ b/sources/route.c
@@ -194,3 +194,46 @@ void od_route_signal_locked(od_route_t *route, od_server_t *server)
 
 	od_multi_pool_signal_locked(mpool, el, server);
 }
+
+od_route_pswd_t *od_route_pswd_create(const char *value)
+{
+	size_t len = strlen(value);
+	size_t t = sizeof(od_route_pswd_t) + len + 1;
+
+	od_route_pswd_t *p = od_malloc(t);
+	if (p == NULL) {
+		return NULL;
+	}
+
+	memset(p, 0, t);
+
+	atomic_store(&p->refs, 1);
+
+	memcpy(p->value, value, len + 1);
+
+	return p;
+}
+
+od_route_pswd_t *od_route_pswd_ref(od_route_pswd_t *p)
+{
+	if (p == NULL) {
+		return NULL;
+	}
+
+	atomic_fetch_add(&p->refs, 1);
+
+	return p;
+}
+
+void od_route_pswd_unref(od_route_pswd_t *p)
+{
+	if (p == NULL) {
+		return;
+	}
+
+	int64_t r = atomic_fetch_sub(&p->refs, 1);
+
+	if (r == 1) {
+		od_free(p);
+	}
+}

--- a/sources/router.c
+++ b/sources/router.c
@@ -1043,8 +1043,11 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 		end_time_ms = now_ms + (uint64_t)route->rule->pool->timeout;
 	}
 
+	int internal = route->rule->pool->pool_type == OD_RULE_POOL_INTERNAL;
+
 	int notice_sent = 0;
-	int notice_sending = route->rule->pool->notice_after_waiting_ms >= 0;
+	int notice_sending =
+		route->rule->pool->notice_after_waiting_ms >= 0 && !internal;
 	uint64_t notice_deadline =
 		now_ms + route->rule->pool->notice_after_waiting_ms;
 	uint64_t waiting_start = now_ms;
@@ -1100,7 +1103,7 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 		}
 
 		/* client disconnected while awaiting for attaching */
-		if (!od_io_connected(&client->io)) {
+		if (!internal && !od_io_connected(&client->io)) {
 			return OD_ROUTER_CLIENT_DISCONNECTED;
 		}
 

--- a/sources/router.c
+++ b/sources/router.c
@@ -575,6 +575,10 @@ static inline int od_router_gc_cb(od_route_t *route, void **argv)
 		goto done;
 	}
 
+	if (route->auth_query_cache.refresh_in_progress) {
+		goto done;
+	}
+
 	if (!od_route_is_dynamic(route) && !route->rule->obsolete) {
 		goto done;
 	}


### PR DESCRIPTION
Password is an object of very rare change, so reuse password even if ttl of cache is invalid, just run one background coroutine for password update