### PR TITLE
fix connection return for TSA check

### DIFF
--- a/sources/backend.c
+++ b/sources/backend.c
@@ -722,12 +722,13 @@ int od_backend_update_endpoint_status(od_instance_t *instance,
 	return OK_RESPONSE;
 }
 
-int od_backend_check_tsa(od_storage_endpoint_t *endpoint, char *context,
-			 od_server_t *server, od_client_t *client,
-			 od_target_session_attrs_t attrs)
+od_tsa_check_result_t od_backend_check_tsa(od_storage_endpoint_t *endpoint,
+					   char *context, od_server_t *server,
+					   od_client_t *client,
+					   od_target_session_attrs_t attrs)
 {
 	if (attrs == OD_TARGET_SESSION_ATTRS_ANY) {
-		return OK_RESPONSE;
+		return OD_TSA_CHECK_OK;
 	}
 
 	od_global_t *global = server->global;
@@ -741,7 +742,7 @@ int od_backend_check_tsa(od_storage_endpoint_t *endpoint, char *context,
 			    instance, client, server, context,
 			    NULL /* do not update lag */,
 			    endpoint) != OK_RESPONSE) {
-			return NOT_OK_RESPONSE;
+			return OD_TSA_CHECK_BACKEND_ERROR;
 		}
 	}
 
@@ -749,10 +750,10 @@ int od_backend_check_tsa(od_storage_endpoint_t *endpoint, char *context,
 	od_storage_endpoint_status_get(&endpoint->status, &status);
 
 	if (!od_tsa_match_rw_state(attrs, status.is_read_write)) {
-		return NOT_OK_RESPONSE;
+		return OD_TSA_CHECK_FAIL;
 	}
 
-	return OK_RESPONSE;
+	return OD_TSA_CHECK_OK;
 }
 
 static inline int od_backend_connect_on_server_address(

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -447,8 +447,9 @@ od_frontend_attach_to_endpoint(od_client_t *client, char *context,
 			return OD_ESERVER_CONNECT;
 		}
 
-		if (od_backend_check_tsa(endpoint, context, server, client,
-					 tsa) != OK_RESPONSE) {
+		od_tsa_check_result_t trc = od_backend_check_tsa(
+			endpoint, context, server, client, tsa);
+		if (trc != OD_TSA_CHECK_OK) {
 			od_address_to_str(&endpoint->address, addr,
 					  sizeof(addr) - 1);
 			od_debug(
@@ -456,8 +457,11 @@ od_frontend_attach_to_endpoint(od_client_t *client, char *context,
 				"read-write status of '%s' is mismatched with expected '%s' or failed to update",
 				addr, od_target_session_attrs_to_str(tsa));
 
-			/* push server to router server pool */
-			od_router_detach(router, client);
+			if (trc == OD_TSA_CHECK_BACKEND_ERROR) {
+				od_router_close(router, client);
+			} else {
+				od_router_detach(router, client);
+			}
 
 			/* try another host */
 			return OD_EATTACH_TARGET_SESSION_ATTRS_MISMATCH;

--- a/sources/include/backend.h
+++ b/sources/include/backend.h
@@ -14,8 +14,15 @@
 
 int od_backend_connect(od_server_t *, char *, kiwi_params_t *, od_client_t *);
 
-int od_backend_check_tsa(od_storage_endpoint_t *, char *, od_server_t *,
-			 od_client_t *, od_target_session_attrs_t);
+typedef enum {
+	OD_TSA_CHECK_OK,
+	OD_TSA_CHECK_FAIL,
+	OD_TSA_CHECK_BACKEND_ERROR,
+} od_tsa_check_result_t;
+
+od_tsa_check_result_t od_backend_check_tsa(od_storage_endpoint_t *, char *,
+					   od_server_t *, od_client_t *,
+					   od_target_session_attrs_t);
 
 int od_backend_connect_cancel(od_server_t *, od_rule_storage_t *,
 			      const od_address_t *, kiwi_key_t *);


### PR DESCRIPTION
We should not return backend to pool
if TSA check failed for reasons of failed queries, otherwise it can lead to detach attempt of broken servers due to sync_repl != sync_req