### PR TITLE
limit cancel queue waiting

### DIFF
--- a/sources/config.c
+++ b/sources/config.c
@@ -80,6 +80,8 @@ void od_config_init(od_config_t *config)
 
 	config->backend_connect_timeout_ms = 30U * 1000U; /* 30 seconds */
 	config->cancel_timeout_ms = 1U * 1000U; /* 1 seconds */
+	config->cancel_queue_timeout_ms = -1;
+	config->cancel_max_inflight = -1;
 	config->virtual_processing = 0;
 
 	config->graceful_shutdown_timeout_ms = 30 * 1000; /* 30 seconds */

--- a/sources/config_reader.c
+++ b/sources/config_reader.c
@@ -111,6 +111,8 @@ typedef enum {
 	OD_LAPPLICATION_NAME_ADD_HOST,
 	OD_LBACKEND_CONNECT_TIMEOUT_MS,
 	OD_LCANCEL_TIMEOUT_MS,
+	OD_LCANCEL_MAX_INFLIGHT,
+	OD_LCANCEL_QUEUE_TIMEOUT_MS,
 	OD_LSERVER_LIFETIME,
 	OD_LSERVER_DROP_ON_BACKED_PLAN_ERROR,
 	OD_LTLS,
@@ -323,6 +325,8 @@ static od_keyword_t od_config_keywords[] = {
 	od_keyword("backend_connect_timeout_ms",
 		   OD_LBACKEND_CONNECT_TIMEOUT_MS),
 	od_keyword("cancel_timeout_ms", OD_LCANCEL_TIMEOUT_MS),
+	od_keyword("cancel_max_inflight", OD_LCANCEL_MAX_INFLIGHT),
+	od_keyword("cancel_queue_timeout_ms", OD_LCANCEL_QUEUE_TIMEOUT_MS),
 
 	/*   tls */
 	od_keyword("tls", OD_LTLS),
@@ -3706,6 +3710,20 @@ static int od_config_reader_parse(od_config_reader_t *reader,
 		case OD_LCANCEL_TIMEOUT_MS:
 			if (!od_config_reader_number(
 				    reader, &config->cancel_timeout_ms)) {
+				goto error;
+			}
+			continue;
+		/* cancel_queue_timeout_ms */
+		case OD_LCANCEL_QUEUE_TIMEOUT_MS:
+			if (!od_config_reader_number(
+				    reader, &config->cancel_queue_timeout_ms)) {
+				goto error;
+			}
+			continue;
+		/* cancel_max_inflight */
+		case OD_LCANCEL_MAX_INFLIGHT:
+			if (!od_config_reader_number(
+				    reader, &config->cancel_max_inflight)) {
 				goto error;
 			}
 			continue;

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -2529,12 +2529,26 @@ void od_frontend(void *arg)
 
 	/* handle cancel request */
 	if (client->startup.is_cancel) {
-		od_log(&instance->logger, "startup", client, NULL,
-		       "cancel request");
+		od_debug(&instance->logger, "startup", client, NULL,
+			 "cancel request");
 
 		od_atomic_u32_dec(&router->clients_routing);
 
-		mm_sem_wait(&global->cancel_sem);
+		uint32_t queue_timeout =
+			instance->config.cancel_queue_timeout_ms >= 0 ?
+				(uint32_t)instance->config
+					.cancel_queue_timeout_ms :
+				2 * instance->config.cancel_timeout_ms;
+
+		rc = mm_sem_timedwait(&global->cancel_sem, queue_timeout);
+		if (rc == -1) {
+			od_error(
+				&instance->logger, "startup", client, NULL,
+				"dropping cancel request due to queue timeout %u ms",
+				queue_timeout);
+			od_frontend_close(client);
+			return;
+		}
 
 		od_router_cancel_t cancel;
 		od_router_cancel_init(&cancel);

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -2538,7 +2538,7 @@ void od_frontend(void *arg)
 			instance->config.cancel_queue_timeout_ms >= 0 ?
 				(uint32_t)instance->config
 					.cancel_queue_timeout_ms :
-				2 * instance->config.cancel_timeout_ms;
+				2 * (uint32_t)instance->config.cancel_timeout_ms;
 
 		rc = mm_sem_timedwait(&global->cancel_sem, queue_timeout);
 		if (rc == -1) {

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -121,6 +121,8 @@ struct od_config {
 
 	int backend_connect_timeout_ms;
 	int cancel_timeout_ms;
+	int cancel_queue_timeout_ms;
+	int cancel_max_inflight;
 
 	int virtual_processing; /* enables some cases for full-virtual query processing */
 

--- a/sources/system.c
+++ b/sources/system.c
@@ -629,7 +629,11 @@ static inline void od_system(void *arg)
 		return;
 	}
 
-	mm_sem_init(&global->cancel_sem, 2 * instance->config.workers);
+	size_t max_inflight =
+		instance->config.cancel_max_inflight > 0 ?
+			(size_t)instance->config.cancel_max_inflight :
+			2 * instance->config.workers;
+	mm_sem_init(&global->cancel_sem, max_inflight);
 
 	/* start cron coroutine */
 	od_cron_t *cron = system->global->cron;

--- a/sources/system.c
+++ b/sources/system.c
@@ -629,10 +629,10 @@ static inline void od_system(void *arg)
 		return;
 	}
 
-	size_t max_inflight =
+	uint64_t max_inflight =
 		instance->config.cancel_max_inflight > 0 ?
-			(size_t)instance->config.cancel_max_inflight :
-			2 * instance->config.workers;
+			(uint64_t)instance->config.cancel_max_inflight :
+			2 * (uint64_t)instance->config.workers;
 	mm_sem_init(&global->cancel_sem, max_inflight);
 
 	/* start cron coroutine */


### PR DESCRIPTION
Also add new parameters:
 - cancel_queue_timeout_ms to limit milliseconds of
queue awaiting, for < 0 it will be set to 2 * cancel_timeout_ms
0 means no waiting
 - cancel_max_inflight to limit concurrency of cancles,
for <= 0 will be set to 2 * workers

Signed-off-by: roman khapov <r.khapov@ya.ru>