### PR TITLE
drain readable data while waiting to write on TLS sockets

### DIFF
--- a/sources/io.c
+++ b/sources/io.c
@@ -12,6 +12,36 @@
 #include <readahead.h>
 #include <io.h>
 
+static void od_io_drain_readable(od_io_t *io)
+{
+	if (!mm_io_is_tls(io->io)) {
+		return;
+	}
+
+	while (1) {
+		int rc = od_io_try_read_some(io);
+		if (rc == 0) {
+			continue;
+		}
+
+		int errno_ = machine_errno();
+		if (errno_ == EWOULDBLOCK) {
+			/* no data in socket */
+			break;
+		}
+		if (errno_ == EINPROGRESS) {
+			/* no place in readahead */
+			break;
+		}
+
+		/*
+		 * real error
+		 * general write will reveal the error, so just break and ignore
+		 */
+		break;
+	}
+}
+
 int od_io_write_raw(od_io_t *io, const void *buf, size_t size,
 		    size_t *processed, uint32_t timeout_ms)
 {
@@ -41,6 +71,13 @@ int od_io_write_raw(od_io_t *io, const void *buf, size_t size,
 				mm_errno_set(EAGAIN);
 				return -1;
 			}
+
+			/*
+			 * sometimes writing can require reading, ex: KeyUpdate in TLS 1.3
+			 * so just try read into readahead as much as we can and then continue
+			 */
+			od_io_drain_readable(io);
+
 			continue;
 		}
 
@@ -98,6 +135,13 @@ int od_io_writev(od_io_t *io, struct iovec *iov, int iovcnt,
 				mm_errno_set(EAGAIN);
 				return -1;
 			}
+
+			/*
+			 * sometimes writing can require reading, ex: KeyUpdate in TLS 1.3
+			 * so just try read into readahead as much as we can and then continue
+			 */
+			od_io_drain_readable(io);
+
 			continue;
 		}
 


### PR DESCRIPTION
Prevents a full-duplex deadlock that can occur with TLS 1.3 peers: if the client's TLS stack needs to send a KeyUpdate record while Odyssey is blocked writing a large result set to the same client socket, neither side reads, and the connection hangs until timeout.

Opportunistically drain the socket (read-until-EWOULDBLOCK, since EPOLLET is used) whenever a write retry wakes up, keeping the TCP window open and letting the peer's TLS layer make progress.