### PR TITLE
scram-passthrough impl

### DIFF
--- a/.github/workflows/scram-passthrough.yml
+++ b/.github/workflows/scram-passthrough.yml
@@ -1,0 +1,29 @@
+name: SCRAM-passthrough tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "sources/**"
+      - "test/**"
+      - "CMakeLists.txt"
+      - "docker/**"
+      - "modules/**"
+      - "cmake/**"
+      - "!docker/prom-exporter/**"
+jobs:
+  scram_passthrough_tests:
+    name: scram_passthrough
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: ['build_release', 'build_asan', 'build_dbg']
+        cc: ['clang', 'gcc']
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: recursive
+    - name: Odyssey scram_passthrough tests
+      run: make scram_passthrough_test ODYSSEY_BUILD_TYPE=${{ matrix.build-type }} ODYSSEY_CC=${{ matrix.cc }}

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,13 @@ regress_test:
 		--tag=odyssey/regress-tester .
 	docker run odyssey/regress-tester
 
+scram_passthrough_test:
+	docker build -f ./test/scram-passthrough/Dockerfile \
+		--build-arg build_type=$(ODYSSEY_BUILD_TYPE) \
+		--build-arg odyssey_cc=$(ODYSSEY_CC) \
+		--tag=odyssey/scram-passthrough-tester .
+	docker run odyssey/scram-passthrough-tester
+
 ci-unittests:
 	docker build \
 		--platform $(ODYSSEY_TEST_TARGET_PLATFORM) \

--- a/sources/auth.c
+++ b/sources/auth.c
@@ -742,6 +742,14 @@ static inline int od_auth_frontend_scram_sha_256(od_client_t *client)
 
 	int rc = od_auth_frontend_scram_sha_256_internal(client, &scram_state);
 
+	if (rc == 0) {
+		memcpy(client->scram_client_key, scram_state.client_key,
+		       sizeof(scram_state.client_key));
+		memcpy(client->scram_server_key, scram_state.server_key,
+		       sizeof(scram_state.server_key));
+		client->scram_key_valid = 1;
+	}
+
 	od_scram_state_free(&scram_state);
 
 	return rc;
@@ -1080,17 +1088,25 @@ static inline int od_auth_backend_sasl_continue(od_server_t *server,
 	}
 
 	/* use storage or user password */
-	char *password;
+	char *password = NULL;
+
+	server->scram_state.has_scram_secret = 0;
 
 	if (route->rule->storage_password) {
 		password = route->rule->storage_password;
-	} else if (client != NULL && client->password.password != NULL) {
-		od_error(
-			&instance->logger, "auth", NULL, server,
-			"cannot authenticate with SCRAM secret from auth_query",
-			route->rule->db_name, route->rule->user_name);
+	} else if (client != NULL) {
+		if (!client->scram_key_valid) {
+			od_error(
+				&instance->logger, "auth", NULL, server,
+				"cannot authenticate without SCRAM secret from client");
+			return -1;
+		}
 
-		return -1;
+		server->scram_state.has_scram_secret = true;
+		memcpy(server->scram_state.client_key, client->scram_client_key,
+		       OD_SCRAM_MAX_KEY_LEN);
+		memcpy(server->scram_state.server_key, client->scram_server_key,
+		       OD_SCRAM_MAX_KEY_LEN);
 	} else if (route->rule->password) {
 		password = route->rule->password;
 	} else if (client->received_password.password) {
@@ -1108,7 +1124,10 @@ static inline int od_auth_backend_sasl_continue(od_server_t *server,
 	}
 #endif
 	od_debug(&instance->logger, "auth", NULL, server,
-		 "continue SASL authentication using password %s", password);
+		 "continue SASL authentication %s",
+		 server->scram_state.has_scram_secret ?
+			 "pass-through SCRAM key" :
+			 "password");
 
 	/* SASLResponse Message */
 	machine_msg_t *msg = od_scram_create_client_final_message(

--- a/sources/auth.c
+++ b/sources/auth.c
@@ -1090,19 +1090,12 @@ static inline int od_auth_backend_sasl_continue(od_server_t *server,
 	/* use storage or user password */
 	char *password = NULL;
 
-	server->scram_state.has_scram_secret = 0;
+	server->scram_state.use_passthrough_keys = 0;
 
 	if (route->rule->storage_password) {
 		password = route->rule->storage_password;
-	} else if (client != NULL) {
-		if (!client->scram_key_valid) {
-			od_error(
-				&instance->logger, "auth", NULL, server,
-				"cannot authenticate without SCRAM secret from client");
-			return -1;
-		}
-
-		server->scram_state.has_scram_secret = true;
+	} else if (client != NULL && client->scram_key_valid) {
+		server->scram_state.use_passthrough_keys = 1;
 		memcpy(server->scram_state.client_key, client->scram_client_key,
 		       OD_SCRAM_MAX_KEY_LEN);
 		memcpy(server->scram_state.server_key, client->scram_server_key,
@@ -1125,7 +1118,7 @@ static inline int od_auth_backend_sasl_continue(od_server_t *server,
 #endif
 	od_debug(&instance->logger, "auth", NULL, server,
 		 "continue SASL authentication %s",
-		 server->scram_state.has_scram_secret ?
+		 server->scram_state.use_passthrough_keys ?
 			 "pass-through SCRAM key" :
 			 "password");
 

--- a/sources/client.c
+++ b/sources/client.c
@@ -59,6 +59,10 @@ void od_client_init(od_client_t *client)
 	memset(client->peer, 0, sizeof(client->peer));
 
 	client->pending_begin = 0;
+
+	memset(client->scram_client_key, 0, sizeof(client->scram_client_key));
+	memset(client->scram_server_key, 0, sizeof(client->scram_server_key));
+	client->scram_key_valid = 0;
 }
 
 void od_client_free(od_client_t *client)

--- a/sources/client.c
+++ b/sources/client.c
@@ -87,6 +87,11 @@ void od_client_free(od_client_t *client)
 	if (client->external_id) {
 		od_free(client->external_id);
 	}
+
+	memset(client->scram_client_key, 0, sizeof(client->scram_client_key));
+	memset(client->scram_server_key, 0, sizeof(client->scram_server_key));
+	client->scram_key_valid = 0;
+
 	od_free(client);
 }
 

--- a/sources/include/client.h
+++ b/sources/include/client.h
@@ -18,6 +18,7 @@
 #include <rules.h>
 #include <list.h>
 #include <pstmt.h>
+#include <scram.h>
 #include <od_ldap.h>
 
 typedef enum {
@@ -85,6 +86,10 @@ struct od_client {
 	char *external_id;
 
 	int pending_begin;
+
+	uint8_t scram_client_key[OD_SCRAM_MAX_KEY_LEN];
+	uint8_t scram_server_key[OD_SCRAM_MAX_KEY_LEN];
+	int scram_key_valid;
 };
 
 static inline od_retcode_t od_client_init_hm(od_client_t *client)

--- a/sources/include/logger.h
+++ b/sources/include/logger.h
@@ -133,6 +133,9 @@ static inline void od_debug(od_logger_t *logger, char *context, void *client,
 static inline void od_gdebug(char *context, void *client, void *server,
 			     char *fmt, ...)
 	__attribute__((format(printf, 4, 5)));
+static inline void od_error(od_logger_t *logger, char *context, void *client,
+			    void *server, char *fmt, ...)
+	__attribute__((format(printf, 5, 6)));
 static inline void od_gerror(char *context, void *client, void *server,
 			     char *fmt, ...)
 	__attribute__((format(printf, 4, 5)));

--- a/sources/include/scram.h
+++ b/sources/include/scram.h
@@ -29,7 +29,7 @@ struct od_scram_state {
 	int iterations;
 	char *salt;
 
-	int has_scram_secret;
+	int use_passthrough_keys;
 	uint8_t stored_key[OD_SCRAM_MAX_KEY_LEN];
 	uint8_t server_key[OD_SCRAM_MAX_KEY_LEN];
 	uint8_t client_key[OD_SCRAM_MAX_KEY_LEN];

--- a/sources/include/scram.h
+++ b/sources/include/scram.h
@@ -8,6 +8,13 @@
 
 #include <od_memory.h>
 
+#include <pg_compat.h>
+#include <common/cryptohash.h>
+#include <common/scram-common.h>
+
+#define OD_SCRAM_MAX_KEY_LEN SCRAM_MAX_KEY_LEN
+#define OD_SCRAM_SHA_256_DEFAULT_ITERATIONS SCRAM_SHA_256_DEFAULT_ITERATIONS
+
 typedef struct od_scram_state od_scram_state_t;
 
 struct od_scram_state {
@@ -22,8 +29,10 @@ struct od_scram_state {
 	int iterations;
 	char *salt;
 
-	uint8_t stored_key[32];
-	uint8_t server_key[32];
+	int has_scram_secret;
+	uint8_t stored_key[OD_SCRAM_MAX_KEY_LEN];
+	uint8_t server_key[OD_SCRAM_MAX_KEY_LEN];
+	uint8_t client_key[OD_SCRAM_MAX_KEY_LEN];
 };
 
 static inline void od_scram_state_init(od_scram_state_t *state)

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -2064,9 +2064,7 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 				od_error(
 					logger, "rules", NULL, NULL,
 					"auth query and pam service auth method cannot be "
-					"used simultaneously",
-					rule->db_name, rule->user_name,
-					rule->address_range.string_value);
+					"used simultaneously");
 				return -1;
 			}
 #endif

--- a/sources/scram.c
+++ b/sources/scram.c
@@ -388,7 +388,7 @@ static int calculate_client_proof(od_scram_state_t *scram_state,
 	const char *errstr = NULL;
 	uint8_t client_key[OD_SCRAM_MAX_KEY_LEN];
 
-	if (scram_state->has_scram_secret) {
+	if (scram_state->use_passthrough_keys) {
 		memcpy(client_key, scram_state->client_key,
 		       OD_SCRAM_MAX_KEY_LEN);
 	} else {
@@ -609,7 +609,7 @@ od_retcode_t od_scram_verify_server_signature(od_scram_state_t *scram_state,
 
 	uint8_t server_key[OD_SCRAM_MAX_KEY_LEN];
 
-	if (scram_state->has_scram_secret) {
+	if (scram_state->use_passthrough_keys) {
 		memcpy(server_key, scram_state->server_key,
 		       OD_SCRAM_MAX_KEY_LEN);
 	} else {

--- a/sources/scram.c
+++ b/sources/scram.c
@@ -29,9 +29,6 @@
 #include <scram.h>
 #include <util.h>
 
-#define OD_SCRAM_MAX_KEY_LEN SCRAM_MAX_KEY_LEN
-#define OD_SCRAM_SHA_256_DEFAULT_ITERATIONS SCRAM_SHA_256_DEFAULT_ITERATIONS
-
 #define od_b64_encode(src, src_len, dst, dst_len) \
 	pg_b64_encode(src, src_len, dst, dst_len);
 #define od_b64_decode(src, src_len, dst, dst_len) \
@@ -388,43 +385,46 @@ static int calculate_client_proof(od_scram_state_t *scram_state,
 				  const char *client_final_message,
 				  uint8_t *client_proof)
 {
-	char *prepared_password = NULL;
-	pg_saslprep_rc rc = pg_saslprep(password, &prepared_password);
-
-	if (rc == SASLPREP_OOM) {
-		return -1;
-	}
-
-	if (rc != SASLPREP_SUCCESS) {
-		prepared_password = od_strdup(password);
-	}
-
-	if (prepared_password == NULL) {
-		return -1;
-	}
-
-	scram_state->salted_password = od_malloc(OD_SCRAM_MAX_KEY_LEN);
-	if (scram_state->salted_password == NULL) {
-		goto error;
-	}
-
-	od_scram_ctx_t *ctx = od_scram_HMAC_create();
 	const char *errstr = NULL;
-	/* usage exists depending of pg version */
-	(void)errstr;
-
-	od_scram_SaltedPassword(prepared_password, salt, SCRAM_DEFAULT_SALT_LEN,
-				iterations, scram_state->salted_password,
-				&errstr);
-
 	uint8_t client_key[OD_SCRAM_MAX_KEY_LEN];
-	od_scram_ClientKey(scram_state->salted_password, client_key, &errstr);
+
+	if (scram_state->has_scram_secret) {
+		memcpy(client_key, scram_state->client_key,
+		       OD_SCRAM_MAX_KEY_LEN);
+	} else {
+		char *prepared_password = NULL;
+		pg_saslprep_rc rc = pg_saslprep(password, &prepared_password);
+
+		if (rc == SASLPREP_OOM) {
+			return -1;
+		}
+		if (rc != SASLPREP_SUCCESS) {
+			prepared_password = od_strdup(password);
+		}
+		if (prepared_password == NULL) {
+			return -1;
+		}
+
+		scram_state->salted_password = od_malloc(OD_SCRAM_MAX_KEY_LEN);
+		if (scram_state->salted_password == NULL) {
+			od_free(prepared_password);
+			return -1;
+		}
+
+		od_scram_SaltedPassword(prepared_password, salt,
+					SCRAM_DEFAULT_SALT_LEN, iterations,
+					scram_state->salted_password, &errstr);
+		od_scram_ClientKey(scram_state->salted_password, client_key,
+				   &errstr);
+
+		od_free(prepared_password);
+	}
 
 	uint8_t stored_key[OD_SCRAM_MAX_KEY_LEN];
 	od_scram_H(client_key, OD_SCRAM_MAX_KEY_LEN, stored_key, &errstr);
 
+	od_scram_ctx_t *ctx = od_scram_HMAC_create();
 	od_scram_HMAC_init(ctx, stored_key, OD_SCRAM_MAX_KEY_LEN);
-
 	od_scram_HMAC_update(ctx, scram_state->client_first_message,
 			     strlen(scram_state->client_first_message));
 	od_scram_HMAC_update(ctx, ",", 1);
@@ -443,13 +443,7 @@ static int calculate_client_proof(od_scram_state_t *scram_state,
 
 	od_scram_HMAC_free(ctx);
 
-	od_free(prepared_password);
 	return 0;
-
-error:
-
-	od_free(prepared_password);
-	return -1;
 }
 
 static char *calculate_server_signature(od_scram_state_t *scram_state)
@@ -614,9 +608,16 @@ od_retcode_t od_scram_verify_server_signature(od_scram_state_t *scram_state,
 	(void)errstr;
 
 	uint8_t server_key[OD_SCRAM_MAX_KEY_LEN];
-	od_scram_ServerKey(scram_state->salted_password, server_key, &errstr);
-	od_scram_HMAC_init(ctx, server_key, OD_SCRAM_MAX_KEY_LEN);
 
+	if (scram_state->has_scram_secret) {
+		memcpy(server_key, scram_state->server_key,
+		       OD_SCRAM_MAX_KEY_LEN);
+	} else {
+		od_scram_ServerKey(scram_state->salted_password, server_key,
+				   &errstr);
+	}
+
+	od_scram_HMAC_init(ctx, server_key, OD_SCRAM_MAX_KEY_LEN);
 	od_scram_HMAC_update(ctx, scram_state->client_first_message,
 			     strlen(scram_state->client_first_message));
 	od_scram_HMAC_update(ctx, ",", 1);
@@ -1014,7 +1015,6 @@ od_retcode_t od_scram_verify_client_proof(od_scram_state_t *scram_state,
 					  uint8_t *client_proof)
 {
 	uint8_t client_signature[OD_SCRAM_MAX_KEY_LEN];
-	uint8_t client_key[OD_SCRAM_MAX_KEY_LEN];
 	uint8_t client_stored_key[OD_SCRAM_MAX_KEY_LEN];
 
 	od_scram_ctx_t *ctx = od_scram_HMAC_create();
@@ -1034,11 +1034,12 @@ od_retcode_t od_scram_verify_client_proof(od_scram_state_t *scram_state,
 	od_scram_HMAC_final(client_signature, ctx);
 
 	for (int i = 0; i < OD_SCRAM_MAX_KEY_LEN; i++) {
-		client_key[i] = client_proof[i] ^ client_signature[i];
+		scram_state->client_key[i] =
+			client_proof[i] ^ client_signature[i];
 	}
 
-	od_scram_H(client_key, OD_SCRAM_MAX_KEY_LEN, client_stored_key,
-		   &errstr);
+	od_scram_H(scram_state->client_key, OD_SCRAM_MAX_KEY_LEN,
+		   client_stored_key, &errstr);
 	od_scram_HMAC_free(ctx);
 
 	if (memcmp(client_stored_key, scram_state->stored_key,

--- a/sources/system.c
+++ b/sources/system.c
@@ -311,9 +311,8 @@ static inline od_retcode_t od_system_server_start(od_system_t *system,
 			rc = chmod(saddr_un.sun_path, mode);
 			if (rc == -1) {
 				od_error(&instance->logger, "server", NULL,
-					 NULL, "chmod(%s, %d) failed",
-					 saddr_un.sun_path,
-					 instance->config.unix_socket_mode);
+					 NULL, "chmod(%s, %ld) failed",
+					 saddr_un.sun_path, mode);
 			}
 		}
 	}

--- a/sources/tls.c
+++ b/sources/tls.c
@@ -117,7 +117,7 @@ int od_tls_frontend_accept(od_client_t *client, od_logger_t *logger,
 				   config->client_login_timeout);
 		if (rc == -1) {
 			od_error(logger, "tls", client, NULL,
-				 "error: %s, login time %d us",
+				 "error: %s, login time %lu us",
 				 od_io_error(&client->io),
 				 machine_time_us() - client->time_accept);
 			return -1;

--- a/test/scram-passthrough/.dockerignore
+++ b/test/scram-passthrough/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/test/scram-passthrough/Dockerfile
+++ b/test/scram-passthrough/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:noble AS common-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Moskow
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt update && apt install -y ca-certificates
+RUN sed -i 's/archive.ubuntu.com/mirror.yandex.ru/g' /etc/apt/sources.list
+
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install -y --no-install-recommends --allow-unauthenticated \
+    git \
+    libssl-dev \
+    openssl \
+    libpam0g-dev \
+    build-essential \
+    cmake \
+    bison flex \
+    pkg-config \
+    libreadline-dev \
+    clang \
+    libsystemd-dev \
+    libpthread-stubs0-dev libclang-rt-dev \
+    python3
+
+FROM common-builder AS pg-build
+
+RUN git clone --depth 1 --branch REL_18_STABLE https://github.com/postgres/postgres.git
+RUN cd postgres && ./configure --prefix /usr --without-icu --without-zlib && make -j install >/dev/null
+
+FROM pg-build AS odyssey-build
+
+ARG build_type=build_dbg
+ARG odyssey_cc=gcc
+
+RUN mkdir /build_dir
+WORKDIR /build_dir
+
+COPY . .
+
+RUN CC=${odyssey_cc} make clean && make ${build_type}
+
+RUN cp /build_dir/build/sources/odyssey /usr/bin/odyssey
+COPY ./sources/machinarium/gdb/machinarium-gdb.py /gdb.py
+COPY ./test/functional/bin/ody-stop /usr/bin/ody-stop
+
+FROM odyssey-build AS runner
+
+RUN useradd -ms /bin/bash postgres
+RUN mkdir regress
+WORKDIR /home/postgres
+
+COPY ./test/scram-passthrough/entrypoint.sh /home/postgres/entrypoint.sh
+COPY ./test/scram-passthrough/odyssey.conf /home/postgres/odyssey.conf
+
+RUN chown postgres /home/postgres/entrypoint.sh
+
+USER postgres
+
+ENTRYPOINT ["/home/postgres/entrypoint.sh"]

--- a/test/scram-passthrough/entrypoint.sh
+++ b/test/scram-passthrough/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -xu
+
+PGDIR=/home/postgres/pgdir
+
+pg_ctl stop -D ${PGDIR} -l ${PGDIR}/log.txt || true
+rm -rf ${PGDIR} || true
+
+initdb -D ${PGDIR}
+
+cat >> "${PGDIR}/postgresql.conf" <<EOF
+password_encryption = 'scram-sha-256'
+listen_addresses = '*'
+EOF
+
+cat > "${PGDIR}/pg_hba.conf" <<EOF
+# TYPE  DATABASE  USER          ADDRESS         METHOD
+host    all       postgres      127.0.0.1/32    trust
+host    all       postgres      ::1/128         trust
+
+host    testdb    test_scram    127.0.0.1/32    scram-sha-256
+host    testdb    test_scram    ::1/128         scram-sha-256
+host    testdb    test_scram    0.0.0.0/0       scram-sha-256
+EOF
+
+pg_ctl start -D ${PGDIR} -l ${PGDIR}/log.txt || exit 1
+
+until pg_isready -h localhost -p 5432 >/dev/null 2>&1; do
+	sleep 0.2
+done
+
+psql -h localhost -U postgres -d postgres -c 'create database testdb' || exit 1
+psql -h localhost -U postgres -d postgres -c "create role test_scram with password 'password' login" || exit 1
+
+PGPASSWORD=password psql -h localhost -U test_scram -d testdb -c 'select 42' || exit 1
+PGPASSWORD=not-password psql -h localhost -U test_scram -d testdb -c 'select 42' && {
+    echo "successfully auth with incorrect password"
+    exit 1
+}
+
+odyssey /home/postgres/odyssey.conf || exit 1
+until pg_isready -h localhost -p 6432 >/dev/null 2>&1; do
+	sleep 0.2
+done
+
+PGPASSWORD=password psql -h localhost -p 6432 -U test_scram -d testdb -c 'select 42' || {
+	cat /home/postgres/odyssey.log
+	exit 1
+}
+PGPASSWORD=not-password psql -h localhost -p 6432  -U test_scram -d testdb -c 'select 42' && {
+    echo "successfully auth with incorrect password"
+	cat /home/postgres/odyssey.log
+    exit 1
+}
+
+ody-stop
+
+exit 0

--- a/test/scram-passthrough/odyssey.conf
+++ b/test/scram-passthrough/odyssey.conf
@@ -1,0 +1,57 @@
+pid_file "/tmp/odyssey.pid"
+daemonize yes
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_to_stdout no
+log_syslog no
+log_syslog_ident "odyssey"
+log_syslog_facility "daemon"
+log_debug yes
+log_config yes
+log_session yes
+log_query no
+log_stats no
+log_file "/home/postgres/odyssey.log"
+stats_interval 60
+workers 1
+readahead 4096
+cache_coroutine 0
+coroutine_stack_size 16
+
+listen {
+	host "*"
+	port 6432
+}
+
+storage "postgres_server" {
+	type "remote"
+	host "localhost:5432"
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		pool_routing "internal"
+		storage "postgres_server"
+		pool "session"
+	}
+}
+
+database default {
+	user default {
+		authentication "scram-sha-256"
+
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_db "postgres"
+		auth_query_user "postgres"
+
+		storage "postgres_server"
+		pool "transaction"
+		pool_size 32
+	}
+}
+
+locks_dir "/tmp/odyssey"
+
+graceful_die_on_errors yes
+enable_online_restart no
+bindwith_reuseport yes


### PR DESCRIPTION
Reuse server key and client key to create backend
connections without specifying plain password.

Inspired by PG commit 761c79508e7fbc33c1b11754bdde4bd03ce9cbb3

Suggested-by: Konstantin Krasnov <kkrasnov@gmail.com>