### PR TITLE
fix machinarium writev build with compression enabled

### DIFF
--- a/sources/include/machinarium/compression.h
+++ b/sources/include/machinarium/compression.h
@@ -17,7 +17,7 @@ static inline int mm_compression_is_active(mm_io_t *io)
 	return io->zpq_stream != NULL;
 }
 
-int mm_compression_writev(mm_io_t *io, struct iovec *iov, int n,
+int mm_compression_writev(mm_io_t *io, const struct iovec *iov, int n,
 			  size_t *processed);
 
 int mm_compression_read_pending(mm_io_t *io);

--- a/sources/include/machinarium/machinarium.h
+++ b/sources/include/machinarium/machinarium.h
@@ -252,7 +252,7 @@ MACHINE_API ssize_t machine_write_raw(mm_io_t *, const void *, size_t,
 				      size_t *);
 
 MACHINE_API ssize_t machine_writev_raw(mm_io_t *, const struct iovec *iov,
-				       int iovcnt);
+				       int iovcnt, size_t *processed);
 
 MACHINE_API int machine_write(mm_io_t *, machine_msg_t *, uint32_t time_ms);
 

--- a/sources/io.c
+++ b/sources/io.c
@@ -115,12 +115,27 @@ int od_io_writev(od_io_t *io, struct iovec *iov, int iovcnt,
 {
 	mm_io_set_deadline(io->io, timeout_ms);
 	while (iovcnt > 0) {
-		ssize_t rc = machine_writev_raw(io->io, iov, iovcnt);
-		if (rc > 0) {
-			struct iovec a = iov_advance(iov, iovcnt, rc);
+		size_t processed = 0;
+		ssize_t rc = machine_writev_raw(io->io, iov, iovcnt, &processed);
+
+		/*
+		 * Advance the scatter-gather vector by the number of consumed
+		 * input bytes. For the socket/TLS paths and for streaming
+		 * compression on success, rc itself is that number. For
+		 * compression, *processed is additionally set by the compressor
+		 * on partial-progress errors (rc <= 0) and holds the bytes
+		 * already accepted; those must not be resent on retry. This
+		 * additive accounting mirrors machine_write_no_free() which
+		 * uses machine_write_raw() the same way.
+		 */
+		size_t consumed = processed + (rc > 0 ? (size_t)rc : 0);
+		if (consumed > 0) {
+			struct iovec a = iov_advance(iov, iovcnt, consumed);
 			iov = a.iov_base;
 			iovcnt = a.iov_len;
+		}
 
+		if (rc > 0) {
 			continue;
 		}
 

--- a/sources/machinarium/compression.c
+++ b/sources/machinarium/compression.c
@@ -18,7 +18,7 @@ void mm_compression_free(mm_io_t *io)
 	}
 }
 
-int mm_compression_writev(mm_io_t *io, struct iovec *iov, int n,
+int mm_compression_writev(mm_io_t *io, const struct iovec *iov, int n,
 			  size_t *processed)
 {
 	int size = mm_iov_size_of(iov, n);

--- a/sources/machinarium/write.c
+++ b/sources/machinarium/write.c
@@ -32,9 +32,11 @@ MACHINE_API ssize_t machine_write_raw(mm_io_t *obj, const void *buf,
 }
 
 MACHINE_API ssize_t machine_writev_raw(mm_io_t *io, const struct iovec *iov,
-				       int iovcnt)
+				       int iovcnt, size_t *processed)
 {
 	mm_errno_set(0);
+	if (processed)
+		*processed = 0;
 
 	int iov_to_write = iovcnt;
 	if (iov_to_write > IOV_MAX) {
@@ -44,12 +46,12 @@ MACHINE_API ssize_t machine_writev_raw(mm_io_t *io, const struct iovec *iov,
 	ssize_t rc;
 #ifdef MM_BUILD_COMPRESSION
 	if (mm_compression_is_active(io)) {
-		size_t processed = 0;
-		rc = mm_compression_writev(io, iovec, iov_to_write, &processed);
-		/* processed > 0 in case of error return code, but consumed input */
-		if (processed > 0) {
-			mm_iov_advance(iov, processed);
-		}
+		/* mm_compression_writev reports consumed input bytes via
+		 * *processed on partial-progress errors (rc <= 0); on
+		 * success it returns the number of consumed input bytes
+		 * as rc, leaving *processed untouched. This matches the
+		 * contract of machine_write_raw() / mm_zpq_write(). */
+		rc = mm_compression_writev(io, iov, iov_to_write, processed);
 	} else if (mm_tls_is_active(io))
 #else
 	if (mm_tls_is_active(io))


### PR DESCRIPTION
Исправление ошибки сборки https://github.com/yandex/odyssey/issues/1462

Честно говоря, сделал полностью с помощью ИИ и сам НЕ вникал, мог получиться бред. Посмотрите, пожалуйста.

<hr>
machine_writev_raw() failed to compile under -DBUILD_COMPRESSION=True: 'iovec' was used instead of the 'iov' parameter, and mm_iov_advance() was referenced but never defined. The local-iov mutation would not have propagated to the caller anyway, so the partial-progress path for compression was dead on arrival.

Align the contract of machine_writev_raw() with the existing machine_write_raw() by adding a size_t *processed out-parameter. *processed is only written by the streaming compressor on partial-progress errors (see zstd_write/zlib_write in zpq_stream.c), which is exactly the contract machine_write_raw() already has via mm_zpq_write(). On success rc itself is the number of consumed input bytes uniformly across the socket, TLS and compression paths.

od_io_writev() advances the scatter-gather vector by processed + (rc > 0 ? rc : 0), matching the additive accounting already used by machine_write_no_free() for the machine_write_raw() path: on a retryable error with partial progress *processed holds the bytes the compressor has already accepted and they must not be resent on retry, otherwise the compressed stream gets corrupted.

Also make the iov argument of mm_compression_writev() const, since it only reads from it via mm_iovcpy(), so the const pointer from machine_writev_raw() can be forwarded without a cast.

Co-authored-by: [Z.AI](https://z.ai/subscribe?ic=OKXME28I1P) GLM

<hr>
Еще вот что ИИ выдал:

"od_io_writev выходит из цикла, как только iovcnt == 0, без проверки mm_compression_write_pending(io) — тогда как machine_write_no_free (write.c:99) такую проверку делает (while (total != size || mm_compression_write_pending(io))). Теоретически, если компрессор принял весь ввод, но ещё не сбросил внутренний TX-буфер, часть байт останется в компрессоре неотправленной. Поведение точно такое же, как в коде до коммита."