### PR TITLE
Narrow gitignore .patch file exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ odyssey.logrotate
 cscope.out
 prometheus/exporter/odyssey_exporter
 site/
-*.patch
+/*.patch
 docs/tf/.terraform.lock.hcl
 docs/tf/.terraform/
 docs/tf/terraform.tfstate


### PR DESCRIPTION
Currently the \*.patch entry in .gitignore covers patches everywhere in the repo, including for example "debian/patches", which can create a bit of an issue for downstream packaging. It's not too hard to work around; for example in Ubuntu we can add a "debian/.gitignore" with an entry to negate the \*.patch ignore (like [here](https://code.launchpad.net/~blkerby/ubuntu/+source/odyssey/+git/odyssey/+merge/508649)), but we wondered if it could make sense to instead narrow the scope of the original  \*.patch ignore to only cover patch files in the root of the repo, if that would cover the purpose of the ignore?