### PR TITLE
Apply runtime logging/stats settings on config reload (SIGHUP)

### DIFF
--- a/sources/backend.c
+++ b/sources/backend.c
@@ -401,8 +401,11 @@ int od_backend_connect_to(od_server_t *server, char *context,
 		}
 	}
 
+	/* snapshot log_session to avoid race on config reload (SIGHUP) */
+	int log_session = instance->config.log_session;
+
 	uint64_t time_connect_start = 0;
-	if (instance->config.log_session) {
+	if (log_session) {
 		time_connect_start = machine_time_us();
 	}
 
@@ -461,7 +464,7 @@ int od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	uint64_t time_resolve = 0;
-	if (instance->config.log_session) {
+	if (log_session) {
 		time_resolve = machine_time_us() - time_connect_start;
 	}
 
@@ -529,12 +532,12 @@ int od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	uint64_t time_connect = 0;
-	if (instance->config.log_session) {
+	if (log_session) {
 		time_connect = machine_time_us() - time_connect_start;
 	}
 
 	/* log server connection */
-	if (instance->config.log_session) {
+	if (log_session) {
 		char addr_buff[256];
 		mm_io_format_socket_addr(server->io.io, addr_buff,
 					 sizeof(addr_buff));

--- a/sources/config.c
+++ b/sources/config.c
@@ -105,6 +105,7 @@ void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 {
 	current_config->log_debug = new_config->log_debug;
 	current_config->log_config = new_config->log_config;
+	current_config->log_session = new_config->log_session;
 	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;
 	current_config->max_sigterms_to_die = new_config->max_sigterms_to_die;

--- a/sources/config.c
+++ b/sources/config.c
@@ -106,6 +106,7 @@ void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 	current_config->log_debug = new_config->log_debug;
 	current_config->log_config = new_config->log_config;
 	current_config->log_session = new_config->log_session;
+	current_config->log_query = new_config->log_query;
 	current_config->log_stats = new_config->log_stats;
 	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;

--- a/sources/config.c
+++ b/sources/config.c
@@ -108,6 +108,7 @@ void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 	current_config->log_session = new_config->log_session;
 	current_config->log_query = new_config->log_query;
 	current_config->log_stats = new_config->log_stats;
+	current_config->stats_interval = new_config->stats_interval;
 	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;
 	current_config->max_sigterms_to_die = new_config->max_sigterms_to_die;

--- a/sources/config.c
+++ b/sources/config.c
@@ -106,6 +106,7 @@ void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 	current_config->log_debug = new_config->log_debug;
 	current_config->log_config = new_config->log_config;
 	current_config->log_session = new_config->log_session;
+	current_config->log_stats = new_config->log_stats;
 	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;
 	current_config->max_sigterms_to_die = new_config->max_sigterms_to_die;

--- a/sources/config.c
+++ b/sources/config.c
@@ -104,6 +104,7 @@ void od_config_init(od_config_t *config)
 void od_config_reload(od_config_t *current_config, od_config_t *new_config)
 {
 	current_config->log_debug = new_config->log_debug;
+	current_config->log_config = new_config->log_config;
 	current_config->client_max_set = new_config->client_max_set;
 	current_config->client_max = new_config->client_max;
 	current_config->max_sigterms_to_die = new_config->max_sigterms_to_die;

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -134,7 +134,10 @@ static inline void od_cron_stat(od_cron_t *cron)
 	od_instance_t *instance = cron->global->instance;
 	od_worker_pool_t *worker_pool = cron->global->worker_pool;
 
-	if (instance->config.log_stats) {
+	/* snapshot log_stats to avoid race on config reload (SIGHUP) */
+	int log_stats = instance->config.log_stats;
+
+	if (log_stats) {
 		/* system worker stats */
 		uint64_t count_coroutine = 0;
 		uint64_t count_coroutine_cache = 0;
@@ -183,7 +186,7 @@ static inline void od_cron_stat(od_cron_t *cron)
 
 	/* update stats per route and print info */
 	od_route_pool_stat_cb_t stat_cb;
-	if (!instance->config.log_stats) {
+	if (!log_stats) {
 		stat_cb = NULL;
 	} else {
 		stat_cb = od_cron_stat_cb;

--- a/sources/system.c
+++ b/sources/system.c
@@ -519,6 +519,7 @@ void od_system_config_reload(od_system_t *system)
 		return;
 	}
 	od_config_reload(&instance->config, &config);
+	od_logger_set_debug(&instance->logger, instance->config.log_debug);
 	od_hba_reload(hba, &hba_rules);
 
 	/* auto-generate default rule for auth_query if none specified */


### PR DESCRIPTION
Added log_debug, log_session, log_query, log_stats, log_config, stats_interval to the config reload path (SIGHUP).