### PR TITLE
up default stack size to 16 pages

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -32,7 +32,7 @@ for all Odyssey rules.
 | `workers`                                  | int              | `1`         | restart | Worker threads for clients                            |
 | `resolvers`                                | int              | `1`         | restart | DNS resolver threads                                  |
 | `readahead`                                | int (bytes)      | one page    | SIGHUP  | Per-connection read buffer                            |
-| `cache_coroutine`                          | int              | `256`       | restart | Coroutines cache size                                  |
+| `cache_coroutine`                          | int              | `1024`      | restart | Coroutines cache size                                  |
 | `nodelay`                                  | int (bool)       | `yes`       | SIGHUP  | Enable TCP\_NODELAY                                   |
 | `disable_nolinger`                         | int (bool)       | `yes`       | SIGHUP  | Do no set tcp linger to 0 for client connections                  |
 | `keepalive`                                | int (sec)        | `15`        | SIGHUP  | TCP keepalive; 0 disables                             |
@@ -40,7 +40,7 @@ for all Odyssey rules.
 | `keepalive_probes`                         | int              | `3`         | SIGHUP  | Probes before killing conn                            |
 | `keepalive_usr_timeout`                    | int (ms)         | `0`         | SIGHUP  | 0 = use system default (`TCP_USER_TIMEOUT`)           |
 | `backend_connect_timeout_ms`               | int (ms)         | `30000`     | SIGHUP  | Backend connection timeout                            |
-| `coroutine_stack_size`                     | int (pages)      | `4`         | restart | Coroutine stack size (client/worker coroutines)       |
+| `coroutine_stack_size`                     | int (pages)      | `16`        | restart | Coroutine stack size (client/worker coroutines); values below 16 are not recommended |
 | `system_coroutine_stack_size`              | int (pages)      | `32`        | restart | Coroutine stack size for internal system coroutines   |
 | `client_max`                               | int              | `0`         | SIGHUP  | Max client connections (0/unset = no global limit)    |
 | `client_max_routing`                       | int              | `0`         | SIGHUP  | 0/unset → auto (typically `64 * workers`)             |
@@ -321,12 +321,14 @@ Rounded up to whole page numbers.
 *integer*
 
 Set pool size of free coroutines cache. It is a good idea to set
-this value to a sum of max clients plus server connections. Please note, that
-each coroutine consumes around 16KB of memory.
+this value to a sum of max clients plus server connections. Note that
+each coroutine reserves `(coroutine_stack_size + 1) * page_size` of virtual address space
+(e.g. 68 KB with the default 16-page stack on a 4 KB page system), but physical pages
+are only faulted in as the stack actually grows, so RSS is typically much lower.
 
 Set to zero, to disable coroutine cache.
 
-`cache_coroutine 128`
+`cache_coroutine 1024`
 
 ## **nodelay**
 *yes|no*
@@ -389,12 +391,19 @@ Timeout for connection to backend (postgres). Default value is 30000 (30 secs)
 
 Coroutine stack size for client and worker coroutines.
 
-Set coroutine stack size in pages. In some rare cases
-it might be necessary to make stack size bigger (like that using the Odyssey with LDAP auth required `coroutine_stack_size 16`). Actual stack will be
-allocated as `(coroutine_stack_size + 1_guard_page) * page_size`.
-Guard page is used to track stack overflows. Stack by default is set to 16KB.
+Set coroutine stack size in pages. Actual stack is allocated as
+`(coroutine_stack_size + 1_guard_page) * page_size`. The guard page
+is protected (`PROT_NONE`) and catches stack overflows. It is purely
+virtual — backed by `mmap(MAP_ANONYMOUS)` with no physical pages
+allocated, so it contributes nothing to RSS.
 
-`coroutine_stack_size 4`
+**Values below 16 pages (64 KB on a 4 KB page system) are not recommended.**
+A stack that is too small can cause silent stack overflows or crashes in
+scenarios involving TLS handshakes, LDAP authentication, config reload, or
+deep library call chains. Odyssey will emit a warning at startup if
+`coroutine_stack_size` is set below 16.
+
+`coroutine_stack_size 16`
 
 ## **system\_coroutine\_stack\_size**
 *integer*
@@ -413,6 +422,8 @@ from `coroutine_stack_size` avoids inflating memory usage for the large number
 of client coroutines just to accommodate the rare system operations.
 
 Actual stack is allocated as `(system_coroutine_stack_size + 1_guard_page) * page_size`.
+The guard page is purely virtual (`mmap(MAP_ANONYMOUS)` + `mprotect(PROT_NONE)`) and
+contributes nothing to RSS.
 
 `system_coroutine_stack_size 32`
 

--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -461,6 +461,14 @@ int convert_global(const od_cfg_global_t *cfg, od_config_t *config,
 	COPY_INT(cfg->cache_msg_gc_size, config->cache_msg_gc_size);
 	COPY_INT(cfg->cache_coroutine, config->cache_coroutine);
 	COPY_INT(cfg->coroutine_stack_size, config->coroutine_stack_size);
+	if (config->coroutine_stack_size < 16) {
+		od_cfg_diag_warning(
+			diags, cfg->coroutine_stack_size.seen.location,
+			"coroutine_stack_size %d is below the recommended minimum of 16 pages (%d KB); "
+			"values below 16 may cause stack overflows with TLS, LDAP, or config reload",
+			config->coroutine_stack_size,
+			config->coroutine_stack_size * 4);
+	}
 	COPY_INT(cfg->system_coroutine_stack_size,
 		 config->system_coroutine_stack_size);
 	COPY_INT(cfg->group_checker_interval, config->group_checker_interval);

--- a/sources/cfg/diag.c
+++ b/sources/cfg/diag.c
@@ -44,6 +44,7 @@ void od_cfg_diag_list_free(od_cfg_diag_list_t *diags)
 	}
 
 	for (size_t i = 0; i < diags->count; i++) {
+		od_free((char *)diags->items[i].location.filename);
 		od_free(diags->items[i].message);
 		od_free(diags->items[i].hint);
 	}
@@ -77,6 +78,8 @@ static void od_cfg_diag_addv(od_cfg_diag_list_t *diags,
 
 	diag->level = level;
 	diag->location = location;
+	diag->location.filename =
+		location.filename ? od_strdup(location.filename) : NULL;
 	diag->message = od_cfg_vformat(fmt, args);
 	diag->hint = NULL;
 }

--- a/sources/cfg/model.c
+++ b/sources/cfg/model.c
@@ -485,8 +485,38 @@ void od_cfg_model_dumpf(FILE *file, const od_cfg_model_t *model)
 
 static void od_cfg_string_field_free(od_cfg_string_field_t *field)
 {
+	od_cfg_seen_free(&field->seen);
 	od_free(field->value);
 	field->value = NULL;
+}
+
+static void od_cfg_int_field_free(od_cfg_int_field_t *field)
+{
+	od_cfg_seen_free(&field->seen);
+}
+
+static void od_cfg_bool_field_free(od_cfg_bool_field_t *field)
+{
+	od_cfg_seen_free(&field->seen);
+}
+
+static void od_cfg_u64_field_free(od_cfg_u64_field_t *field)
+{
+	od_cfg_seen_free(&field->seen);
+}
+
+void od_cfg_seen_set(od_cfg_seen_t *seen, od_cfg_location_t location)
+{
+	seen->is_set = 1;
+	seen->location = location;
+	seen->location.filename =
+		location.filename ? od_strdup(location.filename) : NULL;
+}
+
+void od_cfg_seen_free(od_cfg_seen_t *seen)
+{
+	od_free((char *)seen->location.filename);
+	seen->location.filename = NULL;
 }
 
 static void od_cfg_listen_free(od_cfg_listen_t *listen)
@@ -496,13 +526,16 @@ static void od_cfg_listen_free(od_cfg_listen_t *listen)
 	}
 
 	od_cfg_string_field_free(&listen->host);
-
+	od_cfg_int_field_free(&listen->port);
 	od_cfg_string_field_free(&listen->target_session_attrs);
+	od_cfg_int_field_free(&listen->client_login_timeout);
+	od_cfg_int_field_free(&listen->backlog);
 	od_cfg_string_field_free(&listen->tls);
 	od_cfg_string_field_free(&listen->tls_ca_file);
 	od_cfg_string_field_free(&listen->tls_key_file);
 	od_cfg_string_field_free(&listen->tls_cert_file);
 	od_cfg_string_field_free(&listen->tls_protocols);
+	od_cfg_int_field_free(&listen->catchup_timeout);
 
 	od_free(listen);
 }
@@ -523,12 +556,19 @@ static void od_cfg_storage_free(od_cfg_storage_t *storage)
 
 	od_cfg_string_field_free(&storage->type);
 	od_cfg_string_field_free(&storage->host);
+	od_cfg_int_field_free(&storage->port);
 	od_cfg_string_field_free(&storage->tls);
 	od_cfg_string_field_free(&storage->tls_ca_file);
 	od_cfg_string_field_free(&storage->tls_key_file);
 	od_cfg_string_field_free(&storage->tls_cert_file);
 	od_cfg_string_field_free(&storage->tls_protocols);
+	od_cfg_int_field_free(&storage->server_max_routing);
+	od_cfg_int_field_free(&storage->endpoints_status_poll_interval_ms);
 
+	od_cfg_seen_free(&storage->balancing.seen);
+	od_cfg_bool_field_free(&storage->balancing.show_notice_messages);
+	od_cfg_seen_free(&storage->balancing.method.seen);
+	od_cfg_bool_field_free(&storage->balancing.method.az_aware);
 	od_free(storage->balancing.method.name);
 
 	od_free(storage);
@@ -541,6 +581,7 @@ static void od_cfg_shared_pool_free(od_cfg_shared_pool_t *pool)
 	}
 
 	od_free(pool->name);
+	od_cfg_int_field_free(&pool->pool_size);
 	od_free(pool);
 }
 
@@ -553,6 +594,7 @@ static void od_cfg_ldap_endpoint_free(od_cfg_ldap_endpoint_t *endpoint)
 	od_free(endpoint->name);
 
 	od_cfg_string_field_free(&endpoint->ldapserver);
+	od_cfg_u64_field_free(&endpoint->ldapport);
 	od_cfg_string_field_free(&endpoint->ldapprefix);
 	od_cfg_string_field_free(&endpoint->ldapsuffix);
 	od_cfg_string_field_free(&endpoint->ldapsearchattribute);
@@ -608,32 +650,66 @@ static void od_cfg_user_route_free(od_cfg_route_t *user)
 
 	od_cfg_string_field_free(&user->authentication);
 	od_cfg_string_field_free(&user->auth_module);
-
+	od_cfg_bool_field_free(&user->enable_mdb_iamproxy_auth);
 	od_cfg_string_field_free(&user->mdb_iamproxy_socket_path);
 	od_cfg_string_field_free(&user->auth_pam_service);
 	od_cfg_string_field_free(&user->target_session_attrs);
 	od_cfg_string_field_free(&user->auth_query);
 	od_cfg_string_field_free(&user->auth_query_db);
 	od_cfg_string_field_free(&user->auth_query_user);
+	od_cfg_bool_field_free(&user->password_passthrough);
 	od_cfg_string_field_free(&user->password);
 	od_cfg_string_field_free(&user->role);
+	od_cfg_int_field_free(&user->client_max);
+	od_cfg_bool_field_free(&user->client_fwd_error);
+	od_cfg_bool_field_free(&user->client_show_id);
+	od_cfg_bool_field_free(&user->reserve_session_server_connection);
 	od_cfg_string_field_free(&user->quantiles);
+	od_cfg_bool_field_free(&user->application_name_add_host);
+	od_cfg_bool_field_free(&user->server_drop_on_backend_plan_error);
+	od_cfg_u64_field_free(&user->server_lifetime);
+	od_cfg_int_field_free(&user->ldap_pool_size);
+	od_cfg_int_field_free(&user->ldap_pool_timeout);
+	od_cfg_int_field_free(&user->ldap_pool_ttl);
+	od_cfg_bool_field_free(&user->maintain_params);
 	od_cfg_string_field_free(&user->pool);
 	od_cfg_string_field_free(&user->pool_routing);
+	od_cfg_int_field_free(&user->min_pool_size);
+	od_cfg_int_field_free(&user->pool_size);
+	od_cfg_int_field_free(&user->pool_timeout);
+	od_cfg_int_field_free(&user->pool_ttl);
+	od_cfg_bool_field_free(&user->pool_discard);
+	od_cfg_bool_field_free(&user->pool_smart_discard);
 	od_cfg_string_field_free(&user->pool_discard_query);
+	od_cfg_bool_field_free(&user->pool_cancel);
+	od_cfg_bool_field_free(&user->pool_rollback);
+	od_cfg_u64_field_free(&user->pool_reset_timeout_ms);
+	od_cfg_bool_field_free(&user->pool_reserve_prepared_statement);
+	od_cfg_bool_field_free(&user->pool_pin_on_listen);
+	od_cfg_bool_field_free(&user->pool_attach_check);
+	od_cfg_bool_field_free(&user->pool_acquire_fail_fast);
+	od_cfg_u64_field_free(&user->pool_notice_after_waiting_ms);
+	od_cfg_u64_field_free(&user->pool_client_idle_timeout);
+	od_cfg_u64_field_free(&user->pool_idle_in_transaction_timeout);
 	od_cfg_string_field_free(&user->shared_pool);
 	od_cfg_string_field_free(&user->storage);
 	od_cfg_string_field_free(&user->storage_database);
 	od_cfg_string_field_free(&user->storage_user);
 	od_cfg_string_field_free(&user->storage_password);
+	od_cfg_bool_field_free(&user->log_debug);
+	od_cfg_bool_field_free(&user->log_query);
 	od_cfg_string_field_free(&user->ldap_endpoint_name);
 	od_cfg_string_field_free(&user->ldap_storage_credentials_attr);
 	od_cfg_string_field_free(&user->watchdog_lag_query);
+	od_cfg_int_field_free(&user->watchdog_lag_interval);
+	od_cfg_int_field_free(&user->catchup_timeout);
 	od_cfg_string_field_free(&user->group_query);
 	od_cfg_string_field_free(&user->group_query_user);
 	od_cfg_string_field_free(&user->group_query_db);
 
+	od_cfg_seen_free(&user->pgoptions.seen);
 	od_cfg_string_kvp_list_free(&user->pgoptions);
+	od_cfg_seen_free(&user->backend_startup_options.seen);
 	od_cfg_string_kvp_list_free(&user->backend_startup_options);
 
 	od_free(user);
@@ -662,6 +738,28 @@ static void od_cfg_database_free(od_cfg_database_t *db)
 
 void od_cfg_model_free(od_cfg_model_t *model)
 {
+	/* global bool fields */
+	od_cfg_bool_field_free(&model->global.daemonize);
+	od_cfg_bool_field_free(&model->global.sequential_routing);
+	od_cfg_bool_field_free(&model->global.enable_online_restart);
+	od_cfg_bool_field_free(&model->global.virtual_processing);
+	od_cfg_bool_field_free(&model->global.bindwith_reuseport);
+	od_cfg_bool_field_free(&model->global.enable_host_watcher);
+	od_cfg_bool_field_free(&model->global.log_debug);
+	od_cfg_bool_field_free(&model->global.log_to_stdout);
+	od_cfg_bool_field_free(&model->global.log_config);
+	od_cfg_bool_field_free(&model->global.log_session);
+	od_cfg_bool_field_free(&model->global.log_query);
+	od_cfg_bool_field_free(&model->global.log_stats);
+	od_cfg_bool_field_free(&model->global.log_async);
+	od_cfg_bool_field_free(&model->global.log_syslog);
+	od_cfg_bool_field_free(&model->global.smart_search_path_enquoting);
+	od_cfg_bool_field_free(&model->global.nodelay);
+	od_cfg_bool_field_free(&model->global.disable_nolinger);
+	od_cfg_bool_field_free(&model->global.log_general_stats_prom);
+	od_cfg_bool_field_free(&model->global.log_route_stats_prom);
+
+	/* global string fields */
 	od_cfg_string_field_free(&model->global.pid_file);
 	od_cfg_string_field_free(&model->global.unix_socket_dir);
 	od_cfg_string_field_free(&model->global.unix_socket_mode);
@@ -675,13 +773,46 @@ void od_cfg_model_free(od_cfg_model_t *model)
 	od_cfg_string_field_free(&model->global.cpu_affinity);
 	od_cfg_string_field_free(&model->global.hba_file);
 
-	if (model->soft_oom.seen.is_set) {
-		od_cfg_string_field_free(&model->soft_oom.process);
+	/* global int fields */
+	od_cfg_int_field_free(&model->global.priority);
+	od_cfg_int_field_free(&model->global.graceful_shutdown_timeout_ms);
+	od_cfg_int_field_free(&model->global.log_queue_depth);
+	od_cfg_int_field_free(&model->global.stats_interval);
+	od_cfg_int_field_free(&model->global.client_max);
+	od_cfg_int_field_free(&model->global.client_max_routing);
+	od_cfg_int_field_free(&model->global.server_login_retry);
+	od_cfg_int_field_free(&model->global.readahead);
+	od_cfg_int_field_free(&model->global.keepalive);
+	od_cfg_int_field_free(&model->global.keepalive_keep_interval);
+	od_cfg_int_field_free(&model->global.keepalive_probes);
+	od_cfg_int_field_free(&model->global.keepalive_usr_timeout);
+	od_cfg_int_field_free(&model->global.max_sigterms_to_die);
+	od_cfg_int_field_free(&model->global.backend_connect_timeout_ms);
+	od_cfg_int_field_free(&model->global.cancel_timeout_ms);
+	od_cfg_int_field_free(&model->global.cancel_queue_timeout_ms);
+	od_cfg_int_field_free(&model->global.cancel_max_inflight);
+	od_cfg_int_field_free(&model->global.resolvers);
+	od_cfg_int_field_free(&model->global.dns_cache_ttl);
+	od_cfg_int_field_free(&model->global.cache_msg_gc_size);
+	od_cfg_int_field_free(&model->global.cache_coroutine);
+	od_cfg_int_field_free(&model->global.coroutine_stack_size);
+	od_cfg_int_field_free(&model->global.system_coroutine_stack_size);
+	od_cfg_int_field_free(&model->global.promhttp_server_port);
+	od_cfg_int_field_free(&model->global.group_checker_interval);
+	od_cfg_int_field_free(&model->global.workers);
 
-		if (model->soft_oom.drop.seen.is_set) {
-			od_cfg_string_field_free(&model->soft_oom.drop.signal);
-		}
-	}
+	od_cfg_seen_free(&model->conn_drop_options.seen);
+	od_cfg_bool_field_free(&model->conn_drop_options.drop_enabled);
+	od_cfg_int_field_free(&model->conn_drop_options.rate);
+	od_cfg_int_field_free(&model->conn_drop_options.interval_ms);
+
+	od_cfg_seen_free(&model->soft_oom.seen);
+	od_cfg_u64_field_free(&model->soft_oom.limit);
+	od_cfg_string_field_free(&model->soft_oom.process);
+	od_cfg_int_field_free(&model->soft_oom.check_interval_ms);
+	od_cfg_seen_free(&model->soft_oom.drop.seen);
+	od_cfg_string_field_free(&model->soft_oom.drop.signal);
+	od_cfg_int_field_free(&model->soft_oom.drop.max_rate);
 
 	for (size_t i = 0; i < model->databases_count; ++i) {
 		od_cfg_database_free(model->databases[i]);
@@ -1071,8 +1202,7 @@ int od_cfg_set_bool(od_cfg_diag_list_t *diags, od_cfg_bool_field_t *field,
 	}
 
 	field->value = value ? 1 : 0;
-	field->seen.is_set = 1;
-	field->seen.location = location;
+	od_cfg_seen_set(&field->seen, location);
 	return 0;
 }
 
@@ -1086,8 +1216,7 @@ int od_cfg_set_int(od_cfg_diag_list_t *diags, od_cfg_int_field_t *field,
 	}
 
 	field->value = value;
-	field->seen.is_set = 1;
-	field->seen.location = location;
+	od_cfg_seen_set(&field->seen, location);
 	return 0;
 }
 
@@ -1146,8 +1275,7 @@ int od_cfg_set_u64(od_cfg_diag_list_t *diags, od_cfg_u64_field_t *field,
 	}
 
 	field->value = value;
-	field->seen.is_set = 1;
-	field->seen.location = location;
+	od_cfg_seen_set(&field->seen, location);
 	return 0;
 }
 
@@ -1497,8 +1625,7 @@ int od_cfg_set_string(od_cfg_diag_list_t *diags, od_cfg_string_field_t *field,
 	}
 
 	field->value = value;
-	field->seen.is_set = 1;
-	field->seen.location = location;
+	od_cfg_seen_set(&field->seen, location);
 	return 0;
 }
 

--- a/sources/cfg/parse.y
+++ b/sources/cfg/parse.y
@@ -2065,8 +2065,7 @@ balancing_section:
 				YYERROR;
 			}
 
-			b->seen.is_set = 1;
-			b->seen.location = @1;
+			od_cfg_seen_set(&b->seen, @1);
 			b->location = @1;
 
 			ctx->current_balancing = b;
@@ -2109,8 +2108,7 @@ balancing_method_section:
 				YYERROR;
 			}
 
-			m->seen.is_set = 1;
-			m->seen.location = @1;
+			od_cfg_seen_set(&m->seen, @1);
 			m->location = @1;
 
 			m->name = $2;
@@ -2303,8 +2301,7 @@ conn_drop_options_section:
 				YYERROR;
 			}
 
-			opts->seen.is_set = 1;
-			opts->seen.location = @1;
+			od_cfg_seen_set(&opts->seen, @1);
 			opts->location = @1;
 
 			ctx->current_conn_drop_options = opts;
@@ -2326,8 +2323,7 @@ soft_oom_section:
 				YYERROR;
 			}
 
-			soom->seen.is_set = 1;
-			soom->seen.location = @1;
+			od_cfg_seen_set(&soom->seen, @1);
 			soom->location = @1;
 
 			ctx->current_soft_oom = soom;
@@ -2389,8 +2385,7 @@ soft_oom_drop:
 				YYERROR;
 			}
 
-			drop->seen.is_set = 1;
-			drop->seen.location = @1;
+			od_cfg_seen_set(&drop->seen, @1);
 			drop->location = @1;
 
 			ctx->current_soft_oom_drop = drop;

--- a/sources/config.c
+++ b/sources/config.c
@@ -70,9 +70,9 @@ void od_config_init(od_config_t *config)
 	config->client_max = 0;
 	config->client_max_routing = 0;
 	config->server_login_retry = 1;
-	config->cache_coroutine = 256;
+	config->cache_coroutine = 1024;
 	config->cache_msg_gc_size = 0;
-	config->coroutine_stack_size = 4;
+	config->coroutine_stack_size = 16;
 	config->system_coroutine_stack_size = 32;
 	config->hba_file = NULL;
 	config->max_sigterms_to_die = 3;

--- a/sources/include/cfg/model.h
+++ b/sources/include/cfg/model.h
@@ -18,6 +18,9 @@ typedef struct {
 	od_cfg_location_t location;
 } od_cfg_seen_t;
 
+void od_cfg_seen_set(od_cfg_seen_t *seen, od_cfg_location_t location);
+void od_cfg_seen_free(od_cfg_seen_t *seen);
+
 typedef struct {
 	int value;
 	od_cfg_seen_t seen;

--- a/test/async-notice/test.conf
+++ b/test/async-notice/test.conf
@@ -9,7 +9,6 @@ log_stats no
 
 daemonize no
 
-coroutine_stack_size 16
 
 locks_dir "/tmp/odyssey"
 

--- a/test/functional/odyssey.conf
+++ b/test/functional/odyssey.conf
@@ -38,7 +38,6 @@ graceful_die_on_errors yes
 enable_online_restart yes
 bindwith_reuseport yes
 
-coroutine_stack_size 24
 
 stats_interval 60
 

--- a/test/functional/tests/auth_query/config.conf
+++ b/test/functional/tests/auth_query/config.conf
@@ -60,7 +60,6 @@ log_session no
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/cancel-leak/cancel-leak.conf
+++ b/test/functional/tests/cancel-leak/cancel-leak.conf
@@ -38,7 +38,6 @@ log_session yes
 log_stats yes
 log_query no
 stats_interval 1
-coroutine_stack_size 24
 workers 2
 resolvers 1
 client_max_routing 16

--- a/test/functional/tests/cancel/cancel.conf
+++ b/test/functional/tests/cancel/cancel.conf
@@ -26,7 +26,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/cascade/odyssey-gateway.conf
+++ b/test/functional/tests/cascade/odyssey-gateway.conf
@@ -14,7 +14,6 @@ log_session yes
 log_stats yes
 stats_interval 1
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/cascade/odyssey-root1.conf
+++ b/test/functional/tests/cascade/odyssey-root1.conf
@@ -14,7 +14,6 @@ log_session yes
 log_stats yes
 stats_interval 1
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/cascade/odyssey-root2.conf
+++ b/test/functional/tests/cascade/odyssey-root2.conf
@@ -14,7 +14,6 @@ log_session yes
 log_stats yes
 stats_interval 1
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/copy/config.conf
+++ b/test/functional/tests/copy/config.conf
@@ -27,7 +27,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/functional/tests/copy/config_without_pstmt.conf
+++ b/test/functional/tests/copy/config_without_pstmt.conf
@@ -27,7 +27,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/functional/tests/external_auth/external_auth.conf
+++ b/test/functional/tests/external_auth/external_auth.conf
@@ -27,7 +27,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/graceful-shutdown-timeout/config.conf
+++ b/test/functional/tests/graceful-shutdown-timeout/config.conf
@@ -28,7 +28,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 graceful_shutdown_timeout_ms 5000
 

--- a/test/functional/tests/group/config.conf
+++ b/test/functional/tests/group/config.conf
@@ -141,4 +141,3 @@ stats_interval 60
 group_checker_interval 500
 pid_file "/var/run/odyssey.pid"
 
-coroutine_stack_size 16

--- a/test/functional/tests/hba/common.conf
+++ b/test/functional/tests/hba/common.conf
@@ -53,6 +53,4 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 8
-
 hba_file "/tests/hba/odyssey_hba.conf"

--- a/test/functional/tests/lagpolling/lag-conf.conf
+++ b/test/functional/tests/lagpolling/lag-conf.conf
@@ -27,7 +27,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 8
 
 nodelay yes
 

--- a/test/functional/tests/lagpolling_port/lag-conf.conf
+++ b/test/functional/tests/lagpolling_port/lag-conf.conf
@@ -27,7 +27,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 8
 
 nodelay yes
 

--- a/test/functional/tests/ldap/odyssey.conf
+++ b/test/functional/tests/ldap/odyssey.conf
@@ -147,7 +147,6 @@ log_query no
 log_stats no
 daemonize yes
 
-coroutine_stack_size 24
 
 locks_dir "/tmp/odyssey"
 graceful_die_on_errors yes

--- a/test/functional/tests/min_pool_size/config.conf
+++ b/test/functional/tests/min_pool_size/config.conf
@@ -44,7 +44,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/min_pool_size_reload/config.conf
+++ b/test/functional/tests/min_pool_size_reload/config.conf
@@ -44,7 +44,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/npgsql_compat/config.conf
+++ b/test/functional/tests/npgsql_compat/config.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/online-restart/odyssey.conf
+++ b/test/functional/tests/online-restart/odyssey.conf
@@ -15,7 +15,6 @@ log_session no
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 graceful_shutdown_timeout_ms 5000
 

--- a/test/functional/tests/pause-resume/session.conf
+++ b/test/functional/tests/pause-resume/session.conf
@@ -14,7 +14,6 @@ log_debug no
 log_session yes
 log_stats no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/pause-resume/transaction.conf
+++ b/test/functional/tests/pause-resume/transaction.conf
@@ -14,7 +14,6 @@ log_debug no
 log_session yes
 log_stats no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/pgoptions/odyssey.conf
+++ b/test/functional/tests/pgoptions/odyssey.conf
@@ -10,7 +10,6 @@ log_to_stdout no
 log_config yes
 log_session yes
 
-coroutine_stack_size 24
 
 smart_search_path_enquoting yes
 

--- a/test/functional/tests/pin_on_listen/odyssey.conf
+++ b/test/functional/tests/pin_on_listen/odyssey.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/prep_stmts/pstmts.conf
+++ b/test/functional/tests/prep_stmts/pstmts.conf
@@ -26,7 +26,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 8
 
 nodelay yes
 

--- a/test/functional/tests/query_processing/odyssey.conf
+++ b/test/functional/tests/query_processing/odyssey.conf
@@ -13,7 +13,6 @@ log_config yes
 log_session yes
 log_stats yes
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/reload-show-clients/config.conf
+++ b/test/functional/tests/reload-show-clients/config.conf
@@ -26,7 +26,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 8
 
 nodelay yes
 

--- a/test/functional/tests/reload/conf.conf
+++ b/test/functional/tests/reload/conf.conf
@@ -27,7 +27,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 8
 
 listen {
     host "*"

--- a/test/functional/tests/rule_address/addr.conf
+++ b/test/functional/tests/rule_address/addr.conf
@@ -63,4 +63,3 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24

--- a/test/functional/tests/rule_conn_type/odyssey.conf
+++ b/test/functional/tests/rule_conn_type/odyssey.conf
@@ -66,4 +66,3 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24

--- a/test/functional/tests/rules_order/not_seq_1.conf
+++ b/test/functional/tests/rules_order/not_seq_1.conf
@@ -119,4 +119,3 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24

--- a/test/functional/tests/rules_order/not_seq_1_reload.conf
+++ b/test/functional/tests/rules_order/not_seq_1_reload.conf
@@ -95,4 +95,3 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24

--- a/test/functional/tests/rules_order/seq_1.conf
+++ b/test/functional/tests/rules_order/seq_1.conf
@@ -121,4 +121,3 @@ log_query no
 
 sequential_routing yes
 
-coroutine_stack_size 24

--- a/test/functional/tests/rules_order/seq_1_reload.conf
+++ b/test/functional/tests/rules_order/seq_1_reload.conf
@@ -97,4 +97,3 @@ log_query no
 
 sequential_routing yes
 
-coroutine_stack_size 24

--- a/test/functional/tests/scram/config.conf
+++ b/test/functional/tests/scram/config.conf
@@ -70,7 +70,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/server-lifetime/pool_ttl.conf
+++ b/test/functional/tests/server-lifetime/pool_ttl.conf
@@ -41,7 +41,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/server-lifetime/server_lifetime.conf
+++ b/test/functional/tests/server-lifetime/server_lifetime.conf
@@ -41,7 +41,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/shared_pool/odyssey.conf
+++ b/test/functional/tests/shared_pool/odyssey.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/shell-test/conf.conf
+++ b/test/functional/tests/shell-test/conf.conf
@@ -32,7 +32,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 24
 
 nodelay yes
 

--- a/test/functional/tests/shell-test/conf2.conf
+++ b/test/functional/tests/shell-test/conf2.conf
@@ -26,7 +26,6 @@ readahead 8192
 
 cache_coroutine 0
 
-coroutine_stack_size 24
 
 nodelay yes
 

--- a/test/functional/tests/shell-test/pool_size.conf
+++ b/test/functional/tests/shell-test/pool_size.conf
@@ -15,7 +15,6 @@ log_session yes
 log_query no
 log_stats yes
 
-coroutine_stack_size 16
 
 listen {
 	host "*"

--- a/test/functional/tests/show-unix-socket-ports/conf.conf
+++ b/test/functional/tests/show-unix-socket-ports/conf.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/tls-compat/config.conf
+++ b/test/functional/tests/tls-compat/config.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/transactional/odyssey.conf
+++ b/test/functional/tests/transactional/odyssey.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/functional/tests/transactional_load/odyssey.conf
+++ b/test/functional/tests/transactional_load/odyssey.conf
@@ -15,7 +15,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 # strictly needed, to ensure connections pass free servers signal correctly
 workers 1

--- a/test/functional/tests/unix-socket-storage/conf.conf
+++ b/test/functional/tests/unix-socket-storage/conf.conf
@@ -28,7 +28,6 @@ log_session yes
 log_stats no
 log_query no
 
-coroutine_stack_size 24
 
 listen {
 	host "127.0.0.1"

--- a/test/jemalloc/odyssey.conf
+++ b/test/jemalloc/odyssey.conf
@@ -16,7 +16,6 @@ log_file "/odyssey.log"
 
 stats_interval 60
 
-coroutine_stack_size 24
 
 listen {
     host "0.0.0.0"

--- a/test/oom/odyssey.conf
+++ b/test/oom/odyssey.conf
@@ -6,7 +6,6 @@ log_to_stdout yes
 log_session no
 log_query no
 
-coroutine_stack_size 24
 
 daemonize no
 

--- a/test/pg_regress/conf/az_aware
+++ b/test/pg_regress/conf/az_aware
@@ -23,7 +23,6 @@ readahead 4096
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/pg_regress/conf/balancer
+++ b/test/pg_regress/conf/balancer
@@ -23,7 +23,6 @@ readahead 4096
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/pg_regress/conf/broken_conn
+++ b/test/pg_regress/conf/broken_conn
@@ -23,7 +23,6 @@ readahead 4096
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/pg_regress/conf/simple
+++ b/test/pg_regress/conf/simple
@@ -23,7 +23,6 @@ readahead 4096
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/pg_regress/conf/tsa
+++ b/test/pg_regress/conf/tsa
@@ -23,7 +23,6 @@ readahead 4096
 
 cache_coroutine 0
 
-coroutine_stack_size 16
 
 nodelay yes
 

--- a/test/prom-exporter/test.conf
+++ b/test/prom-exporter/test.conf
@@ -8,7 +8,6 @@ log_query no
 
 daemonize no
 
-coroutine_stack_size 128
 
 locks_dir "/tmp/odyssey"
 

--- a/test/prometheus-legacy/config.conf
+++ b/test/prometheus-legacy/config.conf
@@ -8,7 +8,6 @@ log_session no
 log_query no
 log_stats yes
 
-coroutine_stack_size 24
 
 listen {
     host "127.0.0.1"

--- a/test/proto/odyssey.conf
+++ b/test/proto/odyssey.conf
@@ -8,7 +8,6 @@ log_session yes
 log_query no
 log_stats no
 
-coroutine_stack_size 24
 
 daemonize no
 

--- a/test/quickstart/test.conf
+++ b/test/quickstart/test.conf
@@ -6,7 +6,6 @@ log_to_stdout yes
 log_session yes
 log_query no
 
-coroutine_stack_size 24
 
 daemonize no
 

--- a/test/replication/test.conf
+++ b/test/replication/test.conf
@@ -7,7 +7,6 @@ log_session yes
 log_query no
 log_stats no
 
-coroutine_stack_size 24
 
 daemonize no
 

--- a/test/scram-passthrough/odyssey.conf
+++ b/test/scram-passthrough/odyssey.conf
@@ -15,7 +15,6 @@ stats_interval 60
 workers 1
 readahead 4096
 cache_coroutine 0
-coroutine_stack_size 16
 
 listen {
 	host "*"

--- a/test/stress/odyssey.conf
+++ b/test/stress/odyssey.conf
@@ -16,7 +16,6 @@ log_file "/odyssey.log"
 
 stats_interval 60
 
-coroutine_stack_size 24
 
 listen {
     host "0.0.0.0"


### PR DESCRIPTION
Current default is too small and can lead to overflows with TLS, yyparse and etc. 128KB seems reasonable
and is used in boost.fiber