### PR TITLE
per-storage ramp-rate: replace busy-loop with wait-list & fix livelock

### DIFF
--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -444,6 +444,65 @@ void od_frontend_attach_init_candidates(
 	      candidate_cmp_desc);
 }
 
+/*
+ * returns 1 when a new backend connection attempt should be deferred
+ *
+ * the logic gradually reduces allowed parallelism as the pool fills:
+ * at 0 connections — full max_routing parallelism
+ * at pool_size/2 connections — only 1 parallel attempt allowed
+ */
+static inline int od_ramp_rate_exceeded(int connections_in_pool, int pool_size,
+					int currently_routing, int max_routing)
+{
+	if (pool_size == 0) {
+		return currently_routing >= max_routing;
+	}
+	max_routing =
+		max_routing * (pool_size - connections_in_pool * 2) / pool_size;
+	if (max_routing <= 0) {
+		max_routing = 1;
+	}
+	return currently_routing >= max_routing;
+}
+
+static inline void od_ramp_rate_done(od_rule_storage_t *stor)
+{
+	atomic_fetch_sub(&stor->servers_routing, 1);
+	mm_wait_list_notify(&stor->servers_routing_waiters);
+}
+
+static inline void od_ramp_rate_wait(od_rule_storage_t *storage,
+				     od_multi_pool_element_t *pool_element,
+				     int pool_size)
+{
+	int max_routing = (int)storage->server_max_routing;
+	while (1) {
+		uint64_t current = atomic_load(&storage->servers_routing);
+
+		/*
+		 * pool_element->pool.count_active/idle are read without the
+		 * route lock here. this is intentional: od_ramp_rate_exceeded
+		 * uses connections_in_pool only as a soft hint to gradually
+		 * reduce parallelism — a slightly stale value is harmless
+		 * The hard pool-size limit is enforced under the lock in
+		 * od_route_server_pool_can_add_locked inside the router
+		 */
+		if (od_ramp_rate_exceeded(
+			    od_server_pool_total(&pool_element->pool),
+			    pool_size, (int)current, max_routing)) {
+			mm_wait_list_compare_wait(
+				&storage->servers_routing_waiters, NULL,
+				current, 1000);
+			continue;
+		}
+
+		if (atomic_compare_exchange_weak(&storage->servers_routing,
+						 &current, current + 1)) {
+			break;
+		}
+	}
+}
+
 static inline od_frontend_status_t od_frontend_attach_to_endpoint(
 	od_client_t *client, char *context, kiwi_params_t *route_params,
 	od_storage_endpoint_t *endpoint, od_target_session_attrs_t tsa,
@@ -506,13 +565,20 @@ static inline od_frontend_status_t od_frontend_attach_to_endpoint(
 		/* connect to server, if necessary */
 		if (od_backend_not_connected(server)) {
 			int rc;
-			od_atomic_u32_inc(&router->servers_routing);
+			od_multi_pool_element_t *pool_element =
+				server->pool_element;
+			int pool_size = route->rule->pool->size;
+			if (od_route_has_shared_pool(route)) {
+				pool_size = route->shared_pool->pool_size;
+			}
+
+			od_ramp_rate_wait(storage, pool_element, pool_size);
 
 			assert(client->config_listen != NULL);
 			rc = od_backend_connect(server, context, route_params,
 						client);
 
-			od_atomic_u32_dec(&router->servers_routing);
+			od_ramp_rate_done(storage);
 			if (rc == NOT_OK_RESPONSE) {
 				/* In case of 'too many connections' error, retry attach attempt by
 				* waiting for a idle server connection for pool_timeout ms

--- a/sources/include/router.h
+++ b/sources/include/router.h
@@ -19,8 +19,6 @@ struct od_router {
 	od_route_pool_t route_pool;
 	/* clients */
 	od_atomic_u32_t clients;
-	/* servers */
-	od_atomic_u32_t servers_routing;
 	/* error logging */
 	od_error_logger_t *router_err_logger;
 

--- a/sources/include/storage.h
+++ b/sources/include/storage.h
@@ -6,7 +6,10 @@
  * Scalable PostgreSQL connection pooler.
  */
 
+#include <stdatomic.h>
+
 #include <machinarium/spinlock.h>
+#include <machinarium/wait_list.h>
 
 #include <kiwi/kiwi.h>
 
@@ -89,6 +92,14 @@ struct od_rule_storage {
 	int port; /* default port */
 
 	int server_max_routing;
+	/*
+	 * TODO: this should ideally be per-endpoint (od_storage_endpoint_t)
+	 * rather than per-storage, so that different physical hosts within the
+	 * same storage do not share the ramp-rate budget
+	 */
+	atomic_uint_fast64_t servers_routing;
+	mm_wait_list_t servers_routing_waiters;
+
 	od_storage_watchdog_t *watchdog;
 
 	od_list_t link;

--- a/sources/router.c
+++ b/sources/router.c
@@ -30,7 +30,6 @@ void od_router_init(od_router_t *router, od_global_t *global)
 	od_list_init(&router->servers);
 	od_route_pool_init(&router->route_pool);
 	router->clients = 0;
-	router->servers_routing = 0;
 
 	router->global = global;
 
@@ -816,43 +815,13 @@ void od_router_unroute(od_router_t *router, od_client_t *client)
 	od_route_unlock(route);
 }
 
-bool od_should_not_spun_connection_yet(int connections_in_pool, int pool_size,
-				       int currently_routing, int max_routing)
-{
-	if (pool_size == 0) {
-		return currently_routing >= max_routing;
-	}
-	/*
-	 * This routine controls ramping of server connections.
-	 * When we have a lot of server connections we try to avoid opening new
-	 * in parallel. Meanwhile when we have no server connections we go at
-	 * maximum configured parallelism.
-	 *
-	 * This equation means that we gradually reduce parallelism until we reach
-	 * half of possible connections in the pool.
-	 */
-	max_routing =
-		max_routing * (pool_size - connections_in_pool * 2) / pool_size;
-	if (max_routing <= 0) {
-		max_routing = 1;
-	}
-	return currently_routing >= max_routing;
-}
-
-#define MAX_BUZYLOOP_RETRY 10
-
 static inline od_router_status_t
-od_router_try_create_new_server(od_router_t *router, od_client_t *client,
+od_router_try_create_new_server(od_client_t *client,
 				od_storage_endpoint_t *endpoint,
 				od_server_t **out_server)
 {
 	od_server_t *server = NULL;
 	od_route_t *route = client->route;
-	od_rule_pool_t *rule_pool = route->rule->pool;
-	int pool_size = rule_pool->size;
-	if (od_route_has_shared_pool(route)) {
-		pool_size = route->shared_pool->pool_size;
-	}
 
 	od_multi_pool_element_t *pool_element =
 		od_route_get_server_pool_element_locked(route,
@@ -871,38 +840,6 @@ od_router_try_create_new_server(od_router_t *router, od_client_t *client,
 		/* can't add new connection - wait for some released */
 		od_route_unlock(route);
 		return OD_ROUTER_NEED_WAIT;
-	}
-
-	uint32_t max_routing =
-		(uint32_t)route->rule->storage->server_max_routing;
-
-	int busyloop_sleep = 0;
-	int busyloop_retry = 0;
-	while (od_should_not_spun_connection_yet(
-		od_route_server_pool_total(route, pool_element), pool_size,
-		(int)od_atomic_u32_of(&router->servers_routing),
-		(int)max_routing)) {
-		/* concurrent server connection in progress. */
-		od_route_unlock(route);
-		machine_sleep(busyloop_sleep);
-		busyloop_retry++;
-		/* TODO: support this opt in configure file */
-		if (busyloop_retry > MAX_BUZYLOOP_RETRY) {
-			busyloop_sleep = 1;
-		}
-		od_route_lock(route);
-
-		/* if the idle server was created while busyloop - lets use it */
-		int rc = od_route_server_pool_next_idle_locked(route, endpoint,
-							       &server);
-		if (rc != OD_ROUTER_OK) {
-			od_route_unlock(route);
-			return rc;
-		}
-		if (server != NULL) {
-			*out_server = server;
-			return OD_ROUTER_OK;
-		}
 	}
 
 	/* create new server object */
@@ -937,8 +874,8 @@ od_router_try_create_new_server(od_router_t *router, od_client_t *client,
 }
 
 static inline od_router_status_t
-od_router_try_attach(od_router_t *router, od_client_t *client,
-		     bool wait_for_idle, od_storage_endpoint_t *endpoint)
+od_router_try_attach(od_client_t *client, bool wait_for_idle,
+		     od_storage_endpoint_t *endpoint)
 {
 	od_server_t *server;
 	od_route_t *route = client->route;
@@ -984,7 +921,7 @@ od_router_try_attach(od_router_t *router, od_client_t *client,
 		}
 
 		od_router_status_t st = od_router_try_create_new_server(
-			router, client, endpoint, &server);
+			client, endpoint, &server);
 		if (st != OD_ROUTER_OK) {
 			/*
 			 * od_router_try_create_new_server keeps lock held if everything ok
@@ -1049,6 +986,8 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 				    od_storage_endpoint_t *endpoint,
 				    int immediate)
 {
+	(void)router;
+
 	od_route_t *route;
 	od_router_status_t rc;
 	uint64_t end_time_ms;
@@ -1077,8 +1016,7 @@ od_router_status_t od_router_attach(od_router_t *router, od_client_t *client,
 	while (now_ms < end_time_ms) {
 		uint64_t version = od_route_pools_version(route);
 
-		rc = od_router_try_attach(router, client, wait_for_idle,
-					  endpoint);
+		rc = od_router_try_attach(client, wait_for_idle, endpoint);
 		if (rc != OD_ROUTER_NEED_WAIT) {
 			/* ok or some other error */
 			status = rc;

--- a/sources/storage.c
+++ b/sources/storage.c
@@ -161,6 +161,9 @@ od_rule_storage_t *od_rules_storage_allocate(void)
 	}
 
 	atomic_init(&storage->refs, 1);
+	atomic_init(&storage->servers_routing, 0);
+	mm_wait_list_init(&storage->servers_routing_waiters,
+			  &storage->servers_routing);
 
 	storage->endpoints_status_poll_interval_ms = 1000;
 	od_storage_balancing_init(&storage->balancing);
@@ -206,6 +209,7 @@ void od_rules_storage_free(od_rule_storage_t *storage)
 	}
 
 	od_storage_balancing_destroy(&storage->balancing);
+	mm_wait_list_destroy(&storage->servers_routing_waiters);
 
 	od_free(storage);
 }


### PR DESCRIPTION
Move servers_routing counter from od_router to od_rule_storage so each storage has its own ramp-rate budget. Replace the spin-loop with mm_wait_list_compare_wait. Fix livelock by using CAS to claim the slot instead of pre-incrementing before the check.