### PR TITLE
fix build

### DIFF
--- a/sources/cfg/scan.l
+++ b/sources/cfg/scan.l
@@ -139,6 +139,7 @@ SIZE_SUFFIX  [kK][bB]?|[mM][bB]?|[gG][bB]?|[bB]
 
 
 \"([^\"]|\\\")*\" {
+					assert(yyleng >= 2);
 					size_t len = (size_t)yyleng - 2;
 
 					char *copy = od_cfg_unescape_string(yyextra,


### PR DESCRIPTION
Some compilers generates error like:
20.13 [100%] Linking C executable odyssey_test
20.23 In function 'mm_malloc',
20.23     inlined from 'od_malloc' at ./sources/od_memory.c:8:9,
20.23     inlined from 'od_cfg_unescape_string' at cfg/scan.l:43:14,
20.23     inlined from 'yylex' at cfg/scan.l:144:19,
20.23     inlined from 'yyparse' at ./build/sources/cfg/parse.tab.c:2283:16,
20.23     inlined from 'od_cfg_parse_file_depth' at ./sources/cfg/reader.c:127:17:
20.23 ./sources/machinarium/memory.c:36:14: error: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]