### PR TITLE
add portal tracking on client side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ local_run:
 	$(BUILD_TEST_DIR)/sources/odyssey $(DEV_CONF)
 
 console_run: 
-	$(BUILD_TEST_DIR)/sources/odyssey $(DEV_CONF) --console --log_to_stdout --verbose
+	$(BUILD_TEST_DIR)/sources/odyssey $(DEV_CONF) --console --log_to_stdout # --verbose
 
 check-format:
 	docker build -f docker/format/Dockerfile --tag=odyssey/clang-format-runner .

--- a/sources/backend.c
+++ b/sources/backend.c
@@ -18,6 +18,7 @@
 #include <backend.h>
 #include <types.h>
 #include <server.h>
+#include <pstmt.h>
 #include <instance.h>
 #include <global.h>
 #include <route.h>
@@ -138,6 +139,12 @@ int od_backend_ready(od_server_t *server, char *data, uint32_t size)
 		/* no active transaction */
 		server->is_transaction = 0;
 		server->is_error_tx = 0;
+		/*
+		 * PG destroys all portals at transaction end
+		 */
+		if (server->client != NULL && server->client->portals != NULL) {
+			od_client_portals_clear(server->client);
+		}
 	} else if (status == 'T') {
 		/* active transaction */
 		server->is_transaction = 1;

--- a/sources/client.c
+++ b/sources/client.c
@@ -50,6 +50,7 @@ void od_client_init(od_client_t *client)
 	od_list_init(&client->link);
 
 	client->prep_stmt_ids = NULL;
+	client->portals = NULL;
 	client->last_catchup_lag = 0;
 
 	od_atomic_u64_set(&client->killed, 0);
@@ -83,6 +84,9 @@ void od_client_free(od_client_t *client)
 	kiwi_password_free(&client->received_password);
 	if (client->prep_stmt_ids) {
 		od_client_pstmt_hashmap_free(client->prep_stmt_ids);
+	}
+	if (client->portals) {
+		od_client_portal_hashmap_free(client->portals);
 	}
 	if (client->external_id) {
 		od_free(client->external_id);

--- a/sources/console.c
+++ b/sources/console.c
@@ -181,8 +181,7 @@ od_console_show_frontend_stats_err_add(machine_msg_t *stream,
 		char data[64];
 		int data_len;
 		/* error_type */
-		data_len = od_snprintf(data, sizeof(data), "%" PRIu64,
-				       total_count);
+		data_len = od_snprintf(data, sizeof(data), "%zu", total_count);
 
 		rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 		if (rc != OK_RESPONSE) {
@@ -221,7 +220,7 @@ od_console_show_router_stats_err_add(machine_msg_t *stream,
 		/* error_type */
 		char data[64];
 		int data_len;
-		data_len = od_snprintf(data, sizeof(data), "%" PRIu64,
+		data_len = od_snprintf(data, sizeof(data), "%zu",
 				       od_err_logger_get_aggr_errors_count(
 					       err_logger,
 					       od_router_status_errs[i]));
@@ -399,8 +398,7 @@ static inline int od_console_show_errors_per_route_cb(od_route_t *route,
 
 		char data[64];
 		int data_len;
-		data_len = od_snprintf(data, sizeof(data), "%" PRIu64,
-				       total_count);
+		data_len = od_snprintf(data, sizeof(data), "%zu", total_count);
 
 		rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 		if (rc != OK_RESPONSE) {
@@ -451,8 +449,7 @@ static inline int od_console_show_errors_per_route_cb(od_route_t *route,
 
 		char data[64];
 		int data_len;
-		data_len = od_snprintf(data, sizeof(data), "%" PRIu64,
-				       total_count);
+		data_len = od_snprintf(data, sizeof(data), "%zu", total_count);
 
 		rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 		if (rc != OK_RESPONSE) {
@@ -690,31 +687,31 @@ static inline int od_console_show_pools_add_cb(od_route_t *route, void **argv)
 		goto error;
 	}
 	/* sv_used */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
 	/* sv_tested */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
 	/* sv_login */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
 	/* maxwait */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
 	/* maxwait_us */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
@@ -865,7 +862,7 @@ static inline int od_console_show_databases_add_cb(od_route_t *route,
 	}
 
 	/* reserve_pool */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
@@ -904,14 +901,14 @@ static inline int od_console_show_databases_add_cb(od_route_t *route,
 	}
 
 	/* paused */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
 	}
 
 	/* disabled */
-	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, 0UL);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64, (uint64_t)0);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		goto error;
@@ -1751,13 +1748,14 @@ static inline int od_console_show_clients_callback(od_client_t *client,
 		return NOT_OK_RESPONSE;
 	}
 	/* ptr */
-	data_len = od_snprintf(data, sizeof(data), "%p", client);
+	data_len = od_snprintf(data, sizeof(data), "%p", (void *)client);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}
 	/* coro */
-	data_len = od_snprintf(data, sizeof(data), "%lu", client->coroutine_id);
+	data_len = od_snprintf(data, sizeof(data), "%" PRIu64,
+			       client->coroutine_id);
 	rc = kiwi_be_write_data_row_add(stream, offset, data, data_len);
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1531,16 +1531,23 @@ static inline od_retcode_t od_frontend_log_bind(od_instance_t *instance,
 						od_client_t *client, char *ctx,
 						char *data, int size)
 {
-	uint32_t name_len;
-	char *name;
+	char *portal_name;
+	uint32_t portal_name_len;
+	char *stmt_name;
+	uint32_t stmt_name_len;
 	int rc;
-	rc = kiwi_be_read_bind_stmt_name(data, size, &name, &name_len);
+	rc = kiwi_be_read_bind_names(data, size, &portal_name, &portal_name_len,
+				     &stmt_name, &stmt_name_len);
 	if (rc == -1) {
 		return NOT_OK_RESPONSE;
 	}
 
-	od_log(&instance->logger, ctx, client, client->server, "bind %.*s",
-	       name_len, name);
+	/*
+	 * kiwi_be_read_bind_names returns lengths including the NUL
+	 */
+	od_log(&instance->logger, ctx, client, client->server,
+	       "bind stmt '%.*s' to portal '%.*s'", (int)(stmt_name_len - 1),
+	       stmt_name, (int)(portal_name_len - 1), portal_name);
 	return OK_RESPONSE;
 }
 

--- a/sources/include/client.h
+++ b/sources/include/client.h
@@ -59,6 +59,9 @@ struct od_client {
 	/* desc preparet statements ids */
 	mm_hashmap_t *prep_stmt_ids;
 
+	/* portal name -> *od_pstmt_t (extended protocol portals tracking) */
+	mm_hashmap_t *portals;
+
 	/* passwd from config rule */
 	kiwi_password_t password;
 
@@ -96,6 +99,12 @@ static inline od_retcode_t od_client_init_hm(od_client_t *client)
 {
 	client->prep_stmt_ids = od_client_pstmt_hashmap_create();
 	if (client->prep_stmt_ids == NULL) {
+		return NOT_OK_RESPONSE;
+	}
+	client->portals = od_client_portal_hashmap_create();
+	if (client->portals == NULL) {
+		od_client_pstmt_hashmap_free(client->prep_stmt_ids);
+		client->prep_stmt_ids = NULL;
 		return NOT_OK_RESPONSE;
 	}
 	return OK_RESPONSE;

--- a/sources/include/kiwi/be_read.h
+++ b/sources/include/kiwi/be_read.h
@@ -468,10 +468,11 @@ KIWI_API static inline int kiwi_be_read_close(char *data, uint32_t size,
 	return 0;
 }
 
-KIWI_API static inline int kiwi_be_read_bind_stmt_name(char *data,
-						       uint32_t size,
-						       char **name,
-						       uint32_t *name_len)
+KIWI_API static inline int kiwi_be_read_bind_names(char *data, uint32_t size,
+						   char **portal_name,
+						   uint32_t *portal_name_len,
+						   char **stmt_name,
+						   uint32_t *stmt_name_len)
 {
 	kiwi_header_t *header = (kiwi_header_t *)data;
 	uint32_t len;
@@ -483,21 +484,30 @@ KIWI_API static inline int kiwi_be_read_bind_stmt_name(char *data,
 		return -1;
 	}
 
-	/* destination portal */
 	uint32_t pos_size = len;
 	char *pos = kiwi_header_data(header);
+
+	/* destination portal */
+	char *p = pos;
 	rc = kiwi_readsz(&pos, &pos_size);
 	if (kiwi_unlikely(rc == -1)) {
 		return -1;
+	}
+	if (portal_name) {
+		*portal_name = p;
+		*portal_name_len = pos - p;
 	}
 
 	/* source prepared statement */
-	*name = pos;
+	char *s = pos;
 	rc = kiwi_readsz(&pos, &pos_size);
 	if (kiwi_unlikely(rc == -1)) {
 		return -1;
 	}
-	*name_len = pos - *name;
+	if (stmt_name) {
+		*stmt_name = s;
+		*stmt_name_len = pos - s;
+	}
 
 	return 0;
 }

--- a/sources/include/pstmt.h
+++ b/sources/include/pstmt.h
@@ -60,6 +60,16 @@ int od_client_remove_pstmt(od_client_t *client, const char *name);
 od_pstmt_t *od_client_get_pstmt(od_client_t *client, const char *name);
 void od_client_pstmts_clear(od_client_t *client);
 
+/* "portal_name" -> *od_pstmt_t (portal tracking, extended protocol) */
+mm_hashmap_t *od_client_portal_hashmap_create(void);
+void od_client_portal_hashmap_free(mm_hashmap_t *hm);
+
+int od_client_add_portal(od_client_t *client, const char *portal_name,
+			 const od_pstmt_t *pstmt);
+od_pstmt_t *od_client_get_portal(od_client_t *client, const char *portal_name);
+int od_client_remove_portal(od_client_t *client, const char *portal_name);
+void od_client_portals_clear(od_client_t *client);
+
 /* "odyssey_pstmt_0" -> *od_pstmt_t */
 mm_hashmap_t *od_server_pstmt_hashmap_create(void);
 void od_server_pstmt_hashmap_free(mm_hashmap_t *hm);

--- a/sources/include/query_processing.h
+++ b/sources/include/query_processing.h
@@ -21,6 +21,7 @@ typedef enum {
 	OD_QUERY_PROCESSING_PREPARE,
 	OD_QUERY_PROCESSING_ALL,
 	OD_QUERY_PROCESSING_BEGIN,
+	OD_QUERY_PROCESSING_DISCARD,
 } od_query_processing_keywords_t;
 
 extern od_keyword_t od_query_process_keywords[];
@@ -37,3 +38,9 @@ int od_parse_deallocate(const char *query, size_t query_len, const char **name,
 /* same as above, but for cases of parsing after reading DEALLOCATE on some parser */
 int od_parse_deallocate_parser(od_parser_t *parser, const char **name,
 			       size_t *name_len);
+
+/*
+ * Check whether query is DISCARD ALL (case-insensitive).
+ * Returns 1 if DISCARD ALL, 0 otherwise.
+ */
+int od_parse_discard_all(const char *query, size_t query_len);

--- a/sources/include/util.h
+++ b/sources/include/util.h
@@ -10,6 +10,17 @@
 
 static inline int od_vsnprintf(char *buf, int size, const char *fmt,
 			       va_list args)
+	__attribute__((format(printf, 3, 0)));
+static inline int od_vasprintf(char **__restrict bufp, const char *fmt,
+			       va_list args)
+	__attribute__((format(printf, 2, 0)));
+static inline int od_asprintf(char **__restrict bufp, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
+static inline int od_snprintf(char *buf, int size, const char *fmt, ...)
+	__attribute__((format(printf, 3, 4)));
+
+static inline int od_vsnprintf(char *buf, int size, const char *fmt,
+			       va_list args)
 {
 	int rc;
 	rc = vsnprintf(buf, size, fmt, args);
@@ -89,7 +100,7 @@ static inline int od_concat_prefer_right(char *out, size_t max,
 		left_len = max_left;
 	}
 
-	return od_snprintf(out, max, "%.*s%s", left_len, left, right);
+	return od_snprintf(out, max, "%.*s%s", (int)left_len, left, right);
 }
 
 static inline char *od_strdup_from_buf(const char *source, size_t size)

--- a/sources/include/xplan.h
+++ b/sources/include/xplan.h
@@ -46,13 +46,47 @@ typedef enum {
 	 * remove all pstmts from both client and server hashmaps
 	 * in case of Execute(DISCARD ALL)
 	 */
-	OD_XPLAN_DELTA_REMOVE_ALL
+	OD_XPLAN_DELTA_REMOVE_ALL,
+
+	/*
+	 * remove all pstmts from client hashmap only
+	 * in case of Execute(DEALLOCATE ALL) - virtualized, not sent to server
+	 */
+	OD_XPLAN_DELTA_REMOVE_CLIENT_ALL,
+
+	/*
+	 * add portal -> pstmt mapping on client
+	 * on Bind (destination portal name)
+	 */
+	OD_XPLAN_DELTA_ADD_PORTAL,
+
+	/*
+	 * remove portal -> pstmt mapping on client
+	 * on Close Portal or after Execute of DISCARD/DEALLOCATE
+	 */
+	OD_XPLAN_DELTA_REMOVE_PORTAL,
+
+	/*
+	 * remove a single pstmt by name from client map
+	 * on Execute(DEALLOCATE name)
+	 */
+	OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME
 } od_xplan_delta_type_t;
 
 typedef struct {
 	od_xplan_delta_type_t type;
+	/*
+	 * client_pstmt name. normally points into the original client msg
+	 * (owned by xbuf), EXCEPT for OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME
+	 * where it is an owned NUL-terminated copy (freed in plan_entry_destroy).
+	 */
 	const char *client_pstmt;
 	const od_pstmt_t *pstmt;
+	/*
+	 * portal name for ADD_PORTAL / REMOVE_PORTAL deltas
+	 * points to the original client msg (owned by xbuf)
+	 */
+	const char *portal_name;
 } od_xplan_delta_t;
 
 typedef enum {
@@ -92,6 +126,12 @@ typedef enum {
 	OD_XPLAN_VIRTUAL_ERROR_RESPONSE,
 
 	/*
+	 * virtual CommandComplete for Execute of DEALLOCATE
+	 * that is virtualized (not sent to server)
+	 */
+	OD_XPLAN_VIRTUAL_COMMAND_COMPLETE,
+
+	/*
 	 * deferred simple query begin
 	 */
 	OD_XPLAN_DEFERRED_BEGIN,
@@ -129,10 +169,20 @@ typedef struct {
 	 * note:
 	 * no ParseComplete msg here - it is always const seq of bytes
 	 * no CloseComplete msg here - it is always const seq of bytes
+	 * no CommandComplete msg here - it is always const seq of bytes
+	 *                                (handled by vcc_data, vcc_len)
 	 *
 	 * can be NULL, owned by xplan
 	 */
 	machine_msg_t *vresp;
+
+	/*
+	 * pre-built CommandComplete wire bytes for
+	 * OD_XPLAN_VIRTUAL_COMMAND_COMPLETE. points to a static array,
+	 * not owned. NULL for all other entry types.
+	 */
+	const uint8_t *vcc_data;
+	size_t vcc_len;
 } od_xplan_entry_t;
 
 struct od_xplan {

--- a/sources/ldap.c
+++ b/sources/ldap.c
@@ -49,8 +49,8 @@ od_retcode_t od_ldap_endpoint_prepare(od_ldap_endpoint_t *le)
 		return NOT_OK_RESPONSE;
 	}
 
-	if (od_asprintf(&le->ldapurl, "%s://%s:%d", scheme, le->ldapserver,
-			le->ldapport) != OK_RESPONSE) {
+	if (od_asprintf(&le->ldapurl, "%s://%s:%" PRIu64, scheme,
+			le->ldapserver, le->ldapport) != OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}
 

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -377,8 +377,10 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 				break;
 			/* thread id */
 			case 'T':
-				len = od_snprintf(dst_pos, dst_end - dst_pos,
-						  "0x%llx", pthread_self());
+				len = od_snprintf(
+					dst_pos, dst_end - dst_pos,
+					"0x%" PRIx64,
+					(uint64_t)(uintptr_t)pthread_self());
 				dst_pos += len;
 				break;
 			/* client id */
@@ -829,7 +831,8 @@ od_logger_format_json(od_logger_t *logger, od_logger_level_t level,
 					logger->pid->pid_sz, add_comma);
 
 	memset(tmp_buf, 0, sizeof(tmp_buf));
-	od_snprintf(tmp_buf, sizeof(tmp_buf), "0x%llx", pthread_self());
+	od_snprintf(tmp_buf, sizeof(tmp_buf), "0x%" PRIx64,
+		    (uint64_t)(uintptr_t)pthread_self());
 	dst = od_logger_json_add_string(dst, dst_end, "tid", tmp_buf,
 					add_comma);
 

--- a/sources/pstmt.c
+++ b/sources/pstmt.c
@@ -158,6 +158,92 @@ void od_client_pstmts_clear(od_client_t *client)
 }
 
 /*
+ * client portal hash map
+ * "portal_name" -> *od_pstmt_t
+ *
+ * portals are created by Bind (destination portal name) and destroyed by
+ * Close Portal, transaction end, or DISCARD ALL / DEALLOCATE ALL.
+ *
+ * the value is a non-owning pointer into the global pstmt map. the pointer
+ * is stable because the global map is append-only (od_pstmt_create_or_get
+ * never removes entries; the map is freed on instance shutdown).
+ */
+
+mm_hashmap_t *od_client_portal_hashmap_create(void)
+{
+	return mm_hashmap_create(
+		50 /* XXX: big enough? */,
+		1 /* nlocks = 1, no fully-concurrent access */, sizeof(char *),
+		sizeof(od_pstmt_t *), str_ptr_cmp, murmur_str_ptr, str_ptr_dtor,
+		NULL /* no need to free the pointer from global table */,
+		str_ptr_copy);
+}
+
+void od_client_portal_hashmap_free(mm_hashmap_t *hm)
+{
+	mm_hashmap_free(hm);
+}
+
+od_pstmt_t *od_client_get_portal(od_client_t *client, const char *portal_name)
+{
+	mm_hashmap_keylock_t klock;
+	int rc = mm_hashmap_lock_key(client->portals, &klock, &portal_name,
+				     0 /* do not create */);
+	(void)rc;
+
+	if (klock.found) {
+		od_pstmt_t *ps = *(od_pstmt_t **)mm_hashmap_kvp_val(
+			client->portals, klock.kvp);
+		mm_hashmap_unlock_key(client->portals, &klock);
+		return ps;
+	}
+
+	return NULL;
+}
+
+int od_client_add_portal(od_client_t *client, const char *portal_name,
+			 const od_pstmt_t *pstmt)
+{
+	mm_hashmap_keylock_t klock;
+	int rc = mm_hashmap_lock_key(client->portals, &klock, &portal_name,
+				     1 /* do create */);
+	if (rc == -1) {
+		return rc;
+	}
+
+	/*
+	 * upsert: the unnamed portal "" is silently overwritten on every Bind.
+	 * for named portals PG requires an explicit Close before re-Bind, but
+	 * the server enforces that -- we just store the mapping here.
+	 */
+	void *val = mm_hashmap_kvp_val(client->portals, klock.kvp);
+	memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
+
+	mm_hashmap_unlock_key(client->portals, &klock);
+
+	return 0;
+}
+
+int od_client_remove_portal(od_client_t *client, const char *portal_name)
+{
+	mm_hashmap_keylock_t klock;
+	int rc = mm_hashmap_lock_key(client->portals, &klock, &portal_name,
+				     0 /* do not create */);
+	(void)rc;
+
+	if (klock.kvp != NULL) {
+		mm_hashmap_remove(client->portals, &klock);
+	}
+
+	return 0;
+}
+
+void od_client_portals_clear(od_client_t *client)
+{
+	mm_hashmap_clear(client->portals);
+}
+
+/*
  * server hashmap
  * "odyssey_pstmt_0" -> *od_prepared_stmt_t
  */

--- a/sources/query_processing.c
+++ b/sources/query_processing.c
@@ -22,6 +22,7 @@ od_keyword_t od_query_process_keywords[] = {
 	od_keyword("prepare", OD_QUERY_PROCESSING_PREPARE),
 	od_keyword("all", OD_QUERY_PROCESSING_ALL),
 	od_keyword("begin", OD_QUERY_PROCESSING_BEGIN),
+	od_keyword("discard", OD_QUERY_PROCESSING_DISCARD),
 	{ 0, 0, 0 }
 };
 
@@ -125,4 +126,41 @@ int od_parse_deallocate(const char *query, size_t query_len, const char **name,
 	}
 
 	return -1;
+}
+
+int od_parse_discard_all(const char *query, size_t query_len)
+{
+	od_parser_t parser;
+	od_parser_init_queries_mode(&parser, query, query_len);
+
+	od_token_t token;
+	int rc = od_parser_next(&parser, &token);
+	if (rc != OD_PARSER_KEYWORD) {
+		return 0;
+	}
+
+	od_keyword_t *keyword =
+		od_keyword_match(od_query_process_keywords, &token);
+	if (keyword == NULL || keyword->id != OD_QUERY_PROCESSING_DISCARD) {
+		return 0;
+	}
+
+	rc = od_parser_next(&parser, &token);
+	if (rc != OD_PARSER_KEYWORD) {
+		return 0;
+	}
+
+	keyword = od_keyword_match(od_query_process_keywords, &token);
+	if (keyword == NULL || keyword->id != OD_QUERY_PROCESSING_ALL) {
+		return 0;
+	}
+
+	/* ensure nothing meaningful follows: EOF or ';' */
+	rc = od_parser_next(&parser, &token);
+	if (rc != OD_PARSER_EOF &&
+	    !(rc == OD_PARSER_SYMBOL && token.value.num == ';')) {
+		return 0;
+	}
+
+	return 1;
 }

--- a/sources/relay.c
+++ b/sources/relay.c
@@ -375,6 +375,7 @@ static od_frontend_status_t process_vdeallocate(od_client_t *client,
 		od_debug(&instance->logger, "main", client, server,
 			 "DEALLOCATE ALL detected, remove from client hashmap");
 		od_client_pstmts_clear(client);
+		od_client_portals_clear(client);
 
 		command = "DEALLOCATE ALL";
 		break;
@@ -567,11 +568,12 @@ static void process_discard(od_client_t *client, od_server_t *server,
 		return;
 	}
 
-	if (query_len >= 7 && strncmp(query, "DISCARD", 7) == 0) {
+	if (od_parse_discard_all(query, query_len > 0 ? query_len - 1 : 0)) {
 		od_debug(&instance->logger, "main", client, server,
-			 "discard detected, invalidate caches");
+			 "DISCARD ALL detected, invalidate caches");
 
 		od_client_pstmts_clear(client);
+		od_client_portals_clear(client);
 		if (server != NULL) {
 			od_server_pstmts_clear(server);
 		}
@@ -816,10 +818,13 @@ od_frontend_status_t od_relay_process_query(od_relay_t *relay,
 
 	/*
 	 * in vanilla PG, executing simple query removes the
-	 * unnamed pstmt on client
+	 * unnamed pstmt and unnamed portal on client
 	 */
 	if (relay->client->prep_stmt_ids != NULL) {
 		od_client_remove_pstmt(relay->client, "");
+	}
+	if (relay->client->portals != NULL) {
+		od_client_remove_portal(relay->client, "");
 	}
 
 	return status;

--- a/sources/router.c
+++ b/sources/router.c
@@ -1037,8 +1037,8 @@ static inline int send_waiting_finished_notice(od_client_t *client,
 {
 	char msg[64];
 	char buf[64];
-	od_snprintf(msg, sizeof(msg), "waiting took %lu ms%s", time_spent,
-		    timeout ? ", timeout" : "");
+	od_snprintf(msg, sizeof(msg), "waiting took %" PRIu64 " ms%s",
+		    time_spent, timeout ? ", timeout" : "");
 	int n = kiwi_be_format_notice(buf, sizeof(buf), 'M', msg);
 	size_t unused;
 	return od_io_write_raw(&client->io, buf, n, &unused, 1000, 0);

--- a/sources/tests/odyssey/test_pstmt.c
+++ b/sources/tests/odyssey/test_pstmt.c
@@ -75,6 +75,62 @@ void test_pstmt_client_hashmap(void)
 	od_client_free(client);
 }
 
+static void test_portal_client_hashmap(void)
+{
+	od_client_t *client = od_client_allocate();
+	client->portals = od_client_portal_hashmap_create();
+	test(client->portals != NULL);
+
+	od_pstmt_t pstmt;
+	memset(&pstmt, 0, sizeof(pstmt));
+
+	od_pstmt_t pstmt2;
+	memset(&pstmt2, 0, sizeof(pstmt2));
+
+	/* unnamed portal works */
+	test(od_client_get_portal(client, "") == NULL);
+	test(od_client_add_portal(client, "", &pstmt) == 0);
+	test(od_client_get_portal(client, "") == &pstmt);
+
+	/* portals are always upserted (we are trying our best of tracking) */
+	test(od_client_add_portal(client, "", &pstmt2) == 0);
+	test(od_client_get_portal(client, "") == &pstmt2);
+
+	test(od_client_remove_portal(client, "") == 0);
+	test(od_client_get_portal(client, "") == NULL);
+
+	/* named portals */
+	test(od_client_get_portal(client, "portal_0") == NULL);
+
+	test(od_client_add_portal(client, "portal_0", &pstmt) == 0);
+	test(od_client_get_portal(client, "portal_0") == &pstmt);
+
+	/* re-binding the same portal replaces the pstmt */
+	test(od_client_add_portal(client, "portal_0", &pstmt2) == 0);
+	test(od_client_get_portal(client, "portal_0") == &pstmt2);
+
+	test(od_client_add_portal(client, "portal_1", &pstmt) == 0);
+	test(od_client_get_portal(client, "portal_1") == &pstmt);
+
+	/* remove non-existent is a no-op */
+	test(od_client_remove_portal(client, "nope") == 0);
+	test(od_client_get_portal(client, "portal_0") == &pstmt2);
+	test(od_client_get_portal(client, "portal_1") == &pstmt);
+
+	test(od_client_remove_portal(client, "portal_0") == 0);
+	test(od_client_get_portal(client, "portal_0") == NULL);
+	test(od_client_get_portal(client, "portal_1") == &pstmt);
+
+	od_client_portals_clear(client);
+	test(od_client_get_portal(client, "portal_1") == NULL);
+
+	/* dangling entry survives until free */
+	test(od_client_add_portal(client, "dangling", &pstmt) == 0);
+	test(od_client_get_portal(client, "dangling") == &pstmt);
+
+	od_client_free(client);
+}
+
 static void test_pstmt_server_hashmap(void)
 {
 	od_server_t *server = od_server_allocate(1);
@@ -149,6 +205,7 @@ static void test_impl(void *a)
 	(void)a;
 
 	test_pstmt_client_hashmap();
+	test_portal_client_hashmap();
 	test_pstmt_server_hashmap();
 	test_pstmt_global();
 }

--- a/sources/xplan.c
+++ b/sources/xplan.c
@@ -57,6 +57,8 @@ static const char *plan_entry_type_str(od_xplan_entry_type_t type)
 		return "OD_XPLAN_VIRTUAL_CLOSE_COMPLETE";
 	case OD_XPLAN_VIRTUAL_PARSE_COMPLETE:
 		return "OD_XPLAN_VIRTUAL_PARSE_COMPLETE";
+	case OD_XPLAN_VIRTUAL_COMMAND_COMPLETE:
+		return "OD_XPLAN_VIRTUAL_COMMAND_COMPLETE";
 	case OD_XPLAN_DEFERRED_BEGIN:
 		return "OD_XPLAN_DEFERRED_BEGIN";
 	default:
@@ -88,6 +90,7 @@ static machine_msg_t *plan_entry_backend_msg(od_xplan_entry_t *entry)
 	case OD_XPLAN_VIRTUAL_ERROR_RESPONSE:
 	case OD_XPLAN_VIRTUAL_PARSE_COMPLETE:
 	case OD_XPLAN_VIRTUAL_CLOSE_COMPLETE:
+	case OD_XPLAN_VIRTUAL_COMMAND_COMPLETE:
 		return NULL;
 	default:
 		abort();
@@ -109,6 +112,14 @@ static const char *plan_delta_type_str(od_xplan_delta_type_t type)
 		return "OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY";
 	case OD_XPLAN_DELTA_REMOVE_ALL:
 		return "OD_XPLAN_DELTA_REMOVE_ALL";
+	case OD_XPLAN_DELTA_REMOVE_CLIENT_ALL:
+		return "OD_XPLAN_DELTA_REMOVE_CLIENT_ALL";
+	case OD_XPLAN_DELTA_ADD_PORTAL:
+		return "OD_XPLAN_DELTA_ADD_PORTAL";
+	case OD_XPLAN_DELTA_REMOVE_PORTAL:
+		return "OD_XPLAN_DELTA_REMOVE_PORTAL";
+	case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME:
+		return "OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME";
 	default:
 		abort();
 	}
@@ -123,8 +134,13 @@ static int plan_delta_description(od_xplan_delta_t *delta, char *out,
 	pos += od_snprintf(pos, end - pos,
 			   "type=%s, client_pstmt='%s', pstmt=%s",
 			   plan_delta_type_str(delta->type),
-			   delta->client_pstmt,
+			   delta->client_pstmt ? delta->client_pstmt : "(null)",
 			   delta->pstmt ? delta->pstmt->name : "(null)");
+
+	if (delta->portal_name) {
+		pos += od_snprintf(pos, end - pos, ", portal='%s'",
+				   delta->portal_name);
+	}
 
 	return pos - out;
 }
@@ -189,9 +205,16 @@ static void plan_entry_destroy(void *a)
 
 	/*
 	 * no need to destroy delta:
-	 * - client name points to original msg
-	 * - pstmt points to global hashmap
+	 * - client name points into clmsg (owned by xbuf)
+	 * - pstmt points to the global hashmap
+	 *
+	 * exception: for OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME the
+	 * client_pstmt is an owned NUL-terminated copy (see plan_execute),
+	 * free it here
 	 */
+	if (entry->delta.type == OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME) {
+		od_free((void *)entry->delta.client_pstmt);
+	}
 
 	memset(entry, 0, sizeof(od_xplan_entry_t));
 }
@@ -201,7 +224,8 @@ static void entry_init_internal(od_xplan_entry_t *e, od_xplan_entry_type_t type,
 				machine_msg_t *vresp,
 				od_xplan_delta_type_t delta_type,
 				const char *client_pstmt,
-				const od_pstmt_t *pstmt)
+				const od_pstmt_t *pstmt,
+				const char *portal_name)
 {
 	memset(e, 0, sizeof(od_xplan_entry_t));
 
@@ -213,6 +237,7 @@ static void entry_init_internal(od_xplan_entry_t *e, od_xplan_entry_type_t type,
 	e->delta.type = delta_type;
 	e->delta.client_pstmt = client_pstmt;
 	e->delta.pstmt = pstmt;
+	e->delta.portal_name = portal_name;
 }
 
 static void entry_init_fwd(od_xplan_entry_t *e, machine_msg_t *original,
@@ -221,7 +246,7 @@ static void entry_init_fwd(od_xplan_entry_t *e, machine_msg_t *original,
 			   const char *client_pstmt, const od_pstmt_t *pstmt)
 {
 	entry_init_internal(e, OD_XPLAN_FORWARD, original, rewritten, NULL,
-			    delta_type, client_pstmt, pstmt);
+			    delta_type, client_pstmt, pstmt, NULL);
 }
 
 static void entry_init_fwd_no_delta(od_xplan_entry_t *e,
@@ -236,7 +261,7 @@ static void entry_init_parse(od_xplan_entry_t *e, const char *client_pstmt,
 			     machine_msg_t *rewritten)
 {
 	entry_init_internal(e, OD_XPLAN_PARSE, original, rewritten, NULL,
-			    OD_XPLAN_DELTA_ADD_BOTH, client_pstmt, pstmt);
+			    OD_XPLAN_DELTA_ADD_BOTH, client_pstmt, pstmt, NULL);
 }
 
 static void entry_init_parse_shadow(od_xplan_entry_t *e,
@@ -245,7 +270,8 @@ static void entry_init_parse_shadow(od_xplan_entry_t *e,
 				    machine_msg_t *inserted_parse)
 {
 	entry_init_internal(e, OD_XPLAN_PARSE_SHADOW, original, inserted_parse,
-			    NULL, OD_XPLAN_DELTA_ADD_SERVER_ONLY, NULL, pstmt);
+			    NULL, OD_XPLAN_DELTA_ADD_SERVER_ONLY, NULL, pstmt,
+			    NULL);
 }
 
 static void entry_init_virtual_error_response(od_xplan_entry_t *e,
@@ -253,7 +279,7 @@ static void entry_init_virtual_error_response(od_xplan_entry_t *e,
 					      machine_msg_t *msg)
 {
 	entry_init_internal(e, OD_XPLAN_VIRTUAL_ERROR_RESPONSE, original, NULL,
-			    msg, OD_XPLAN_DELTA_NONE, NULL, NULL);
+			    msg, OD_XPLAN_DELTA_NONE, NULL, NULL, NULL);
 }
 
 static void entry_init_virtual_parse_complete(od_xplan_entry_t *e,
@@ -263,8 +289,8 @@ static void entry_init_virtual_parse_complete(od_xplan_entry_t *e,
 {
 	entry_init_internal(e, OD_XPLAN_VIRTUAL_PARSE_COMPLETE, original, NULL,
 			    NULL /* no virtual msg - const seq of bytes */,
-			    OD_XPLAN_DELTA_ADD_CLIENT_ONLY, client_pstmt,
-			    pstmt);
+			    OD_XPLAN_DELTA_ADD_CLIENT_ONLY, client_pstmt, pstmt,
+			    NULL);
 }
 
 static void entry_init_virtual_close_complete(od_xplan_entry_t *e,
@@ -274,7 +300,7 @@ static void entry_init_virtual_close_complete(od_xplan_entry_t *e,
 	entry_init_internal(e, OD_XPLAN_VIRTUAL_CLOSE_COMPLETE, original, NULL,
 			    NULL /* no virtual msg - const seq of bytes */,
 			    OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY, client_pstmt,
-			    NULL);
+			    NULL, NULL);
 }
 
 static void entry_init_deferred_begin(od_xplan_entry_t *e, machine_msg_t *begin)
@@ -282,7 +308,44 @@ static void entry_init_deferred_begin(od_xplan_entry_t *e, machine_msg_t *begin)
 	assert(msg_is_begin_query(begin));
 
 	entry_init_internal(e, OD_XPLAN_DEFERRED_BEGIN, begin, NULL, NULL,
-			    OD_XPLAN_DELTA_NONE, NULL, NULL);
+			    OD_XPLAN_DELTA_NONE, NULL, NULL, NULL);
+}
+
+/*
+ * Forward (e.g. Bind) that also adds a portal -> pstmt mapping on client.
+ */
+static void entry_init_fwd_portal(od_xplan_entry_t *e, machine_msg_t *original,
+				  machine_msg_t *rewritten,
+				  const char *portal_name,
+				  const od_pstmt_t *pstmt)
+{
+	entry_init_internal(e, OD_XPLAN_FORWARD, original, rewritten, NULL,
+			    OD_XPLAN_DELTA_ADD_PORTAL, NULL, pstmt,
+			    portal_name);
+}
+
+/*
+ * Virtual CommandComplete for a virtualized Execute (DEALLOCATE).
+ * Combines multiple deltas:
+ * - REMOVE_CLIENT_ALL for DEALLOCATE ALL
+ * - REMOVE_CLIENT_ONLY_BY_NAME for DEALLOCATE name
+ *
+ * DISCARD ALL is NOT virtualized (forwarded to server), so it never
+ * goes through this path.
+ *
+ * vcc_data/vcc_len is a pre-built CommandComplete wire packet,
+ * points to a static array, not owned.
+ */
+static void entry_init_virtual_command_complete(
+	od_xplan_entry_t *e, machine_msg_t *original,
+	od_xplan_delta_type_t delta_type, const char *client_pstmt,
+	const char *portal_name, const uint8_t *vcc_data, size_t vcc_len)
+{
+	entry_init_internal(e, OD_XPLAN_VIRTUAL_COMMAND_COMPLETE, original,
+			    NULL, NULL, delta_type, client_pstmt, NULL,
+			    portal_name);
+	e->vcc_data = vcc_data;
+	e->vcc_len = vcc_len;
 }
 
 static int xplan_append(od_xplan_t *xp, const od_xplan_entry_t *e)
@@ -415,6 +478,40 @@ xplan_append_deferred_begin(od_xplan_t *xp, machine_msg_t *begin)
 	return OD_OK;
 }
 
+static inline od_frontend_status_t
+xplan_append_fwd_portal(od_xplan_t *xp, machine_msg_t *original,
+			machine_msg_t *rewritten, const char *portal_name,
+			const od_pstmt_t *pstmt)
+{
+	od_xplan_entry_t e;
+	entry_init_fwd_portal(&e, original, rewritten, portal_name, pstmt);
+
+	int rc = xplan_append(xp, &e);
+	if (rc != 0) {
+		return OD_EOOM;
+	}
+
+	return OD_OK;
+}
+
+static inline od_frontend_status_t xplan_append_virtual_command_complete(
+	od_xplan_t *xp, machine_msg_t *original,
+	od_xplan_delta_type_t delta_type, const char *client_pstmt,
+	const char *portal_name, const uint8_t *vcc_data, size_t vcc_len)
+{
+	od_xplan_entry_t e;
+	entry_init_virtual_command_complete(&e, original, delta_type,
+					    client_pstmt, portal_name, vcc_data,
+					    vcc_len);
+
+	int rc = xplan_append(xp, &e);
+	if (rc != 0) {
+		return OD_EOOM;
+	}
+
+	return OD_OK;
+}
+
 void od_xplan_init(od_xplan_t *xp)
 {
 	memset(xp, 0, sizeof(od_xplan_t));
@@ -452,6 +549,8 @@ static const od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp,
 		switch (delta->type) {
 		case OD_XPLAN_DELTA_ADD_SERVER_ONLY:
 		case OD_XPLAN_DELTA_NONE:
+		case OD_XPLAN_DELTA_ADD_PORTAL:
+		case OD_XPLAN_DELTA_REMOVE_PORTAL:
 			/* non-client pstmts op */
 			break;
 
@@ -471,7 +570,15 @@ static const od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp,
 			}
 			break;
 
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME:
+			if (strcmp(pstmt_name, delta->client_pstmt) == 0) {
+				/* found removing of the pstmt */
+				return NULL;
+			}
+			break;
+
 		case OD_XPLAN_DELTA_REMOVE_ALL:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ALL:
 			/* all pstmts was removed, including this */
 			return NULL;
 
@@ -481,6 +588,57 @@ static const od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp,
 	}
 
 	return od_client_get_pstmt(client, pstmt_name);
+}
+
+static const od_pstmt_t *plan_client_get_portal(od_xplan_t *xp,
+						od_client_t *client,
+						const char *portal_name)
+{
+	/*
+	 * searching from newest state to oldest,
+	 * this means to search from tail to head of the plan deltas
+	 * and then on commited portals hashmap
+	 */
+
+	for (int i = (int)mm_vector_size(&xp->entries) - 1; i >= 0; --i) {
+		od_xplan_entry_t *e = mm_vector_get(&xp->entries, (size_t)i);
+		od_xplan_delta_t *delta = &e->delta;
+
+		switch (delta->type) {
+		case OD_XPLAN_DELTA_ADD_SERVER_ONLY:
+		case OD_XPLAN_DELTA_NONE:
+		case OD_XPLAN_DELTA_ADD_BOTH:
+		case OD_XPLAN_DELTA_ADD_CLIENT_ONLY:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME:
+			/* non-portal op */
+			break;
+
+		case OD_XPLAN_DELTA_ADD_PORTAL:
+			if (strcmp(portal_name, delta->portal_name) == 0) {
+				/* found portal -> pstmt mapping */
+				return delta->pstmt;
+			}
+			break;
+
+		case OD_XPLAN_DELTA_REMOVE_PORTAL:
+			if (strcmp(portal_name, delta->portal_name) == 0) {
+				/* found removing of the portal */
+				return NULL;
+			}
+			break;
+
+		case OD_XPLAN_DELTA_REMOVE_ALL:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ALL:
+			/* all portals was removed, including this */
+			return NULL;
+
+		default:
+			abort();
+		}
+	}
+
+	return od_client_get_portal(client, portal_name);
 }
 
 static int plan_client_pstmt_exists(od_xplan_t *xp, od_client_t *client,
@@ -506,6 +664,10 @@ static int plan_server_has_pstmt(od_xplan_t *xp, od_server_t *server,
 		case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY:
 		case OD_XPLAN_DELTA_ADD_CLIENT_ONLY:
 		case OD_XPLAN_DELTA_NONE:
+		case OD_XPLAN_DELTA_ADD_PORTAL:
+		case OD_XPLAN_DELTA_REMOVE_PORTAL:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME:
+		case OD_XPLAN_DELTA_REMOVE_CLIENT_ALL:
 			/* non-server pstmts op */
 			break;
 
@@ -666,12 +828,66 @@ static od_frontend_status_t plan_close(od_relay_t *relay, od_xplan_t *xp,
 		return OD_ECLIENT_PROTOCOL_ERROR;
 	}
 
-	if (type != KIWI_FE_CLOSE_PREPARED_STATEMENT) {
-		return xplan_append_fwd_no_delta(xp, msg,
-						 NULL /* no rewrite */);
+	if (type == KIWI_FE_CLOSE_PORTAL) {
+		/*
+		 * close portal: forward Close to the server (so the server
+		 * destroys its own portal) and remove the portal -> pstmt
+		 * mapping from the client. the server replies with CloseComplete
+		 * which is proxied to the client.
+		 *
+		 * srvmsg is NULL so plan_entry_backend_msg returns clmsg (the
+		 * original message owned by xbuf) - no double free on cleanup.
+		 */
+		od_xplan_entry_t e;
+		entry_init_fwd(&e, msg, NULL /* no rewrite, forward clmsg */,
+			       OD_XPLAN_DELTA_REMOVE_PORTAL, NULL, NULL);
+		e.delta.portal_name = pstmt_name;
+		int rc = xplan_append(xp, &e);
+		if (rc != 0) {
+			return OD_EOOM;
+		}
+		return OD_OK;
+	} else if (type == KIWI_FE_CLOSE_PREPARED_STATEMENT) {
+		return xplan_append_virtual_close_complete(xp, pstmt_name, msg);
 	}
 
-	return xplan_append_virtual_close_complete(xp, pstmt_name, msg);
+	/* let the pg format the correct error */
+	return xplan_append_fwd_no_delta(xp, msg, NULL /* no rewrite */);
+}
+
+/*
+ * detect whether a prepared statement is a DEALLOCATE that must be
+ * virtualized (not sent to the server) in the extended protocol path.
+ *
+ * returns:
+ *  -1  not a virtualizable query
+ *   0  DEALLOCATE name  (name stored in *name / *name_len)
+ *   1  DEALLOCATE ALL
+ *
+ * note: DISCARD ALL is NOT virtualized - it resets much more than just
+ * prepared statements (temp tables, sequences, listen/notify, session
+ * variables, advisory locks, etc) and must be executed on the server.
+ *
+ * for DEALLOCATE name, *name points into desc->data (stable, NUL-terminated).
+ */
+static int pstmt_deallocate_check(const od_pstmt_t *pstmt, const char **name,
+				  size_t *name_len)
+{
+	const od_pstmt_desc_t *desc = &pstmt->desc;
+	if (desc->len < 10) {
+		return -1;
+	}
+
+	int rc = od_parse_deallocate(desc->data, strlen(desc->data), name,
+				     name_len);
+	switch (rc) {
+	case 1:
+		return 1;
+	case 0:
+		return 0;
+	default:
+		return -1;
+	}
 }
 
 static inline machine_msg_t *rewrite_bind_msg(char *data, int size,
@@ -690,7 +906,8 @@ static inline machine_msg_t *rewrite_bind_msg(char *data, int size,
 	/* packet header */
 	memcpy(rewrite_data, data, opname_start_offset);
 	/* prefix for opname */
-	od_snprintf(rewrite_data + opname_start_offset, opnamelen, opname);
+	od_snprintf(rewrite_data + opname_start_offset, opnamelen, "%s",
+		    opname);
 	/* rest of msg */
 	memcpy(rewrite_data + opname_start_offset + opnamelen,
 	       data + opname_start_offset + operator_name_len,
@@ -707,7 +924,6 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 {
 	od_client_t *client = relay->client;
 	od_server_t *server = client->server;
-	od_instance_t *instance = client->global->instance;
 
 	machine_msg_t *msg = m->msg;
 	char *data = machine_msg_data(msg);
@@ -715,9 +931,11 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 
 	uint32_t pstmt_name_len;
 	char *pstmt_name;
+	uint32_t portal_name_len;
+	char *portal_name;
 	int rc;
-	rc = kiwi_be_read_bind_stmt_name(data, size, &pstmt_name,
-					 &pstmt_name_len);
+	rc = kiwi_be_read_bind_names(data, size, &portal_name, &portal_name_len,
+				     &pstmt_name, &pstmt_name_len);
 	if (rc == -1) {
 		return OD_ECLIENT_PROTOCOL_ERROR;
 	}
@@ -730,34 +948,6 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 		}
 
 		return xplan_append_virtual_error_response(xp, msg, vresp);
-	}
-
-	int remove_all = 0;
-
-	/* XXX: we must plan discard on Execute, not on Bind */
-	const od_pstmt_desc_t *desc = &pstmt->desc;
-	if (desc->len >= 7) {
-		if (strncmp(desc->data, "DISCARD", 7) == 0) {
-			od_debug(&instance->logger, "rewrite bind", client,
-				 server, "discard detected, invalidate caches");
-			remove_all = 1;
-		} else {
-			size_t name_len;
-			const char *name = NULL;
-			int rc = od_parse_deallocate(desc->data,
-						     strlen(desc->data), &name,
-						     &name_len);
-			switch (rc) {
-			case 1:
-				remove_all = 1;
-				break;
-			case 0:
-				/* TODO: support DEALLOCATE name */
-				break;
-			default:
-				break;
-			}
-		}
 	}
 
 	int pstmt_start_offset = kiwi_be_bind_opname_offset(data, size);
@@ -777,20 +967,126 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 		return OD_EOOM;
 	}
 
-	if (!remove_all) {
-		return xplan_append_fwd_no_delta(xp, msg, bmsg);
-	}
-
-	return xplan_append_fwd(xp, msg, bmsg, OD_XPLAN_DELTA_REMOVE_ALL,
-				pstmt_name, pstmt);
+	/*
+	 * forward the Bind and add portal -> pstmt mapping on client.
+	 */
+	return xplan_append_fwd_portal(xp, msg, bmsg, portal_name, pstmt);
 }
 
 static od_frontend_status_t plan_execute(od_relay_t *relay, od_xplan_t *xp,
 					 od_xbuf_msg_t *m)
 {
-	(void)relay;
+	static const uint8_t cc_deallocate[] = { 'C', 0,   0,	0,   15,  'D',
+						 'E', 'A', 'L', 'L', 'O', 'C',
+						 'A', 'T', 'E', 0 };
 
-	return xplan_append_fwd_no_delta(xp, m->msg, NULL /* no rewrite */);
+	static const uint8_t cc_deallocate_all[] = { 'C', 0,   0,   0,	 19,
+						     'D', 'E', 'A', 'L', 'L',
+						     'O', 'C', 'A', 'T', 'E',
+						     ' ', 'A', 'L', 'L', 0 };
+
+	od_client_t *client = relay->client;
+	od_server_t *server = client->server;
+	od_instance_t *instance = client->global->instance;
+
+	machine_msg_t *msg = m->msg;
+	char *data = machine_msg_data(msg);
+	int size = machine_msg_size(msg);
+
+	uint32_t portal_name_len;
+	char *portal_name;
+	int rc = kiwi_be_read_execute(data, size, &portal_name,
+				      &portal_name_len);
+	if (rc == -1) {
+		return OD_ECLIENT_PROTOCOL_ERROR;
+	}
+
+	const od_pstmt_t *pstmt =
+		plan_client_get_portal(xp, client, portal_name);
+	if (pstmt == NULL) {
+		/*
+		 * portal not found - just forward, let the server
+		 * produce the appropriate ErrorResponse
+		 */
+		return xplan_append_fwd_no_delta(xp, msg,
+						 NULL /* no rewrite */);
+	}
+
+	/*
+	 * detect DEALLOCATE ALL / DEALLOCATE name in the prepared statement
+	 * text and virtualize the Execute:
+	 * - do not send Execute to the server
+	 * - synthesize a virtual CommandComplete
+	 * - apply the appropriate delta to keep client state in sync
+	 *
+	 * this fixes the long-standing issue where DEALLOCATE was detected at
+	 * Bind time (too early) and DEALLOCATE name was a no-op.
+	 *
+	 * note: we only clear the CLIENT hashmap (not server), matching the
+	 * simple-protocol process_vdeallocate behavior. the server still
+	 * holds its odyssey_pstmt_N entries (they are reused on next Bind).
+	 *
+	 * DISCARD ALL is NOT virtualized: it resets much more than just
+	 * prepared statements (temp tables, sequences, listen/notify,
+	 * session variables, advisory locks) and must run on the server.
+	 * it is forwarded and REMOVE_ALL delta clears both hashmaps after
+	 * the server replies (matching simple-protocol process_discard).
+	 */
+	const od_pstmt_desc_t *desc = &pstmt->desc;
+	if (od_parse_discard_all(desc->data, strlen(desc->data))) {
+		od_debug(&instance->logger, "rewrite execute", client, server,
+			 "DISCARD ALL detected via portal, invalidate caches");
+		return xplan_append_fwd(xp, msg, NULL,
+					OD_XPLAN_DELTA_REMOVE_ALL, NULL, pstmt);
+	}
+
+	size_t dealloc_name_len;
+	const char *dealloc_name = NULL;
+	int vrc =
+		pstmt_deallocate_check(pstmt, &dealloc_name, &dealloc_name_len);
+	switch (vrc) {
+	case 1: /* DEALLOCATE ALL */
+		od_debug(
+			&instance->logger, "rewrite execute", client, server,
+			"DEALLOCATE ALL detected via portal, invalidate client caches");
+		return xplan_append_virtual_command_complete(
+			xp, msg, OD_XPLAN_DELTA_REMOVE_CLIENT_ALL, NULL, NULL,
+			cc_deallocate_all, sizeof(cc_deallocate_all));
+	case 0: { /* DEALLOCATE name */
+		od_debug(&instance->logger, "rewrite execute", client, server,
+			 "DEALLOCATE '%.*s' detected via portal",
+			 (int)dealloc_name_len, dealloc_name);
+		/*
+		 * TODO: PG returns ERROR 26000 if the statement does not
+		 * exist; we always report success, same as
+		 * process_vdeallocate() in the simple path.
+		 *
+		 * od_parse_deallocate returns a pointer into pstmt->desc.data
+		 * (not NUL-terminated). The client_pstmt delta field is passed
+		 * to hashmap operations (strcmp/strlen) which require a
+		 * NUL-terminated string, so make an owned copy. It is freed in
+		 * plan_entry_destroy.
+		 */
+		char *dealloc_name_z =
+			od_strdup_from_buf(dealloc_name, dealloc_name_len);
+		if (dealloc_name_z == NULL) {
+			return OD_EOOM;
+		}
+		od_frontend_status_t st = xplan_append_virtual_command_complete(
+			xp, msg, OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME,
+			dealloc_name_z, NULL, cc_deallocate,
+			sizeof(cc_deallocate));
+		if (st != OD_OK) {
+			od_free(dealloc_name_z);
+		}
+		return st;
+	}
+	default:
+		/* not a special query - forward normally */
+		break;
+	}
+
+	return xplan_append_fwd_no_delta(xp, msg, NULL /* no rewrite */);
 }
 
 static od_frontend_status_t plan_flush(od_relay_t *relay, od_xplan_t *xp,
@@ -993,9 +1289,23 @@ delta_apply(od_xplan_delta_t *delta, od_client_t *client, od_server_t *server)
 	case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY:
 		od_client_remove_pstmt(client, delta->client_pstmt);
 		break;
+	case OD_XPLAN_DELTA_REMOVE_CLIENT_ONLY_BY_NAME:
+		od_client_remove_pstmt(client, delta->client_pstmt);
+		break;
+	case OD_XPLAN_DELTA_ADD_PORTAL:
+		od_client_add_portal(client, delta->portal_name, delta->pstmt);
+		break;
+	case OD_XPLAN_DELTA_REMOVE_PORTAL:
+		od_client_remove_portal(client, delta->portal_name);
+		break;
 	case OD_XPLAN_DELTA_REMOVE_ALL:
 		od_client_pstmts_clear(client);
+		od_client_portals_clear(client);
 		od_server_pstmts_clear(server);
+		break;
+	case OD_XPLAN_DELTA_REMOVE_CLIENT_ALL:
+		od_client_pstmts_clear(client);
+		od_client_portals_clear(client);
 		break;
 
 	case OD_XPLAN_DELTA_ADD_BOTH:
@@ -1082,6 +1392,22 @@ static od_frontend_status_t run_virtual_close_complete(od_xplan_entry_t *cc,
 	size_t unused;
 	int rc = od_io_write_raw(&client->io, bytes, sizeof(bytes), &unused,
 				 timeout_ms, 0);
+	if (rc != 0) {
+		return OD_ECLIENT_WRITE;
+	}
+
+	return OD_OK;
+}
+
+static od_frontend_status_t run_virtual_command_complete(od_xplan_entry_t *cc,
+							 od_client_t *client,
+							 uint32_t timeout_ms)
+{
+	assert(cc->vcc_data != NULL && cc->vcc_len > 0);
+
+	size_t unused;
+	int rc = od_io_write_raw(&client->io, cc->vcc_data, cc->vcc_len,
+				 &unused, timeout_ms, 0);
 	if (rc != 0) {
 		return OD_ECLIENT_WRITE;
 	}
@@ -1442,6 +1768,10 @@ static od_frontend_status_t run_plan_impl(od_xplan_t *xp, od_relay_t *relay,
 		case OD_XPLAN_VIRTUAL_CLOSE_COMPLETE:
 			status = run_virtual_close_complete(entry, client,
 							    timeout_ms);
+			break;
+		case OD_XPLAN_VIRTUAL_COMMAND_COMPLETE:
+			status = run_virtual_command_complete(entry, client,
+							      timeout_ms);
 			break;
 		case OD_XPLAN_FORWARD:
 			/* fallthrough */

--- a/test/proto/entrypoint.sh
+++ b/test/proto/entrypoint.sh
@@ -24,8 +24,7 @@ do_test() {
   POSTGRES_DB=postgres \
   POSTGRES_USER="$user" \
   /usr/bin/proto.test \
-      -test.v \
-      -test.skip 'TestDeallocatePrepareRemovesPstmtsByXproto|TestDeallocateRemovesPstmtsByXproto'
+      -test.v
 }
 
 do_test suser


### PR DESCRIPTION
This allows to correctly support the
DEALLOCATE and DISCARD commands.

Solved by adding the map portal name -> pstmt* for each client

Additional portal tests: https://github.com/pg-sharding/spqr/pull/2822