### PR TITLE
Be more lenient for network errors in accept loop.

### DIFF
--- a/sources/include/machinarium/machinarium.h
+++ b/sources/include/machinarium/machinarium.h
@@ -140,6 +140,8 @@ MACHINE_API int machine_errno(void);
 
 MACHINE_API int machine_errno_retryable(int errno_);
 
+MACHINE_API int machine_accept_errno_retryable(int errno_);
+
 MACHINE_API const char *machine_coroutine_get_name(uint64_t coroutine_id);
 
 /* condition */

--- a/sources/machinarium/accept.c
+++ b/sources/machinarium/accept.c
@@ -56,7 +56,7 @@ MACHINE_API int mm_io_accept(mm_io_t *obj, mm_io_t **client, int backlog,
 		}
 
 		int err = errno;
-		if (machine_errno_retryable(err)) {
+		if (machine_accept_errno_retryable(err)) {
 			/* wait for EPOLLIN event on socket */
 			rc = mm_io_wait_deadline(io);
 			if (rc == MM_COND_WAIT_OK_PROPAGATED) {

--- a/sources/machinarium/machine.c
+++ b/sources/machinarium/machine.c
@@ -424,16 +424,28 @@ MACHINE_API int machine_errno_retryable(int errno_)
 	return errno_ == EAGAIN || errno_ == EWOULDBLOCK || errno_ == EINTR;
 }
 
+/* See also accept(2) */
 MACHINE_API int machine_accept_errno_retryable(int errno_)
 {
-	return machine_errno_retryable(errno_) || errno_ == ENETDOWN ||
-	       errno_ == EPROTO || errno_ == ENOPROTOOPT ||
-	       errno_ == EHOSTDOWN ||
+	if (machine_errno_retryable(errno_)) {
+		return 1;
+	}
+
+	switch (errno_) {
+	case ENETDOWN:
+	case EPROTO:
+	case ENOPROTOOPT:
+	case EHOSTDOWN:
 #ifdef ENONET
-	       errno_ == ENONET ||
+	case ENONET:
 #endif
-	       errno_ == EHOSTUNREACH || errno_ == EOPNOTSUPP ||
-	       errno_ == ENETUNREACH;
+	case EHOSTUNREACH:
+	case EOPNOTSUPP:
+	case ENETUNREACH:
+		return 1;
+	default:
+		return 0;
+	}
 }
 
 MACHINE_API uint64_t machine_time_ms(void)

--- a/sources/machinarium/machine.c
+++ b/sources/machinarium/machine.c
@@ -424,6 +424,15 @@ MACHINE_API int machine_errno_retryable(int errno_)
 	return errno_ == EAGAIN || errno_ == EWOULDBLOCK || errno_ == EINTR;
 }
 
+MACHINE_API int machine_accept_errno_retryable(int errno_)
+{
+	return machine_errno_retryable(errno_) || errno_ == ENETDOWN ||
+	       errno_ == EPROTO || errno_ == ENOPROTOOPT ||
+	       errno_ == EHOSTDOWN || errno_ == ENONET ||
+	       errno_ == EHOSTUNREACH || errno_ == EOPNOTSUPP ||
+	       errno_ == ENETUNREACH;
+}
+
 MACHINE_API uint64_t machine_time_ms(void)
 {
 	mm_clock_update(&mm_self->loop.clock);

--- a/sources/machinarium/machine.c
+++ b/sources/machinarium/machine.c
@@ -428,7 +428,10 @@ MACHINE_API int machine_accept_errno_retryable(int errno_)
 {
 	return machine_errno_retryable(errno_) || errno_ == ENETDOWN ||
 	       errno_ == EPROTO || errno_ == ENOPROTOOPT ||
-	       errno_ == EHOSTDOWN || errno_ == ENONET ||
+	       errno_ == EHOSTDOWN ||
+#ifdef ENONET
+	       errno_ == ENONET ||
+#endif
 	       errno_ == EHOSTUNREACH || errno_ == EOPNOTSUPP ||
 	       errno_ == ENETUNREACH;
 }


### PR DESCRIPTION
As recommended per https://man7.org/linux/man-pages/man2/accept.2.html#RETURN_VALUE

```
 For
       reliable operation the application should detect the network
       errors defined for the protocol after accept() and treat them like
       EAGAIN by retrying.  In the case of TCP/IP, these are ENETDOWN,
       EPROTO, ENOPROTOOPT, EHOSTDOWN, ENONET, EHOSTUNREACH, EOPNOTSUPP,
       and ENETUNREACH.
```