### PR TITLE
correct support for tls "allow" at storage

### DIFF
--- a/docs/configuration/storage.md
+++ b/docs/configuration/storage.md
@@ -47,6 +47,54 @@ Supported TLS modes:
 "verify_full" - require valid certificate
 ```
 
+The modes follow the `sslmode` parameter of libpq.
+
+`allow` connects in plaintext first. A server that requires TLS refuses such a
+connection only at startup, with `no pg_hba.conf entry ... no encryption`, and
+only then does Odyssey drop the connection and retry it over TLS.
+`backend_connect_timeout_ms` applies to each attempt separately.
+
+The retry is not limited to the TLS-related error, since the error itself is not
+a reliable signal: its text is translated according to the server `lc_messages`,
+and a server that is not PostgreSQL reports the same situation differently. Like
+libpq, Odyssey retries whenever the server answered the startup packet with an
+ErrorResponse, whatever the error is; a connection that was closed or a reply
+that could not be parsed is reported as is, without a second attempt.
+
+Two exceptions are made:
+
+* `57P03` (`cannot_connect_now`), just like libpq, which considers another host
+  more promising than another encryption method
+* `53300` (`too_many_connections`), `3D000` (`invalid_catalog_name`) and `28P01`
+  (`invalid_password`) — unlike libpq. These are definite answers that TLS will
+  not change, and repeating them for every client would only double the
+  connection load on a server that is already refusing connections.
+
+Note that with `allow` the startup packet and the authentication exchange of the
+first attempt are sent in cleartext, and against a server that supports TLS but
+does not require it the connection stays unencrypted. Use `prefer` to negotiate
+TLS whenever the server supports it, or `require` to demand it.
+
+Cancel requests send no startup packet and therefore have nothing to retry on,
+so with `allow` they are always sent in plaintext. This does not make them fail:
+a server handles a cancel request before authentication and without consulting
+`pg_hba.conf`, so it accepts a plaintext one even when it otherwise allows
+`hostssl` connections only. The cancel key does travel in cleartext then, just
+as it does with the signal-safe `PQcancel()` of libpq. Use `prefer` or `require`
+if that matters.
+
+Connections preallocated for `min_pool_size` are established in plaintext as
+well, since they are connected long before they are used. Such a connection is
+retried over TLS when a client picks it up and the startup is finally
+performed.
+
+!!! warning
+    Earlier versions of Odyssey negotiated TLS first for `allow` and fell back
+    to plaintext, i.e. `allow` behaved the way `prefer` does now. Replace it
+    with `prefer` to keep that behaviour — otherwise connections that used to be
+    encrypted become plaintext. Odyssey logs a message at startup for every
+    storage that still uses `allow`.
+
 ## **tls\_ca\_file**
 *string*
 

--- a/sources/backend.c
+++ b/sources/backend.c
@@ -162,15 +162,171 @@ int od_backend_ready(od_server_t *server, char *data, uint32_t size)
 	return 0;
 }
 
+static inline void od_backend_reset_for_retry(od_server_t *server)
+{
+	od_backend_close_connection(server);
+
+	od_io_free(&server->io);
+	od_io_init(&server->io);
+
+	od_scram_state_free(&server->scram_state);
+	od_scram_state_init(&server->scram_state);
+
+	kiwi_key_init(&server->key);
+	kiwi_vars_init(&server->vars);
+
+	/*
+	 * do not reset client key here
+	 * 
+	 * client key can be set before real connection attempt
+	 * and if connect retry successeded, the key will be zeroed
+	 */
+
+	server->sync_request = 0;
+	server->sync_reply = 0;
+	server->is_transaction = 0;
+	server->is_error_tx = 0;
+	server->msg_broken = 0;
+	server->oom = 0;
+	server->synced_settings = false;
+	server->need_startup = 1;
+}
+
+/*
+ * libpq switches to the next encryption method only when the server has
+ * answered the startup packet with a valid ErrorResponse: see CONNECTION_FAILED
+ * in the ErrorResponse branch of CONNECTION_AWAITING_RESPONSE in PQconnectPoll.
+ * A closed connection, a garbled reply or a peer that is not a postgres server
+ * at all end the attempt right there, and ERRCODE_CANNOT_CONNECT_NOW is special
+ * cased to move on to the next host instead of changing the encryption.
+ *
+ * On top of that we skip the retry for errors that have nothing to do with
+ * encryption at all. libpq can afford repeating them, a pooler cannot: it would
+ * double the connection load on a server that is already unhappy, and it would
+ * hide the original error from the code that inspects it (see
+ * od_frontend_error_is_too_many_connections).
+ */
+static inline int od_backend_startup_error_allows_tls_retry(od_server_t *server,
+							    const char **code)
+{
+	*code = NULL;
+
+	if (server->error_connect == NULL) {
+		/* connection lost, or the peer does not talk our protocol */
+		return 0;
+	}
+
+	kiwi_fe_error_t error;
+	if (kiwi_fe_read_error(machine_msg_data(server->error_connect),
+			       machine_msg_size(server->error_connect),
+			       &error) == -1) {
+		return 0;
+	}
+
+	if (error.code == NULL) {
+		return 0;
+	}
+
+	*code = error.code;
+
+	/* as in libpq: another host may accept us, encryption is irrelevant */
+	if (strcmp(error.code, KIWI_CANNOT_CONNECT_NOW) == 0) {
+		return 0;
+	}
+
+	/*
+	 * Unlike libpq: the server gave a definite answer that TLS will not
+	 * change. Drop these lines to follow libpq to the letter.
+	 */
+	if (strcmp(error.code, KIWI_TOO_MANY_CONNECTIONS) == 0 ||
+	    strcmp(error.code, KIWI_INVALID_CATALOG_NAME) == 0 ||
+	    strcmp(error.code, KIWI_INVALID_PASSWORD) == 0) {
+		return 0;
+	}
+
+	return 1;
+}
+
+/*
+ * Perform startup, falling back to a TLS connection for the "allow" mode.
+ *
+ * With libpq sslmode=allow the plaintext attempt comes first and the whole
+ * connection is retried over TLS once it fails, since a server that requires
+ * TLS refuses the plaintext one only at startup, with an ErrorResponse.
+ */
+static int od_backend_startup_with_tls_fallback(od_server_t *server,
+						char *context,
+						od_rule_storage_t *storage,
+						kiwi_params_t *route_params,
+						od_client_t *client)
+{
+	od_instance_t *instance = server->global->instance;
+	od_tls_opts_t *tlsopts = storage->tls_opts;
+
+	int rc = od_backend_startup(server, route_params, client);
+	if (rc == OK_RESPONSE) {
+		return OK_RESPONSE;
+	}
+
+	/*
+	 * server->tls is set only once TLS has been negotiated, so the retry
+	 * below never happens more than once per connection.
+	 */
+	if (tlsopts->tls_mode != OD_CONFIG_TLS_ALLOW || server->tls != NULL) {
+		return NOT_OK_RESPONSE;
+	}
+
+	/* must be checked before the reset, it frees error_connect */
+	const char *code = NULL;
+	if (!od_backend_startup_error_allows_tls_retry(server, &code)) {
+		od_debug(
+			&instance->logger, context, client, server,
+			"startup over a plaintext connection failed, not retrying with tls (allow), code=%s",
+			code ? code : "(null)");
+		return NOT_OK_RESPONSE;
+	}
+
+	od_debug(
+		&instance->logger, context, client, server,
+		"startup over a plaintext connection failed (code=%s), retrying with tls (allow)",
+		code ? code : "(null)");
+
+	/* points to server->error_connect, which can be reset at next lines */
+	code = NULL;
+
+	od_backend_reset_for_retry(server);
+
+	if (route_params != NULL) {
+		/* drop the parameters collected by the failed attempt */
+		kiwi_params_free(route_params);
+		kiwi_params_init(route_params);
+	}
+
+	rc = od_backend_connect_to(server, context,
+				   od_server_pool_address(server), tlsopts,
+				   OD_BACKEND_TLS_NEGOTIATE);
+	if (rc != OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+
+	return od_backend_startup(server, route_params, client);
+}
+
 int od_backend_startup_preallocated(od_server_t *server,
 				    kiwi_params_t *route_params,
 				    od_client_t *client)
 {
-	if (od_backend_need_startup(server)) {
-		return od_backend_startup(server, route_params, client);
+	if (!od_backend_need_startup(server)) {
+		return OK_RESPONSE;
 	}
 
-	return 0;
+	/*
+	 * A preallocated connection is connected long before it is started up,
+	 * so this is where the "allow" mode learns that the server wants TLS.
+	 */
+	return od_backend_startup_with_tls_fallback(
+		server, "startup", server->route->rule->storage, route_params,
+		client);
 }
 
 int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
@@ -366,8 +522,25 @@ int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
 	return 0;
 }
 
+static inline int od_backend_tls_negotiate(od_tls_opts_t *tlsopts,
+					   od_backend_tls_attempt_t attempt)
+{
+	if (tlsopts->tls_mode == OD_CONFIG_TLS_DISABLE) {
+		return 0;
+	}
+	if (attempt == OD_BACKEND_TLS_NEGOTIATE) {
+		return 1;
+	}
+	/*
+	 * libpq sslmode=allow: try a plaintext connection first, TLS is
+	 * negotiated only after the server has refused the plaintext one.
+	 */
+	return tlsopts->tls_mode != OD_CONFIG_TLS_ALLOW;
+}
+
 int od_backend_connect_to(od_server_t *server, char *context,
-			  const od_address_t *address, od_tls_opts_t *tlsopts)
+			  const od_address_t *address, od_tls_opts_t *tlsopts,
+			  od_backend_tls_attempt_t tls_attempt)
 {
 	od_instance_t *instance = server->global->instance;
 	od_assert(server->io.io == NULL);
@@ -401,7 +574,8 @@ int od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	/* set tls options */
-	if (tlsopts->tls_mode != OD_CONFIG_TLS_DISABLE) {
+	int negotiate_tls = od_backend_tls_negotiate(tlsopts, tls_attempt);
+	if (negotiate_tls) {
 		server->tls = od_tls_backend(tlsopts);
 		if (server->tls == NULL) {
 			return -1;
@@ -531,7 +705,7 @@ int od_backend_connect_to(od_server_t *server, char *context,
 	}
 
 	/* do tls handshake */
-	if (tlsopts->tls_mode != OD_CONFIG_TLS_DISABLE) {
+	if (negotiate_tls) {
 		rc = od_tls_backend_connect(server, &instance->logger, tlsopts);
 		if (rc == NOT_OK_RESPONSE) {
 			return NOT_OK_RESPONSE;
@@ -779,13 +953,15 @@ static inline int od_backend_connect_on_server_address(
 
 	od_retcode_t rc;
 
-	rc = od_backend_connect_to(server, context, address, storage->tls_opts);
+	rc = od_backend_connect_to(server, context, address, storage->tls_opts,
+				   OD_BACKEND_TLS_DEFAULT);
 	if (rc == NOT_OK_RESPONSE) {
 		return rc;
 	}
 
 	/* send startup and do initial configuration */
-	rc = od_backend_startup(server, route_params, client);
+	rc = od_backend_startup_with_tls_fallback(server, context, storage,
+						  route_params, client);
 	if (rc == NOT_OK_RESPONSE) {
 		return rc;
 	}
@@ -821,10 +997,20 @@ int od_backend_connect_cancel(od_server_t *server, od_rule_storage_t *storage,
 			(uint32_t)instance->config.cancel_timeout_ms :
 			UINT32_MAX;
 
-	/* connect to server */
+	/*
+	 * Connect to server.
+	 *
+	 * A cancel connection sends no startup packet, so the "allow" mode has
+	 * nothing to retry on and stays plaintext here. That is enough: the
+	 * postmaster handles CancelRequest before authentication and before
+	 * pg_hba.conf is consulted, so a plaintext cancel is delivered even by
+	 * a server that accepts hostssl connections only. The cancel key is
+	 * sent in cleartext then, exactly like the signal-safe PQcancel() of
+	 * libpq does it.
+	 */
 	int rc;
-	rc = od_backend_connect_to(server, "cancel", address,
-				   storage->tls_opts);
+	rc = od_backend_connect_to(server, "cancel", address, storage->tls_opts,
+				   OD_BACKEND_TLS_DEFAULT);
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -318,6 +318,16 @@ static int od_frontend_startup(od_client_t *client)
 		return 0;
 	}
 
+	if (client->config_listen->tls_opts->tls_mode >=
+		    OD_CONFIG_TLS_REQUIRE &&
+	    !ssl_done) {
+		od_log(&instance->logger, "tls", client, NULL,
+		       "required, closing");
+		od_frontend_error(client, KIWI_PROTOCOL_VIOLATION,
+				  "SSL is required");
+		return -1;
+	}
+
 	if (PG_PROTOCOL_MINOR(client->startup.proto_version) >
 		    PG_PROTOCOL_MINOR(PG_PROTOCOL_LATEST) ||
 	    has_unsupported_features(client)) {

--- a/sources/include/backend.h
+++ b/sources/include/backend.h
@@ -29,9 +29,16 @@ od_tsa_check_result_t od_backend_check_tsa(od_rule_storage_t *,
 int od_backend_connect_cancel(od_server_t *, od_rule_storage_t *,
 			      const od_address_t *, kiwi_key_t *);
 
+typedef enum {
+	/* obey tls_mode, i.e. plaintext for the first attempt of "allow" */
+	OD_BACKEND_TLS_DEFAULT,
+	/* negotiate TLS even if tls_mode alone would have chosen plaintext */
+	OD_BACKEND_TLS_NEGOTIATE,
+} od_backend_tls_attempt_t;
+
 /* need perform startup after this */
 int od_backend_connect_to(od_server_t *, char *, const od_address_t *,
-			  od_tls_opts_t *);
+			  od_tls_opts_t *, od_backend_tls_attempt_t);
 
 int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
 		       od_client_t *client);

--- a/sources/include/tls_config.h
+++ b/sources/include/tls_config.h
@@ -8,6 +8,7 @@
  */
 
 typedef enum {
+	/* do not change the order */
 	OD_CONFIG_TLS_DISABLE,
 	OD_CONFIG_TLS_ALLOW,
 	OD_CONFIG_TLS_PREFER,

--- a/sources/router.c
+++ b/sources/router.c
@@ -369,7 +369,8 @@ od_router_create_connected_server(od_route_t *route,
 	od_route_unlock(route);
 
 	int rc = od_backend_connect_to(server, "idle-preallocate", address,
-				       storage->tls_opts);
+				       storage->tls_opts,
+				       OD_BACKEND_TLS_DEFAULT);
 
 	/* caller function believes the lock is held */
 	od_route_lock(route);

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -1965,6 +1965,12 @@ int od_rules_validate(od_rules_t *rules, od_config_t *config,
 				   0) {
 				storage->tls_opts->tls_mode =
 					OD_CONFIG_TLS_ALLOW;
+				od_log(logger, "rules", NULL, NULL,
+				       "storage '%s': tls \"allow\" now follows libpq sslmode=allow, "
+				       "a connection is made in plaintext and is retried with tls "
+				       "only after the server has rejected it; "
+				       "use tls \"prefer\" to always negotiate tls first",
+				       storage->name);
 			} else if (strcmp(storage->tls_opts->tls, "prefer") ==
 				   0) {
 				storage->tls_opts->tls_mode =

--- a/sources/tls.c
+++ b/sources/tls.c
@@ -68,81 +68,60 @@ machine_tls_t *od_tls_frontend(od_config_listen_t *config)
 int od_tls_frontend_accept(od_client_t *client, od_logger_t *logger,
 			   od_config_listen_t *config, machine_tls_t *tls)
 {
-	if (client->startup.is_ssl_request) {
-		od_debug(logger, "tls", client, NULL, "ssl request");
+	od_debug(logger, "tls", client, NULL, "ssl request");
 
-		int rc;
-		if (config->tls_opts->tls_mode == OD_CONFIG_TLS_DISABLE) {
-			/* not supported 'N' */
-			machine_msg_t *msg;
-			msg = machine_msg_create(sizeof(uint8_t));
-			if (msg == NULL) {
-				return -1;
-			}
-			uint8_t *type = machine_msg_data(msg);
-			*type = 'N';
-			rc = od_write(&client->io, msg);
-			if (rc == -1) {
-				od_error(logger, "tls", client, NULL,
-					 "write error: %s",
-					 od_io_error(&client->io));
-				return -1;
-			}
-			od_debug(logger, "tls", client, NULL,
-				 "is disabled, ignoring");
-			return 0;
-		}
-
-		/* supported 'S' */
+	int rc;
+	if (config->tls_opts->tls_mode == OD_CONFIG_TLS_DISABLE) {
+		/* not supported 'N' */
 		machine_msg_t *msg;
 		msg = machine_msg_create(sizeof(uint8_t));
 		if (msg == NULL) {
 			return -1;
 		}
 		uint8_t *type = machine_msg_data(msg);
-		*type = 'S';
+		*type = 'N';
 		rc = od_write(&client->io, msg);
 		if (rc == -1) {
 			od_error(logger, "tls", client, NULL, "write error: %s",
 				 od_io_error(&client->io));
 			return -1;
 		}
-
-		if (od_readahead_unread(&client->io.readahead) > 0) {
-			od_error(logger, "tls", client, NULL,
-				 "extraneous data from client");
-			return -1; /* prevent possible buffer, protecting against CVE-2021-23214-like attacks */
-		}
-
-		rc = mm_io_set_tls(client->io.io, tls,
-				   config->client_login_timeout);
-		if (rc == -1) {
-			od_error(logger, "tls", client, NULL,
-				 "error: %s, login time %" PRIu64 " us",
-				 od_io_error(&client->io),
-				 machine_time_us() - client->time_accept);
-			return -1;
-		}
-		od_debug(logger, "tls", client, NULL, "ok");
+		od_debug(logger, "tls", client, NULL, "is disabled, ignoring");
 		return 0;
 	}
 
-	/* Client sends cancel request without encryption */
-	if (client->startup.is_cancel) {
-		return 0;
-	}
-
-	switch (config->tls_opts->tls_mode) {
-	case OD_CONFIG_TLS_DISABLE:
-	case OD_CONFIG_TLS_ALLOW:
-	case OD_CONFIG_TLS_PREFER:
-		break;
-	default:
-		od_log(logger, "tls", client, NULL, "required, closing");
-		od_frontend_error(client, KIWI_PROTOCOL_VIOLATION,
-				  "SSL is required");
+	/* supported 'S' */
+	machine_msg_t *msg;
+	msg = machine_msg_create(sizeof(uint8_t));
+	if (msg == NULL) {
 		return -1;
 	}
+	uint8_t *type = machine_msg_data(msg);
+	*type = 'S';
+	rc = od_write(&client->io, msg);
+	if (rc == -1) {
+		od_error(logger, "tls", client, NULL, "write error: %s",
+			 od_io_error(&client->io));
+		return -1;
+	}
+
+	if (od_readahead_unread(&client->io.readahead) > 0) {
+		od_error(logger, "tls", client, NULL,
+			 "extraneous data from client");
+		return -1; /* prevent possible buffer, protecting against CVE-2021-23214-like attacks */
+	}
+
+	rc = mm_io_set_tls(client->io.io, tls, config->client_login_timeout);
+	if (rc == -1) {
+		od_error(logger, "tls", client, NULL,
+			 "error: %s, login time %" PRIu64 " us",
+			 od_io_error(&client->io),
+			 machine_time_us() - client->time_accept);
+		return -1;
+	}
+
+	od_debug(logger, "tls", client, NULL, "ok");
+
 	return 0;
 }
 

--- a/test/functional/Dockerfile
+++ b/test/functional/Dockerfile
@@ -200,7 +200,7 @@ COPY ./test/functional/requirements.txt .
 RUN python3 -m venv /opt/tests/venv
 ENV PATH="/opt/tests/venv/bin:$PATH"
 
-RUN pip install -Ur requirements.txt
+RUN pip install -Ur requirements.txt --index-url=https://pypi-mirror.gitverse.ru/simple/
 
 COPY ./test/functional/test_functional.py .
 

--- a/test/functional/tests/tls-compat/config.conf
+++ b/test/functional/tests/tls-compat/config.conf
@@ -27,6 +27,50 @@ listen {
 	tls_protocols "tlsv1.2"
 }
 
+listen {
+	host "127.0.0.1"
+	port 7432
+
+	tls "allow"
+	tls_key_file "/tests/tls-compat/server.key"
+	tls_cert_file "/tests/tls-compat/server.pem"
+	tls_ca_file "/tests/tls-compat/root.pem"
+	tls_protocols "tlsv1.2"
+}
+
+listen {
+	host "127.0.0.1"
+	port 8432
+
+	tls "prefer"
+	tls_key_file "/tests/tls-compat/server.key"
+	tls_cert_file "/tests/tls-compat/server.pem"
+	tls_ca_file "/tests/tls-compat/root.pem"
+	tls_protocols "tlsv1.2"
+}
+
+listen {
+	host "127.0.0.1"
+	port 9432
+
+	tls "verify_ca"
+	tls_key_file "/tests/tls-compat/server.key"
+	tls_cert_file "/tests/tls-compat/server.pem"
+	tls_ca_file "/tests/tls-compat/root.pem"
+	tls_protocols "tlsv1.2"
+}
+
+listen {
+	host "127.0.0.1"
+	port 10432
+
+	tls "verify_full"
+	tls_key_file "/tests/tls-compat/server.key"
+	tls_cert_file "/tests/tls-compat/server.pem"
+	tls_ca_file "/tests/tls-compat/root.pem"
+	tls_protocols "tlsv1.2"
+}
+
 storage "postgres_server" {
 	type "remote"
 	host "127.0.0.1"

--- a/test/functional/tests/tls-compat/runner.sh
+++ b/test/functional/tests/tls-compat/runner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-set -ex
+set -e
 
 pushd /tests/tls-compat/
 
@@ -24,11 +24,30 @@ dpkg -l | grep ssl | cat
 /usr/bin/odyssey /tests/tls-compat/config.conf
 sleep 1
 
-# Check some read-only load will work with tls
-pgbench 'host=localhost port=6432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' -j 2 -c 10 --select-only --no-vacuum --progress 1 -T 20
+psql 'host=localhost port=6432 user=postgres dbname=postgres sslmode=disable' && {
+    echo "should not connect with ssl mode require"
+    exit 1
+}
+psql 'host=localhost port=9432 user=postgres dbname=postgres sslmode=disable' && {
+    echo "should not connect with ssl mode verify-ca"
+    exit 1
+}
+psql 'host=localhost port=10432 user=postgres dbname=postgres sslmode=disable' && {
+    echo "should not connect with ssl mode verify-full"
+    exit 1
+}
 
-pgbench 'host=localhost port=6432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' -j 2 -c 10 --select-only --no-vacuum --progress 1 -T 20 --connect
+# prefer and allow at listen section should accept both tls and non-tls connections
+psql 'host=localhost port=7432 user=postgres dbname=postgres sslmode=disable' || exit 1
+psql 'host=localhost port=7432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' || exit 1
+psql 'host=localhost port=8432 user=postgres dbname=postgres sslmode=disable' || exit 1
+psql 'host=localhost port=8432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' || exit 1
+
+# Check some read-only load will work with tls
+pgbench 'host=localhost port=6432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' -j 2 -c 10 --select-only --no-vacuum --progress 1 -T 20 || exit 1
+
+pgbench 'host=localhost port=6432 user=postgres dbname=postgres sslmode=verify-full sslrootcert=/tests/tls-compat/root.pem' -j 2 -c 10 --select-only --no-vacuum --progress 1 -T 20 --connect || exit 1
 
 sleep 1
 
-ody-stop
+ody-stop || exit 1


### PR DESCRIPTION
Partly follows the libpq behaviour now
Also fix tls check error left in 9a908826d718a1ec33dc79977cd75bff04fafb41