### PR TITLE
ref counters for global pstmts map

### DIFF
--- a/sources/console.c
+++ b/sources/console.c
@@ -1277,7 +1277,8 @@ static inline int od_console_show_fds_server_cb(od_server_t *server,
 	return 0;
 }
 
-static inline int show_server_pstmt_cb_internal(mm_hashmap_kvp_t *kvp,
+static inline int show_server_pstmt_cb_internal(mm_hashmap_t *server_map,
+						mm_hashmap_kvp_t *kvp,
 						void **argv)
 {
 	od_server_t *server = argv[1];
@@ -1324,8 +1325,8 @@ static inline int show_server_pstmt_cb_internal(mm_hashmap_kvp_t *kvp,
 		goto error;
 	}
 
-	const od_pstmt_t *pstmt = *(
-		const od_pstmt_t **)mm_hashmap_kvp_val(server->prep_stmts, kvp);
+	const od_pstmt_t *pstmt =
+		*(const od_pstmt_t **)mm_hashmap_kvp_val_const(server_map, kvp);
 
 	/* name */
 	rc = kiwi_be_write_data_row_add(stream, offset, pstmt->name,

--- a/sources/include/instance.h
+++ b/sources/include/instance.h
@@ -9,12 +9,11 @@
 #include <pthread.h>
 #include <stdatomic.h>
 
-#include <machinarium/ds/hm.h>
-
 #include <types.h>
 #include <config.h>
 #include <logger.h>
 #include <pid.h>
+#include <pstmt.h>
 
 typedef struct timeval od_timeval_t;
 
@@ -33,7 +32,7 @@ struct od_instance {
 		char **envp;
 	} cmdline;
 
-	mm_hashmap_t *pstmts;
+	od_global_pstmt_map_t *pstmts;
 };
 
 od_instance_t *od_instance_create(void);
@@ -46,4 +45,4 @@ char *od_instance_getenv(od_instance_t *instance, const char *name);
 void od_instance_set_shutdown_worker_id(od_instance_t *instance, int64_t id);
 int64_t od_instance_get_shutdown_worker_id(od_instance_t *instance);
 
-mm_hashmap_t *od_instance_get_pstmts_map(od_instance_t *instance);
+od_global_pstmt_map_t *od_instance_get_pstmts_map(od_instance_t *instance);

--- a/sources/include/machinarium/ds/hm.h
+++ b/sources/include/machinarium/ds/hm.h
@@ -19,6 +19,8 @@
 
 typedef uint64_t mm_hash_t;
 
+typedef struct mm_hashmap mm_hashmap_t;
+
 typedef int (*mm_hm_key_cmp_fn)(const void *key1, const void *key2);
 typedef mm_hash_t (*mm_hm_key_hash_fn)(const void *key);
 typedef void (*mm_hm_key_dtor_fn)(void *key);
@@ -31,7 +33,8 @@ typedef struct {
 	uint8_t keyval[];
 } mm_hashmap_kvp_t;
 
-typedef int (*mm_hm_kvp_cb_fn)(mm_hashmap_kvp_t *kvp, void **argv);
+typedef int (*mm_hm_kvp_cb_fn)(mm_hashmap_t *hm, mm_hashmap_kvp_t *kvp,
+			       void **argv);
 
 typedef struct {
 	/* mm_hashmap_kvp_t[] */
@@ -44,7 +47,11 @@ typedef struct {
 	int found;
 } mm_hashmap_keylock_t;
 
-typedef struct {
+typedef enum {
+	MM_HASHMAP_CREATE = 1 << 0,
+} mm_hashmap_lockkey_flags_t;
+
+struct mm_hashmap {
 	size_t keysz;
 	size_t valsz;
 
@@ -63,7 +70,7 @@ typedef struct {
 
 	size_t nlocks;
 	mm_mutex_t *locks;
-} mm_hashmap_t;
+};
 
 void *mm_hashmap_kvp_key(const mm_hashmap_t *hm, mm_hashmap_kvp_t *kvp);
 void *mm_hashmap_kvp_val(const mm_hashmap_t *hm, mm_hashmap_kvp_t *kvp);
@@ -83,7 +90,8 @@ void mm_hashmap_free(mm_hashmap_t *hm);
 void mm_hashmap_clear(mm_hashmap_t *hm);
 int mm_hashmap_foreach(mm_hashmap_t *hm, mm_hm_kvp_cb_fn cb, void **argv);
 int mm_hashmap_lock_key(mm_hashmap_t *hm, mm_hashmap_keylock_t *klock,
-			const void *key, int create);
+			const void *key,
+			int flags /* see mm_hashmap_lockkey_flags_t */);
 void mm_hashmap_unlock_key(mm_hashmap_t *hm, mm_hashmap_keylock_t *klock);
 void mm_hashmap_remove(mm_hashmap_t *hm, mm_hashmap_keylock_t *klock);
 

--- a/sources/include/od_assert.h
+++ b/sources/include/od_assert.h
@@ -23,8 +23,15 @@ extern void od_assert_fail(const char *expr, const char *file, int line);
 #else
 #define od_assert(expr)                                            \
 	do {                                                       \
-		if (!(expr)) {                                     \
+		if (od_unlikely(!(expr))) {                        \
 			od_assert_fail(#expr, __FILE__, __LINE__); \
 		}                                                  \
 	} while (0)
 #endif
+
+#define od_release_assert(expr)                                    \
+	do {                                                       \
+		if (od_unlikely(!(expr))) {                        \
+			od_assert_fail(#expr, __FILE__, __LINE__); \
+		}                                                  \
+	} while (0)

--- a/sources/include/od_c.h
+++ b/sources/include/od_c.h
@@ -49,11 +49,6 @@
 #define OK_RESPONSE 0
 #define NOT_OK_RESPONSE -1
 
-#define _STRINGIFY(x) #x
-#define STRINGIFY(x) _STRINGIFY(x)
-#define CONCAT_(A, B) A##B
-#define CONCAT(A, B) CONCAT_(A, B)
-
 static const uint64_t interval_usec = 1000000ull;
 
 typedef int od_retcode_t;

--- a/sources/include/pstmt.h
+++ b/sources/include/pstmt.h
@@ -29,14 +29,16 @@
  */
 
 #include <machinarium/ds/hm.h>
+#include <machinarium/machinarium.h>
 
 #include <types.h>
 
 #define OD_PSTMT_NAME_PREFIX "odyssey_pstmt_"
-#define OD_PSTMT_NAME_MAX \
-	(sizeof(OD_PSTMT_NAME_PREFIX) + sizeof("18446744073709551615") + 1)
+#define OD_MAX_PSTMT_NUM (99999999999999999UL)
+#define OD_PSTMT_NAME_MAX_LEN \
+	(sizeof(OD_PSTMT_NAME_PREFIX) + 17 /* length of OD_MAX_PSTMT_NUM */)
 
-typedef char od_pstmt_name_t[OD_PSTMT_NAME_MAX];
+typedef char od_pstmt_name_t[OD_PSTMT_NAME_MAX_LEN];
 
 /* query and param bytes from Parse message */
 typedef struct {
@@ -44,9 +46,28 @@ typedef struct {
 	size_t len;
 } od_pstmt_desc_t;
 
+typedef struct {
+	mm_hashmap_t *hm;
+	atomic_uint_fast64_t counter;
+} od_global_pstmt_map_t;
+
 struct od_pstmt {
+	/* own the desc->data copy */
 	od_pstmt_desc_t desc;
 	od_pstmt_name_t name;
+
+	/*
+	 * holded by:
+	 * - client pstmts, portals
+	 * - server pstmts
+	 * - xplan entries
+	 * - global pstmts map
+	 *
+	 * after reach 1, the stmt must be deleted from global map
+	 */
+	atomic_uint_fast64_t refs;
+
+	od_global_pstmt_map_t *source;
 };
 
 /* "P_0" -> *od_pstmt_t */
@@ -54,7 +75,7 @@ mm_hashmap_t *od_client_pstmt_hashmap_create(void);
 void od_client_pstmt_hashmap_free(mm_hashmap_t *hm);
 
 int od_client_add_pstmt(od_client_t *client, const char *name,
-			const od_pstmt_t *pstmt);
+			od_pstmt_t *pstmt);
 int od_client_has_pstmt(od_client_t *client, const char *name);
 int od_client_remove_pstmt(od_client_t *client, const char *name);
 od_pstmt_t *od_client_get_pstmt(od_client_t *client, const char *name);
@@ -65,7 +86,7 @@ mm_hashmap_t *od_client_portal_hashmap_create(void);
 void od_client_portal_hashmap_free(mm_hashmap_t *hm);
 
 int od_client_add_portal(od_client_t *client, const char *portal_name,
-			 const od_pstmt_t *pstmt);
+			 od_pstmt_t *pstmt);
 od_pstmt_t *od_client_get_portal(od_client_t *client, const char *portal_name);
 int od_client_remove_portal(od_client_t *client, const char *portal_name);
 void od_client_portals_clear(od_client_t *client);
@@ -75,17 +96,18 @@ mm_hashmap_t *od_server_pstmt_hashmap_create(void);
 void od_server_pstmt_hashmap_free(mm_hashmap_t *hm);
 
 int od_server_has_pstmt(od_server_t *server, const od_pstmt_t *pstmt);
-int od_server_add_pstmt(od_server_t *server, const od_pstmt_t *pstmt);
+int od_server_add_pstmt(od_server_t *server, od_pstmt_t *pstmt);
 int od_server_remove_pstmt(od_server_t *server, const od_pstmt_t *pstmt);
 void od_server_pstmts_clear(od_server_t *server);
 
 /* od_pstmt_desc_t -> od_pstmt_t */
-mm_hashmap_t *od_global_pstmts_map_create(void);
-void od_global_pstmts_map_free(mm_hashmap_t *hm);
-
-void od_pstmt_next_name(od_pstmt_t *out);
-
-od_pstmt_t *od_pstmt_create_or_get(mm_hashmap_t *gm, od_pstmt_desc_t desc);
+od_global_pstmt_map_t *od_global_pstmts_map_create(size_t nlocks);
+void od_global_pstmts_map_free(od_global_pstmt_map_t *hm);
+od_pstmt_t *od_pstmt_create_or_get(od_global_pstmt_map_t *gm,
+				   od_pstmt_desc_t desc);
+int od_global_pstmts_has_pstmt(od_global_pstmt_map_t *gm,
+			       const od_pstmt_desc_t desc);
+void od_global_pstmt_try_remove(od_global_pstmt_map_t *gm, od_pstmt_t *pstmt);
 
 /* helpers */
 char *od_pstmt_name_from_parse(machine_msg_t *msg);
@@ -94,3 +116,27 @@ od_pstmt_desc_t od_pstmt_desc_copy(const od_pstmt_desc_t desc);
 
 machine_msg_t *od_pstmt_parse_of(const od_pstmt_t *pstmt);
 machine_msg_t *od_pstmt_describe_of(const od_pstmt_t *pstmt);
+
+/*
+ * should be called only with
+ * - lock on global map held
+ * - or from ref that is already valid
+ */
+static inline void od_pstmt_ref(od_pstmt_t *pstmt)
+{
+	atomic_fetch_add_explicit(&pstmt->refs, 1, memory_order_relaxed);
+}
+
+static inline void od_pstmt_unref(od_pstmt_t *pstmt)
+{
+	uint64_t v = atomic_fetch_sub_explicit(&pstmt->refs, 1,
+					       memory_order_release);
+	od_assert(v > 1);
+	if (v == 2) {
+		/*
+		 * some other thread can ref this pstmt in parallel
+		 * this fact will be rechecked in remove fn
+		 */
+		od_global_pstmt_try_remove(pstmt->source, pstmt);
+	}
+}

--- a/sources/include/xplan.h
+++ b/sources/include/xplan.h
@@ -8,6 +8,7 @@
 
 #include <status.h>
 #include <types.h>
+#include <pstmt.h>
 
 #include <machinarium/machinarium.h>
 #include <machinarium/ds/vector.h>
@@ -81,7 +82,7 @@ typedef struct {
 	 * where it is an owned NUL-terminated copy (freed in plan_entry_destroy).
 	 */
 	const char *client_pstmt;
-	const od_pstmt_t *pstmt;
+	od_pstmt_t *pstmt;
 	/*
 	 * portal name for ADD_PORTAL / REMOVE_PORTAL deltas
 	 * points to the original client msg (owned by xbuf)

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -628,7 +628,7 @@ int64_t od_instance_get_shutdown_worker_id(od_instance_t *instance)
 	return atomic_load(&instance->shutdown_worker_id);
 }
 
-mm_hashmap_t *od_instance_get_pstmts_map(od_instance_t *instance)
+od_global_pstmt_map_t *od_instance_get_pstmts_map(od_instance_t *instance)
 {
 	return instance->pstmts;
 }

--- a/sources/machinarium/ds/hm.c
+++ b/sources/machinarium/ds/hm.c
@@ -258,7 +258,7 @@ int mm_hashmap_foreach(mm_hashmap_t *hm, mm_hm_kvp_cb_fn cb, void **argv)
 			mm_hashmap_kvp_t *kvp =
 				mm_container_of(i, mm_hashmap_kvp_t, link);
 
-			rc = cb(kvp, argv);
+			rc = cb(hm, kvp, argv);
 			if (rc != 0) {
 				break;
 			}
@@ -297,7 +297,7 @@ static mm_hashmap_kvp_t *kvp_find_locked(mm_hashmap_t *hm,
 }
 
 int mm_hashmap_lock_key(mm_hashmap_t *hm, mm_hashmap_keylock_t *klock,
-			const void *key, int create)
+			const void *key, int flags)
 {
 	memset(klock, 0, sizeof(mm_hashmap_keylock_t));
 
@@ -319,7 +319,7 @@ int mm_hashmap_lock_key(mm_hashmap_t *hm, mm_hashmap_keylock_t *klock,
 
 	mm_mutex_unlock(mu);
 
-	if (!create) {
+	if (!(flags & MM_HASHMAP_CREATE)) {
 		klock->found = 0;
 		klock->kvp = NULL;
 		return 0;

--- a/sources/pstmt.c
+++ b/sources/pstmt.c
@@ -18,6 +18,9 @@
 #include <server.h>
 #include <pstmt.h>
 
+/* XXX: randomize seed ? */
+static const uint64_t hash_seed = 0;
+
 /*
  * client hash map
  * "P_0" -> *od_prepared_stmt_t
@@ -27,7 +30,7 @@ static mm_hash_t xxh_str_ptr(const void *data)
 {
 	const char *ptr = *(const char **)data;
 
-	return mm_xxh64_hash(ptr, strlen(ptr), 0);
+	return mm_xxh64_hash(ptr, strlen(ptr), hash_seed);
 }
 
 static int str_ptr_cmp(const void *k1, const void *k2)
@@ -61,15 +64,30 @@ mm_hashmap_t *od_client_pstmt_hashmap_create(void)
 {
 	return mm_hashmap_create(
 		50 /* XXX: big enough? */,
-		1 /* nlocks = 1, no fully-concurrent access to server hashmap */,
-		sizeof(char *), sizeof(od_pstmt_t *), str_ptr_cmp, xxh_str_ptr,
-		str_ptr_dtor,
+		1 /* nlocks = 1, no fully-concurrent access to client hashmap */,
+		sizeof(char *) /* key size */,
+		sizeof(od_pstmt_t *) /* val size */, str_ptr_cmp /* key cmp */,
+		xxh_str_ptr /* key hash */, str_ptr_dtor /* key dtor */,
 		NULL /* no need to free the pointer from global table */,
-		str_ptr_copy);
+		str_ptr_copy /* key copy */);
+}
+
+static int unref_pstmt_entry(mm_hashmap_t *hm, mm_hashmap_kvp_t *kvp,
+			     void **argv)
+{
+	(void)argv;
+
+	od_pstmt_t *pstmt = *(od_pstmt_t **)mm_hashmap_kvp_val(hm, kvp);
+
+	od_pstmt_unref(pstmt);
+
+	return 0;
 }
 
 void od_client_pstmt_hashmap_free(mm_hashmap_t *hm)
 {
+	mm_hashmap_foreach(hm, unref_pstmt_entry, NULL);
+
 	mm_hashmap_free(hm);
 }
 
@@ -93,11 +111,14 @@ od_pstmt_t *od_client_get_pstmt(od_client_t *client, const char *name)
 }
 
 int od_client_add_pstmt(od_client_t *client, const char *name,
-			const od_pstmt_t *pstmt)
+			od_pstmt_t *pstmt)
 {
 	mm_hashmap_keylock_t klock;
+	od_pstmt_t *to_unref = NULL;
+	const int unnamed = name[0] == '\0';
+
 	int rc = mm_hashmap_lock_key(client->prep_stmt_ids, &klock, &name,
-				     1 /* do create */);
+				     MM_HASHMAP_CREATE /* do create */);
 	if (rc == -1) {
 		/* cant create and lock is not held */
 		return rc;
@@ -105,27 +126,35 @@ int od_client_add_pstmt(od_client_t *client, const char *name,
 
 	int ret = 0;
 
-	if (!klock.found || name[0] == '\0') {
+	void *val = mm_hashmap_kvp_val(client->prep_stmt_ids, klock.kvp);
+	if (unnamed && (*(void **)val) != NULL) {
 		/*
-		 * new element - set the value
-		 *
-		 * if already exists - rewrite value only if name is ""
-		 * (its PG specific for "" statemnt - unnamed statemnt is
-		 * rewritten every Parse, not generate ErrorResponse about
+		 * its ok to redefine "" statement
+		 * (unnamed statemnt is rewritten every Parse,
+		 * not generate ErrorResponse about
 		 * statement already exists)
+		 *
+		 * so need to not forget to unref previous pstmt
 		 */
-		void *val =
-			mm_hashmap_kvp_val(client->prep_stmt_ids, klock.kvp);
-		memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
+		to_unref = *(od_pstmt_t **)val;
+	}
 
+	if (!klock.found || unnamed) {
+		/* new or "" - save */
+		memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
+		od_pstmt_ref(pstmt);
 		ret = 0;
 	} else {
-		/* value already exists and name != "" */
+		/* already exists - skip */
 		ret = 1;
 	}
 
 	/* no real concurrent access - can unlock now and return */
 	mm_hashmap_unlock_key(client->prep_stmt_ids, &klock);
+
+	if (to_unref != NULL) {
+		od_pstmt_unref(to_unref);
+	}
 
 	return ret;
 }
@@ -143,7 +172,12 @@ int od_client_remove_pstmt(od_client_t *client, const char *name)
 	(void)rc;
 
 	if (klock.kvp != NULL) {
+		od_pstmt_t *pstmt = *(od_pstmt_t **)mm_hashmap_kvp_val(
+			client->prep_stmt_ids, klock.kvp);
 		mm_hashmap_remove(client->prep_stmt_ids, &klock);
+		if (pstmt != NULL) {
+			od_pstmt_unref(pstmt);
+		}
 	}
 
 	/* if not found - lock is not held */
@@ -153,12 +187,14 @@ int od_client_remove_pstmt(od_client_t *client, const char *name)
 
 void od_client_pstmts_clear(od_client_t *client)
 {
+	mm_hashmap_foreach(client->prep_stmt_ids, unref_pstmt_entry, NULL);
+
 	mm_hashmap_clear(client->prep_stmt_ids);
 }
 
 /*
  * client portal hash map
- * "portal_name" -> *od_pstmt_t
+ * "portal_name" -> od_pstmt_t*
  *
  * portals are created by Bind (destination portal name) and destroyed by
  * Close Portal, transaction end, or DISCARD ALL / DEALLOCATE ALL.
@@ -172,14 +208,19 @@ mm_hashmap_t *od_client_portal_hashmap_create(void)
 {
 	return mm_hashmap_create(
 		50 /* XXX: big enough? */,
-		1 /* nlocks = 1, no fully-concurrent access */, sizeof(char *),
-		sizeof(od_pstmt_t *), str_ptr_cmp, xxh_str_ptr, str_ptr_dtor,
+		1 /* nlocks = 1, no fully-concurrent access */,
+		sizeof(char *) /* key size */,
+		sizeof(od_pstmt_t *) /* value size */,
+		str_ptr_cmp /* key cmp */, xxh_str_ptr /* key hash */,
+		str_ptr_dtor /* key dtor */,
 		NULL /* no need to free the pointer from global table */,
-		str_ptr_copy);
+		str_ptr_copy /* key copy */);
 }
 
 void od_client_portal_hashmap_free(mm_hashmap_t *hm)
 {
+	mm_hashmap_foreach(hm, unref_pstmt_entry, NULL);
+
 	mm_hashmap_free(hm);
 }
 
@@ -201,24 +242,32 @@ od_pstmt_t *od_client_get_portal(od_client_t *client, const char *portal_name)
 }
 
 int od_client_add_portal(od_client_t *client, const char *portal_name,
-			 const od_pstmt_t *pstmt)
+			 od_pstmt_t *pstmt)
 {
 	mm_hashmap_keylock_t klock;
+	od_pstmt_t *to_unref = NULL;
+
 	int rc = mm_hashmap_lock_key(client->portals, &klock, &portal_name,
-				     1 /* do create */);
+				     MM_HASHMAP_CREATE /* do create */);
 	if (rc == -1) {
 		return rc;
 	}
 
 	/*
-	 * upsert: the unnamed portal "" is silently overwritten on every Bind.
+	 * note: unnamed portal "" is silently overwritten on every Bind.
 	 * for named portals PG requires an explicit Close before re-Bind, but
-	 * the server enforces that -- we just store the mapping here.
+	 * the server will enforce that - we just store the mapping here
 	 */
-	void *val = mm_hashmap_kvp_val(client->portals, klock.kvp);
-	memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
 
+	void *val = mm_hashmap_kvp_val(client->portals, klock.kvp);
+	to_unref = *(od_pstmt_t **)(val);
+	memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
+	od_pstmt_ref(pstmt);
 	mm_hashmap_unlock_key(client->portals, &klock);
+
+	if (to_unref != NULL) {
+		od_pstmt_unref(to_unref);
+	}
 
 	return 0;
 }
@@ -231,7 +280,14 @@ int od_client_remove_portal(od_client_t *client, const char *portal_name)
 	(void)rc;
 
 	if (klock.kvp != NULL) {
+		od_pstmt_t *pstmt = *(od_pstmt_t **)mm_hashmap_kvp_val(
+			client->portals, klock.kvp);
+
 		mm_hashmap_remove(client->portals, &klock);
+
+		if (pstmt != NULL) {
+			od_pstmt_unref(pstmt);
+		}
 	}
 
 	return 0;
@@ -239,6 +295,8 @@ int od_client_remove_portal(od_client_t *client, const char *portal_name)
 
 void od_client_portals_clear(od_client_t *client)
 {
+	mm_hashmap_foreach(client->portals, unref_pstmt_entry, NULL);
+
 	mm_hashmap_clear(client->portals);
 }
 
@@ -251,7 +309,7 @@ static mm_hash_t xxh_str_inplace(const void *data)
 {
 	const char *key = data;
 
-	return mm_xxh64_hash(data, strlen(key), 0);
+	return mm_xxh64_hash(data, strlen(key), hash_seed);
 }
 
 static int str_inplace_cmp(const void *k1, const void *k2)
@@ -267,8 +325,10 @@ mm_hashmap_t *od_server_pstmt_hashmap_create(void)
 	return mm_hashmap_create(
 		100 /* XXX: big enough? */,
 		1 /* nlocks = 1, no fully-concurrent access to server hashmap */,
-		sizeof(od_pstmt_name_t), sizeof(od_pstmt_t *), str_inplace_cmp,
-		xxh_str_inplace, NULL /* no need to free on inplace str */,
+		sizeof(od_pstmt_name_t) /* key size */,
+		sizeof(od_pstmt_t *) /* value size */,
+		str_inplace_cmp /* key cmp */, xxh_str_inplace /* key hash */,
+		NULL /* no need to free on inplace str */,
 		NULL /* no need to free the pointer from global table */,
 		NULL /* no key copy function */
 	);
@@ -276,6 +336,8 @@ mm_hashmap_t *od_server_pstmt_hashmap_create(void)
 
 void od_server_pstmt_hashmap_free(mm_hashmap_t *hm)
 {
+	mm_hashmap_foreach(hm, unref_pstmt_entry, NULL);
+
 	mm_hashmap_free(hm);
 }
 
@@ -296,15 +358,21 @@ int od_server_has_pstmt(od_server_t *server, const od_pstmt_t *pstmt)
 	return 0;
 }
 
-int od_server_add_pstmt(od_server_t *server, const od_pstmt_t *pstmt)
+int od_server_add_pstmt(od_server_t *server, od_pstmt_t *pstmt)
 {
 	mm_hashmap_keylock_t klock;
 	int rc = mm_hashmap_lock_key(server->prep_stmts, &klock, pstmt->name,
-				     1 /* do create */);
+				     MM_HASHMAP_CREATE /* do create */);
 	if (rc == -1) {
 		/* cant create and lock is not held */
 		return rc;
 	}
+
+	/*
+	 * note: server's pstmt has generated name like odyssey_pstmt_1337
+	 * so there is no unnamed statements at all and no possibility for unref
+	 * because no pstmts can be upserted
+	 */
 
 	int ret = 0;
 
@@ -312,7 +380,7 @@ int od_server_add_pstmt(od_server_t *server, const od_pstmt_t *pstmt)
 		/* new element - set the value */
 		void *val = mm_hashmap_kvp_val(server->prep_stmts, klock.kvp);
 		memcpy(val, &pstmt, sizeof(const od_pstmt_t *));
-
+		od_pstmt_ref(pstmt);
 		ret = 0;
 	} else {
 		ret = 1;
@@ -332,7 +400,12 @@ int od_server_remove_pstmt(od_server_t *server, const od_pstmt_t *pstmt)
 	(void)rc;
 
 	if (klock.found) {
+		od_pstmt_t *p = *(od_pstmt_t **)mm_hashmap_kvp_val(
+			server->prep_stmts, klock.kvp);
 		mm_hashmap_remove(server->prep_stmts, &klock);
+		if (p != NULL) {
+			od_pstmt_unref(p);
+		}
 	}
 
 	/* if not found - lock is not held */
@@ -342,19 +415,24 @@ int od_server_remove_pstmt(od_server_t *server, const od_pstmt_t *pstmt)
 
 void od_server_pstmts_clear(od_server_t *server)
 {
+	mm_hashmap_foreach(server->prep_stmts, unref_pstmt_entry, NULL);
+
 	mm_hashmap_clear(server->prep_stmts);
 }
 
 /*
  * global map
- * od_pstmt_desc_t -> od_pstmt_t
+ *
+ * key:   od_pstmt_desc_t (inline, non-owning — desc.data points into
+ *        the value's desc.data, so the key is a "view" of the value)
+ * value: od_pstmt_t (inline, owns its own copy of desc.data)
  */
 
 static mm_hash_t xxh_pstmt_desc(const void *data)
 {
 	const od_pstmt_desc_t *desc = data;
 
-	return mm_xxh64_hash(desc->data, desc->len, 0);
+	return mm_xxh64_hash(desc->data, desc->len, hash_seed);
 }
 
 static int pstmt_desc_cmp(const void *k1, const void *k2)
@@ -369,67 +447,164 @@ static int pstmt_desc_cmp(const void *k1, const void *k2)
 	return memcmp(d1->data, d2->data, d1->len);
 }
 
-static void pstmt_desc_free(void *k)
+static void pstmt_desc_val_dtor(void *val)
 {
-	od_pstmt_desc_t *desc = k;
-	od_free(desc->data);
+	od_pstmt_t *pstmt = val;
+	od_assert(atomic_load_explicit(&pstmt->refs, memory_order_acquire) ==
+		  1);
+	od_free(pstmt->desc.data);
 }
 
-static int pstmt_desc_copy_cb(void *dest, const void *src)
+static void pstmt_init_new(od_global_pstmt_map_t *hm, od_pstmt_t *out)
 {
-	const od_pstmt_desc_t *orig = src;
-	od_pstmt_desc_t copy = od_pstmt_desc_copy(*orig);
-	if (copy.data == NULL) {
-		return 1;
+	uint64_t num = atomic_fetch_add_explicit(&hm->counter, 1,
+						 memory_order_relaxed);
+	od_release_assert(num <= OD_MAX_PSTMT_NUM);
+
+	atomic_init(&out->refs, 1);
+	out->source = hm;
+
+	od_snprintf(out->name, sizeof(od_pstmt_name_t), "%s%" PRIu64,
+		    OD_PSTMT_NAME_PREFIX, num);
+}
+
+od_global_pstmt_map_t *od_global_pstmts_map_create(size_t nlocks)
+{
+	mm_hashmap_t *hm = mm_hashmap_create(
+		10000 /* XXX: big enough? */, nlocks,
+		sizeof(od_pstmt_desc_t) /* key size */,
+		sizeof(od_pstmt_t) /* value size */,
+		pstmt_desc_cmp /* key comparator */,
+		xxh_pstmt_desc /* key hash */,
+		NULL /* key does not own desc.data */,
+		pstmt_desc_val_dtor /* value owns desc.data */,
+		NULL /* no key copy — raw memcpy, data ptr overwritten after insert */
+	);
+
+	if (hm == NULL) {
+		return NULL;
 	}
 
-	memcpy(dest, &copy, sizeof(od_pstmt_desc_t));
+	od_global_pstmt_map_t *gm = od_malloc(sizeof(od_global_pstmt_map_t));
+	if (gm == NULL) {
+		mm_hashmap_free(hm);
+		return NULL;
+	}
 
-	return 0;
+	gm->hm = hm;
+	atomic_init(&gm->counter, 0);
+
+	return gm;
 }
 
-mm_hashmap_t *od_global_pstmts_map_create(void)
+void od_global_pstmts_map_free(od_global_pstmt_map_t *hm)
 {
-	return mm_hashmap_create(1000 /* XXX: big enough? */,
-				 1000 /* XXX: big enough? */,
-				 sizeof(od_pstmt_desc_t), sizeof(od_pstmt_t),
-				 pstmt_desc_cmp, xxh_pstmt_desc,
-				 pstmt_desc_free, NULL, pstmt_desc_copy_cb);
+	mm_hashmap_free(hm->hm);
+	od_free(hm);
 }
 
-void od_global_pstmts_map_free(mm_hashmap_t *hm)
-{
-	mm_hashmap_free(hm);
-}
-
-od_pstmt_t *od_pstmt_create_or_get(mm_hashmap_t *pstmts,
+od_pstmt_t *od_pstmt_create_or_get(od_global_pstmt_map_t *pstmts,
 				   const od_pstmt_desc_t desc)
 {
 	mm_hashmap_keylock_t klock;
-	int rc = mm_hashmap_lock_key(pstmts, &klock, &desc,
-				     1 /* create if not exists */);
+	int rc;
+	od_pstmt_desc_t *key;
+	od_pstmt_t *value;
+
+	/*
+	 * lock_key will creates a key that is binary-copy of desc
+	 *
+	 * need to remember: it does not owns desc.data
+	 */
+	rc = mm_hashmap_lock_key(pstmts->hm, &klock, &desc,
+				 MM_HASHMAP_CREATE /* create if not exists */);
 	if (rc == -1) {
 		return NULL;
 	}
 
-	void *value = mm_hashmap_kvp_val(pstmts, klock.kvp);
+	value = (od_pstmt_t *)mm_hashmap_kvp_val(pstmts->hm, klock.kvp);
+	key = (od_pstmt_desc_t *)mm_hashmap_kvp_key(pstmts->hm, klock.kvp);
 
 	if (!klock.found) {
 		/* init new prep stmt */
-		od_pstmt_t pstmt;
-		memset(&pstmt, 0, sizeof(od_pstmt_t));
-		od_pstmt_next_name(&pstmt);
+		memset(value, 0, sizeof(od_pstmt_t));
+		pstmt_init_new(pstmts, value);
 
-		/* let the value points to key */
-		pstmt.desc = *((od_pstmt_desc_t *)mm_hashmap_kvp_key(
-			pstmts, klock.kvp));
+		value->desc = od_pstmt_desc_copy(desc);
+		if (value->desc.data == NULL) {
+			mm_hashmap_remove(pstmts->hm, &klock);
+			return NULL;
+		}
 
-		memcpy(value, &pstmt, sizeof(od_pstmt_t));
+		/*
+		 * rewrite the key's data pointer to point into the value
+		 * so the key becomes a non-owning view of the value, instead of
+		 * memcpy of find key (desc)
+		 */
+		key->data = value->desc.data;
+	} else {
+		/* the key already exists and has a copy of desc.data, do nothing */
 	}
 
-	mm_hashmap_unlock_key(pstmts, &klock);
+	/* the call-side now holds the ref too */
+	od_pstmt_ref(value);
+
+	mm_hashmap_unlock_key(pstmts->hm, &klock);
 
 	return value;
+}
+
+void od_global_pstmt_try_remove(od_global_pstmt_map_t *gm, od_pstmt_t *pstmt)
+{
+	mm_hashmap_keylock_t klock;
+	int rc;
+	uint64_t refs;
+
+	rc = mm_hashmap_lock_key(gm->hm, &klock, &pstmt->desc,
+				 0 /* no create */);
+	if (rc == -1) {
+		return;
+	}
+
+	/*
+	 * every pstmt must be created from global hashmap,
+	 * so no need to check the klock.kvp != NULL
+	 */
+	od_assert(klock.kvp != NULL);
+	od_assert((od_pstmt_t *)mm_hashmap_kvp_val(gm->hm, klock.kvp) == pstmt);
+
+	/*
+	 * note: ref can be done only with the lock held (create_or_get)
+	 * or from the ref, that is already valid, so no race here
+	 */
+	refs = atomic_load_explicit(&pstmt->refs, memory_order_acquire);
+	if (refs > 1) {
+		mm_hashmap_unlock_key(gm->hm, &klock);
+	} else {
+		mm_hashmap_remove(gm->hm, &klock);
+	}
+}
+
+int od_global_pstmts_has_pstmt(od_global_pstmt_map_t *gm,
+			       const od_pstmt_desc_t desc)
+{
+	mm_hashmap_keylock_t klock;
+	int rc;
+
+	rc = mm_hashmap_lock_key(gm->hm, &klock, &desc, 0 /* do not create */);
+	if (rc == -1) {
+		return 0;
+	}
+
+	if (klock.found) {
+		/* yes, not so thread-safe check, but this function is only used in tests */
+		mm_hashmap_unlock_key(gm->hm, &klock);
+		return 1;
+	}
+
+	/* no lock held */
+
+	return 0;
 }
 
 /* helpers */
@@ -501,14 +676,4 @@ od_pstmt_desc_t od_pstmt_desc_copy(const od_pstmt_desc_t desc)
 	}
 
 	return copy;
-}
-
-void od_pstmt_next_name(od_pstmt_t *out)
-{
-	static atomic_uint_fast64_t cnt = 0;
-
-	uint64_t num = atomic_fetch_add(&cnt, 1);
-
-	od_snprintf(out->name, sizeof(od_pstmt_name_t), "%s%" PRIu64,
-		    OD_PSTMT_NAME_PREFIX, num);
 }

--- a/sources/system.c
+++ b/sources/system.c
@@ -632,7 +632,8 @@ static inline void od_system(void *arg)
 	od_instance_t *instance = system->global->instance;
 	od_router_t *router = system->global->router;
 
-	instance->pstmts = od_global_pstmts_map_create();
+	instance->pstmts = od_global_pstmts_map_create(
+		4 * (size_t)instance->config.workers);
 	if (instance->pstmts == NULL) {
 		od_error(&instance->logger, "system", NULL, NULL,
 			 "failed to create pstmts map, errno = %d (%s)",

--- a/sources/tests/odyssey/test_pstmt.c
+++ b/sources/tests/odyssey/test_pstmt.c
@@ -7,183 +7,38 @@
 
 #include <pstmt.h>
 
-void test_pstmt_client_hashmap(void)
+static void test_refs(void)
 {
-	od_client_t *client = od_client_allocate();
-	client->prep_stmt_ids = od_client_pstmt_hashmap_create();
-	test(client->prep_stmt_ids != NULL);
+	od_global_pstmt_map_t *global = od_global_pstmts_map_create(1);
+	test(global != NULL);
 
-	od_pstmt_t pstmt;
-	memset(&pstmt, 0, sizeof(pstmt));
+	od_pstmt_desc_t desc;
+	desc.data = "data1";
+	desc.len = sizeof("data1");
+	od_pstmt_t *ps = od_pstmt_create_or_get(global, desc);
+	test(ps != NULL);
 
-	od_pstmt_t pstmt2;
-	memset(&pstmt2, 0, sizeof(pstmt2));
+	od_pstmt_unref(ps);
+	test(od_global_pstmts_has_pstmt(global, desc) == 0);
 
-	/* works correctly with unnamed */
-	test(od_client_has_pstmt(client, "") == 0);
-	test(od_client_get_pstmt(client, "") == NULL);
+	ps = od_pstmt_create_or_get(global, desc);
+	test(ps != NULL);
 
-	test(od_client_add_pstmt(client, "", &pstmt) == 0);
-	test(od_client_has_pstmt(client, "") == 1);
-	test(od_client_get_pstmt(client, "") == &pstmt);
+	od_pstmt_t *p2 = ps;
+	od_pstmt_ref(ps);
 
-	/* allows to redefine unnamed statement */
-	test(od_client_add_pstmt(client, "", &pstmt2) == 0);
-	test(od_client_has_pstmt(client, "") == 1);
-	test(od_client_get_pstmt(client, "") == &pstmt2);
+	od_pstmt_unref(ps);
+	test(od_global_pstmts_has_pstmt(global, desc) == 1);
 
-	test(od_client_remove_pstmt(client, "") == 0);
-	test(od_client_has_pstmt(client, "") == 0);
-	test(od_client_get_pstmt(client, "") == NULL);
+	od_pstmt_unref(p2);
+	test(od_global_pstmts_has_pstmt(global, desc) == 0);
 
-	test(od_client_has_pstmt(client, "P_0") == 0);
-	test(od_client_get_pstmt(client, "P_0") == NULL);
-
-	test(od_client_has_pstmt(client, "P_0") == 0);
-	test(od_client_get_pstmt(client, "P_0") == NULL);
-
-	test(od_client_add_pstmt(client, "P_0", &pstmt) == 0);
-	test(od_client_has_pstmt(client, "P_0") == 1);
-	test(od_client_get_pstmt(client, "P_0") == &pstmt);
-	/* do not add twice */
-	test(od_client_add_pstmt(client, "P_0", &pstmt) == 1);
-	test(od_client_has_pstmt(client, "P_0") == 1);
-	test(od_client_get_pstmt(client, "P_0") == &pstmt);
-
-	test(od_client_remove_pstmt(client, "P_1") == 0);
-	test(od_client_has_pstmt(client, "P_1") == 0);
-	test(od_client_get_pstmt(client, "P_1") == NULL);
-
-	test(od_client_add_pstmt(client, "P_1", &pstmt2) == 0);
-	test(od_client_has_pstmt(client, "P_1") == 1);
-	test(od_client_get_pstmt(client, "P_1") == &pstmt2);
-
-	test(od_client_remove_pstmt(client, "P_0") == 0);
-	test(od_client_has_pstmt(client, "P_1") == 1);
-	test(od_client_get_pstmt(client, "P_1") == &pstmt2);
-	test(od_client_has_pstmt(client, "P_0") == 0);
-	test(od_client_get_pstmt(client, "P_0") == NULL);
-
-	od_client_pstmts_clear(client);
-	test(od_client_has_pstmt(client, "P_1") == 0);
-	test(od_client_get_pstmt(client, "P_1") == NULL);
-
-	test(od_client_add_pstmt(client, "dangling", &pstmt) == 0);
-	test(od_client_has_pstmt(client, "dangling") == 1);
-	test(od_client_get_pstmt(client, "dangling") == &pstmt);
-
-	od_client_free(client);
-}
-
-static void test_portal_client_hashmap(void)
-{
-	od_client_t *client = od_client_allocate();
-	client->portals = od_client_portal_hashmap_create();
-	test(client->portals != NULL);
-
-	od_pstmt_t pstmt;
-	memset(&pstmt, 0, sizeof(pstmt));
-
-	od_pstmt_t pstmt2;
-	memset(&pstmt2, 0, sizeof(pstmt2));
-
-	/* unnamed portal works */
-	test(od_client_get_portal(client, "") == NULL);
-	test(od_client_add_portal(client, "", &pstmt) == 0);
-	test(od_client_get_portal(client, "") == &pstmt);
-
-	/* portals are always upserted (we are trying our best of tracking) */
-	test(od_client_add_portal(client, "", &pstmt2) == 0);
-	test(od_client_get_portal(client, "") == &pstmt2);
-
-	test(od_client_remove_portal(client, "") == 0);
-	test(od_client_get_portal(client, "") == NULL);
-
-	/* named portals */
-	test(od_client_get_portal(client, "portal_0") == NULL);
-
-	test(od_client_add_portal(client, "portal_0", &pstmt) == 0);
-	test(od_client_get_portal(client, "portal_0") == &pstmt);
-
-	/* re-binding the same portal replaces the pstmt */
-	test(od_client_add_portal(client, "portal_0", &pstmt2) == 0);
-	test(od_client_get_portal(client, "portal_0") == &pstmt2);
-
-	test(od_client_add_portal(client, "portal_1", &pstmt) == 0);
-	test(od_client_get_portal(client, "portal_1") == &pstmt);
-
-	/* remove non-existent is a no-op */
-	test(od_client_remove_portal(client, "nope") == 0);
-	test(od_client_get_portal(client, "portal_0") == &pstmt2);
-	test(od_client_get_portal(client, "portal_1") == &pstmt);
-
-	test(od_client_remove_portal(client, "portal_0") == 0);
-	test(od_client_get_portal(client, "portal_0") == NULL);
-	test(od_client_get_portal(client, "portal_1") == &pstmt);
-
-	od_client_portals_clear(client);
-	test(od_client_get_portal(client, "portal_1") == NULL);
-
-	/* dangling entry survives until free */
-	test(od_client_add_portal(client, "dangling", &pstmt) == 0);
-	test(od_client_get_portal(client, "dangling") == &pstmt);
-
-	od_client_free(client);
-}
-
-static void test_pstmt_server_hashmap(void)
-{
-	od_server_t *server = od_server_allocate(1);
-
-	od_pstmt_t pstmt1;
-	od_pstmt_next_name(&pstmt1);
-	pstmt1.desc.data = "data1";
-	pstmt1.desc.len = sizeof("data1");
-
-	od_pstmt_t pstmt2;
-	od_pstmt_next_name(&pstmt2);
-	pstmt2.desc.data = "data2";
-	pstmt2.desc.len = sizeof("data2");
-
-	test(od_server_has_pstmt(server, &pstmt1) == 0);
-	test(od_server_has_pstmt(server, &pstmt2) == 0);
-
-	test(od_server_remove_pstmt(server, &pstmt1) == 0);
-	test(od_server_remove_pstmt(server, &pstmt2) == 0);
-
-	test(od_server_add_pstmt(server, &pstmt1) == 0);
-	test(od_server_has_pstmt(server, &pstmt1) == 1);
-	test(od_server_has_pstmt(server, &pstmt2) == 0);
-
-	test(od_server_add_pstmt(server, &pstmt2) == 0);
-	test(od_server_has_pstmt(server, &pstmt1) == 1);
-	test(od_server_has_pstmt(server, &pstmt2) == 1);
-
-	test(od_server_remove_pstmt(server, &pstmt2) == 0);
-	test(od_server_has_pstmt(server, &pstmt1) == 1);
-	test(od_server_has_pstmt(server, &pstmt2) == 0);
-
-	od_server_pstmts_clear(server);
-	test(od_server_has_pstmt(server, &pstmt1) == 0);
-	test(od_server_has_pstmt(server, &pstmt2) == 0);
-
-	od_pstmt_t dangling;
-	od_pstmt_next_name(&dangling);
-	dangling.desc.data = "dangling";
-	dangling.desc.len = sizeof("dangling");
-
-	od_pstmt_t danglingcopy;
-	memcpy(&danglingcopy, &dangling, sizeof(od_pstmt_t));
-	test(od_server_add_pstmt(server, &dangling) == 0);
-	test(od_server_has_pstmt(server, &dangling) == 1);
-	test(od_server_has_pstmt(server, &danglingcopy) == 1);
-
-	od_server_free(server);
+	od_global_pstmts_map_free(global);
 }
 
 static void test_pstmt_global(void)
 {
-	mm_hashmap_t *gm = od_global_pstmts_map_create();
+	od_global_pstmt_map_t *gm = od_global_pstmts_map_create(1);
 
 	od_pstmt_desc_t desc;
 	desc.data = "data";
@@ -194,20 +49,348 @@ static void test_pstmt_global(void)
 	test(desc.len == pstmt->desc.len);
 	test(memcmp(desc.data, pstmt->desc.data, pstmt->desc.len) == 0);
 	test(&pstmt->desc != &desc);
+	test(pstmt->desc.data != desc.data);
 
-	test(od_pstmt_create_or_get(gm, desc) == pstmt);
+	od_pstmt_t *t = od_pstmt_create_or_get(gm, desc);
+	test(t == pstmt);
+	od_pstmt_unref(t);
+
+	od_pstmt_t *pstmt2 = od_pstmt_create_or_get(gm, desc);
+	test(pstmt2 == pstmt);
+	test(pstmt2->desc.data == pstmt->desc.data);
+
+	od_pstmt_desc_t desc_copy;
+	desc_copy.data = od_strdup("data");
+	test(desc.data != NULL);
+	desc_copy.len = sizeof("data");
+	od_pstmt_t *pstmt3 = od_pstmt_create_or_get(gm, desc_copy);
+	test(pstmt3 == pstmt2);
+	test(pstmt3 == pstmt);
+
+	od_pstmt_unref(pstmt);
+	od_pstmt_unref(pstmt2);
+	od_pstmt_unref(pstmt3);
+
+	od_free(desc_copy.data);
+
+	test(od_global_pstmts_has_pstmt(gm, desc) == 0);
 
 	od_global_pstmts_map_free(gm);
+}
+
+void test_pstmt_client_hashmap(void)
+{
+	od_global_pstmt_map_t *global = od_global_pstmts_map_create(1);
+	test(global != NULL);
+
+	od_client_t *client = od_client_allocate();
+	client->prep_stmt_ids = od_client_pstmt_hashmap_create();
+	test(client->prep_stmt_ids != NULL);
+
+	od_pstmt_desc_t desc1;
+	desc1.data = "data";
+	desc1.len = sizeof("data");
+
+	od_pstmt_desc_t desc2;
+	desc2.data = "data2";
+	desc2.len = sizeof("data2");
+
+	od_pstmt_desc_t desc3;
+	desc3.data = "data3";
+	desc3.len = sizeof("data3");
+
+	od_pstmt_desc_t desc4;
+	desc4.data = "data4";
+	desc4.len = sizeof("data4");
+
+	od_pstmt_desc_t desc5;
+	desc5.data = "data5";
+	desc5.len = sizeof("data5");
+
+	od_pstmt_t *unnamed1 = od_pstmt_create_or_get(global, desc1);
+	test(unnamed1 != NULL);
+
+	od_pstmt_t *unnamed2 = od_pstmt_create_or_get(global, desc2);
+	test(unnamed2 != NULL);
+
+	od_pstmt_t *p0 = od_pstmt_create_or_get(global, desc3);
+	test(p0 != NULL);
+
+	od_pstmt_t *p1 = od_pstmt_create_or_get(global, desc4);
+	test(p1 != NULL);
+
+	od_pstmt_t *dangling = od_pstmt_create_or_get(global, desc5);
+	test(dangling != NULL);
+
+	test(unnamed1 != unnamed2);
+	test(unnamed1 != p0);
+	test(unnamed1 != p1);
+	test(unnamed1 != dangling);
+	test(unnamed2 != p0);
+	test(unnamed2 != p1);
+	test(unnamed2 != dangling);
+	test(p0 != p1);
+	test(p0 != dangling);
+	test(p1 != dangling);
+
+	/* works correctly with unnamed */
+	test(od_client_has_pstmt(client, "") == 0);
+	test(od_client_get_pstmt(client, "") == NULL);
+
+	test(od_client_add_pstmt(client, "", unnamed1) == 0);
+	test(od_client_has_pstmt(client, "") == 1);
+	test(od_client_get_pstmt(client, "") == unnamed1);
+
+	od_pstmt_unref(unnamed1);
+
+	/* allows to redefine unnamed statement */
+	test(od_client_add_pstmt(client, "", unnamed2) == 0);
+	test(od_client_has_pstmt(client, "") == 1);
+	test(od_client_get_pstmt(client, "") == unnamed2);
+
+	od_pstmt_unref(unnamed2);
+
+	test(od_client_remove_pstmt(client, "") == 0);
+	test(od_client_has_pstmt(client, "") == 0);
+	test(od_client_get_pstmt(client, "") == NULL);
+
+	/* some named prepared statements */
+
+	test(od_client_has_pstmt(client, "P_0") == 0);
+	test(od_client_get_pstmt(client, "P_0") == NULL);
+
+	test(od_client_has_pstmt(client, "P_0") == 0);
+	test(od_client_get_pstmt(client, "P_0") == NULL);
+
+	test(od_client_add_pstmt(client, "P_0", p0) == 0);
+	test(od_client_has_pstmt(client, "P_0") == 1);
+	test(od_client_get_pstmt(client, "P_0") == p0);
+
+	/* do not add twice */
+	test(od_client_add_pstmt(client, "P_0", p0) == 1);
+	test(od_client_has_pstmt(client, "P_0") == 1);
+	test(od_client_get_pstmt(client, "P_0") == p0);
+
+	test(od_client_remove_pstmt(client, "P_1") == 0);
+	test(od_client_has_pstmt(client, "P_1") == 0);
+	test(od_client_get_pstmt(client, "P_1") == NULL);
+
+	test(od_client_add_pstmt(client, "P_1", p1) == 0);
+	test(od_client_has_pstmt(client, "P_1") == 1);
+	test(od_client_get_pstmt(client, "P_1") == p1);
+
+	test(od_client_remove_pstmt(client, "P_0") == 0);
+
+	test(od_client_has_pstmt(client, "P_1") == 1);
+	test(od_client_get_pstmt(client, "P_1") == p1);
+	test(od_client_has_pstmt(client, "P_0") == 0);
+	test(od_client_get_pstmt(client, "P_0") == NULL);
+
+	od_pstmt_unref(p0);
+	od_pstmt_unref(p1);
+
+	od_client_pstmts_clear(client);
+
+	test(od_client_has_pstmt(client, "P_1") == 0);
+	test(od_client_get_pstmt(client, "P_1") == NULL);
+
+	test(od_client_add_pstmt(client, "dangling", dangling) == 0);
+	test(od_client_has_pstmt(client, "dangling") == 1);
+	test(od_client_get_pstmt(client, "dangling") == dangling);
+
+	od_pstmt_unref(dangling);
+
+	od_client_free(client);
+
+	od_global_pstmts_map_free(global);
+}
+
+static void test_portal_client_hashmap(void)
+{
+	od_global_pstmt_map_t *global = od_global_pstmts_map_create(1);
+	test(global != NULL);
+
+	od_client_t *client = od_client_allocate();
+	client->portals = od_client_portal_hashmap_create();
+	test(client->portals != NULL);
+
+	od_pstmt_desc_t desc1;
+	desc1.data = "data";
+	desc1.len = sizeof("data");
+
+	od_pstmt_desc_t desc2;
+	desc2.data = "data2";
+	desc2.len = sizeof("data2");
+
+	od_pstmt_desc_t desc3;
+	desc3.data = "data3";
+	desc3.len = sizeof("data3");
+
+	od_pstmt_desc_t desc4;
+	desc4.data = "data4";
+	desc4.len = sizeof("data4");
+
+	od_pstmt_desc_t desc5;
+	desc5.data = "data5";
+	desc5.len = sizeof("data5");
+
+	od_pstmt_t *unnamed1 = od_pstmt_create_or_get(global, desc1);
+	test(unnamed1 != NULL);
+
+	od_pstmt_t *unnamed2 = od_pstmt_create_or_get(global, desc2);
+	test(unnamed2 != NULL);
+
+	od_pstmt_t *p0 = od_pstmt_create_or_get(global, desc3);
+	test(p0 != NULL);
+
+	od_pstmt_t *p1 = od_pstmt_create_or_get(global, desc4);
+	test(p1 != NULL);
+
+	od_pstmt_t *dangling = od_pstmt_create_or_get(global, desc5);
+	test(dangling != NULL);
+
+	test(unnamed1 != unnamed2);
+	test(unnamed1 != p0);
+	test(unnamed1 != p1);
+	test(unnamed1 != dangling);
+	test(unnamed2 != p0);
+	test(unnamed2 != p1);
+	test(unnamed2 != dangling);
+	test(p0 != p1);
+	test(p0 != dangling);
+	test(p1 != dangling);
+
+	/* unnamed portal works */
+	test(od_client_get_portal(client, "") == NULL);
+	test(od_client_add_portal(client, "", unnamed1) == 0);
+	test(od_client_get_portal(client, "") == unnamed1);
+	od_pstmt_unref(unnamed1);
+
+	/* portals are always upserted (we are trying our best of tracking) */
+	test(od_client_add_portal(client, "", unnamed2) == 0);
+	test(od_client_get_portal(client, "") == unnamed2);
+	od_pstmt_unref(unnamed2);
+
+	test(od_client_remove_portal(client, "") == 0);
+	test(od_client_get_portal(client, "") == NULL);
+
+	/* named portals */
+	test(od_client_get_portal(client, "portal_0") == NULL);
+
+	test(od_client_add_portal(client, "portal_0", p0) == 0);
+	test(od_client_get_portal(client, "portal_0") == p0);
+
+	/* re-binding the same portal replaces the pstmt */
+	test(od_client_add_portal(client, "portal_0", p1) == 0);
+	test(od_client_get_portal(client, "portal_0") == p1);
+
+	test(od_client_add_portal(client, "portal_1", p0) == 0);
+	test(od_client_get_portal(client, "portal_1") == p0);
+
+	/* remove non-existent is a no-op */
+	test(od_client_remove_portal(client, "nope") == 0);
+	test(od_client_get_portal(client, "portal_0") == p1);
+	test(od_client_get_portal(client, "portal_1") == p0);
+
+	test(od_client_remove_portal(client, "portal_0") == 0);
+	test(od_client_get_portal(client, "portal_0") == NULL);
+	test(od_client_get_portal(client, "portal_1") == p0);
+
+	od_client_portals_clear(client);
+
+	od_pstmt_unref(p0);
+	od_pstmt_unref(p1);
+
+	test(od_client_get_portal(client, "portal_1") == NULL);
+
+	/* dangling entry survives until free */
+	test(od_client_add_portal(client, "dangling", dangling) == 0);
+	test(od_client_get_portal(client, "dangling") == dangling);
+
+	od_pstmt_unref(dangling);
+
+	od_client_free(client);
+
+	od_global_pstmts_map_free(global);
+}
+
+static void test_pstmt_server_hashmap(void)
+{
+	od_global_pstmt_map_t *global = od_global_pstmts_map_create(1);
+	test(global != NULL);
+
+	od_server_t *server = od_server_allocate(1);
+
+	od_pstmt_desc_t desc3;
+	desc3.data = "data3";
+	desc3.len = sizeof("data3");
+
+	od_pstmt_desc_t desc4;
+	desc4.data = "data4";
+	desc4.len = sizeof("data4");
+
+	od_pstmt_desc_t desc5;
+	desc5.data = "data5";
+	desc5.len = sizeof("data5");
+
+	od_pstmt_t *p0 = od_pstmt_create_or_get(global, desc3);
+	test(p0 != NULL);
+
+	od_pstmt_t *p1 = od_pstmt_create_or_get(global, desc4);
+	test(p1 != NULL);
+
+	od_pstmt_t *dangling = od_pstmt_create_or_get(global, desc5);
+	test(dangling != NULL);
+
+	test(p0 != p1);
+	test(p0 != dangling);
+	test(p1 != dangling);
+
+	test(od_server_has_pstmt(server, p0) == 0);
+	test(od_server_has_pstmt(server, p1) == 0);
+
+	test(od_server_remove_pstmt(server, p0) == 0);
+	test(od_server_remove_pstmt(server, p1) == 0);
+
+	test(od_server_add_pstmt(server, p0) == 0);
+	test(od_server_has_pstmt(server, p0) == 1);
+	test(od_server_has_pstmt(server, p1) == 0);
+
+	test(od_server_add_pstmt(server, p1) == 0);
+	test(od_server_has_pstmt(server, p0) == 1);
+	test(od_server_has_pstmt(server, p1) == 1);
+
+	test(od_server_remove_pstmt(server, p1) == 0);
+	test(od_server_has_pstmt(server, p0) == 1);
+	test(od_server_has_pstmt(server, p1) == 0);
+
+	od_server_pstmts_clear(server);
+	test(od_server_has_pstmt(server, p0) == 0);
+	test(od_server_has_pstmt(server, p1) == 0);
+
+	od_pstmt_unref(p0);
+	od_pstmt_unref(p1);
+
+	test(od_server_add_pstmt(server, dangling) == 0);
+	test(od_server_has_pstmt(server, dangling) == 1);
+
+	od_pstmt_unref(dangling);
+
+	od_server_free(server);
+
+	od_global_pstmts_map_free(global);
 }
 
 static void test_impl(void *a)
 {
 	(void)a;
 
+	test_pstmt_global();
+	test_refs();
+
 	test_pstmt_client_hashmap();
 	test_portal_client_hashmap();
 	test_pstmt_server_hashmap();
-	test_pstmt_global();
 }
 
 void odyssey_test_pstmt(void)

--- a/sources/xplan.c
+++ b/sources/xplan.c
@@ -216,6 +216,10 @@ static void plan_entry_destroy(void *a)
 		od_free((void *)entry->delta.client_pstmt);
 	}
 
+	if (entry->delta.pstmt != NULL) {
+		od_pstmt_unref(entry->delta.pstmt);
+	}
+
 	memset(entry, 0, sizeof(od_xplan_entry_t));
 }
 
@@ -223,8 +227,7 @@ static void entry_init_internal(od_xplan_entry_t *e, od_xplan_entry_type_t type,
 				machine_msg_t *clmsg, machine_msg_t *srvmsg,
 				machine_msg_t *vresp,
 				od_xplan_delta_type_t delta_type,
-				const char *client_pstmt,
-				const od_pstmt_t *pstmt,
+				const char *client_pstmt, od_pstmt_t *pstmt,
 				const char *portal_name)
 {
 	memset(e, 0, sizeof(od_xplan_entry_t));
@@ -238,12 +241,16 @@ static void entry_init_internal(od_xplan_entry_t *e, od_xplan_entry_type_t type,
 	e->delta.client_pstmt = client_pstmt;
 	e->delta.pstmt = pstmt;
 	e->delta.portal_name = portal_name;
+
+	if (e->delta.pstmt != NULL) {
+		od_pstmt_ref(e->delta.pstmt);
+	}
 }
 
 static void entry_init_fwd(od_xplan_entry_t *e, machine_msg_t *original,
 			   machine_msg_t *rewritten,
 			   od_xplan_delta_type_t delta_type,
-			   const char *client_pstmt, const od_pstmt_t *pstmt)
+			   const char *client_pstmt, od_pstmt_t *pstmt)
 {
 	entry_init_internal(e, OD_XPLAN_FORWARD, original, rewritten, NULL,
 			    delta_type, client_pstmt, pstmt, NULL);
@@ -257,15 +264,14 @@ static void entry_init_fwd_no_delta(od_xplan_entry_t *e,
 }
 
 static void entry_init_parse(od_xplan_entry_t *e, const char *client_pstmt,
-			     const od_pstmt_t *pstmt, machine_msg_t *original,
+			     od_pstmt_t *pstmt, machine_msg_t *original,
 			     machine_msg_t *rewritten)
 {
 	entry_init_internal(e, OD_XPLAN_PARSE, original, rewritten, NULL,
 			    OD_XPLAN_DELTA_ADD_BOTH, client_pstmt, pstmt, NULL);
 }
 
-static void entry_init_parse_shadow(od_xplan_entry_t *e,
-				    const od_pstmt_t *pstmt,
+static void entry_init_parse_shadow(od_xplan_entry_t *e, od_pstmt_t *pstmt,
 				    machine_msg_t *original,
 				    machine_msg_t *inserted_parse)
 {
@@ -284,7 +290,7 @@ static void entry_init_virtual_error_response(od_xplan_entry_t *e,
 
 static void entry_init_virtual_parse_complete(od_xplan_entry_t *e,
 					      const char *client_pstmt,
-					      const od_pstmt_t *pstmt,
+					      od_pstmt_t *pstmt,
 					      machine_msg_t *original)
 {
 	entry_init_internal(e, OD_XPLAN_VIRTUAL_PARSE_COMPLETE, original, NULL,
@@ -316,8 +322,7 @@ static void entry_init_deferred_begin(od_xplan_entry_t *e, machine_msg_t *begin)
  */
 static void entry_init_fwd_portal(od_xplan_entry_t *e, machine_msg_t *original,
 				  machine_msg_t *rewritten,
-				  const char *portal_name,
-				  const od_pstmt_t *pstmt)
+				  const char *portal_name, od_pstmt_t *pstmt)
 {
 	entry_init_internal(e, OD_XPLAN_FORWARD, original, rewritten, NULL,
 			    OD_XPLAN_DELTA_ADD_PORTAL, NULL, pstmt,
@@ -356,7 +361,7 @@ static int xplan_append(od_xplan_t *xp, const od_xplan_entry_t *e)
 static inline od_frontend_status_t
 xplan_append_fwd(od_xplan_t *xp, machine_msg_t *original,
 		 machine_msg_t *rewritten, od_xplan_delta_type_t delta_type,
-		 const char *client_pstmt, const od_pstmt_t *pstmt)
+		 const char *client_pstmt, od_pstmt_t *pstmt)
 {
 	od_xplan_entry_t e;
 	entry_init_fwd(&e, original, rewritten, delta_type, client_pstmt,
@@ -385,11 +390,9 @@ xplan_append_fwd_no_delta(od_xplan_t *xp, machine_msg_t *original,
 	return OD_OK;
 }
 
-static inline od_frontend_status_t xplan_append_parse(od_xplan_t *xp,
-						      const char *client_pstmt,
-						      const od_pstmt_t *pstmt,
-						      machine_msg_t *original,
-						      machine_msg_t *rewritten)
+static inline od_frontend_status_t
+xplan_append_parse(od_xplan_t *xp, const char *client_pstmt, od_pstmt_t *pstmt,
+		   machine_msg_t *original, machine_msg_t *rewritten)
 {
 	od_xplan_entry_t e;
 	entry_init_parse(&e, client_pstmt, pstmt, original, rewritten);
@@ -403,7 +406,7 @@ static inline od_frontend_status_t xplan_append_parse(od_xplan_t *xp,
 }
 
 static inline od_frontend_status_t
-xplan_append_parse_shadow(od_xplan_t *xp, const od_pstmt_t *pstmt,
+xplan_append_parse_shadow(od_xplan_t *xp, od_pstmt_t *pstmt,
 			  machine_msg_t *original,
 			  machine_msg_t *inserted_parse)
 {
@@ -435,8 +438,7 @@ xplan_append_virtual_error_response(od_xplan_t *xp, machine_msg_t *original,
 
 static inline od_frontend_status_t
 xplan_append_virtual_parse_complete(od_xplan_t *xp, const char *client_pstmt,
-				    const od_pstmt_t *pstmt,
-				    machine_msg_t *original)
+				    od_pstmt_t *pstmt, machine_msg_t *original)
 {
 	od_xplan_entry_t e;
 	entry_init_virtual_parse_complete(&e, client_pstmt, pstmt, original);
@@ -481,7 +483,7 @@ xplan_append_deferred_begin(od_xplan_t *xp, machine_msg_t *begin)
 static inline od_frontend_status_t
 xplan_append_fwd_portal(od_xplan_t *xp, machine_msg_t *original,
 			machine_msg_t *rewritten, const char *portal_name,
-			const od_pstmt_t *pstmt)
+			od_pstmt_t *pstmt)
 {
 	od_xplan_entry_t e;
 	entry_init_fwd_portal(&e, original, rewritten, portal_name, pstmt);
@@ -532,14 +534,16 @@ void od_xplan_clear(od_xplan_t *xp)
 	mm_vector_clear(&xp->entries);
 }
 
-static const od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp,
-					       od_client_t *client,
-					       const char *pstmt_name)
+static od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp, od_client_t *client,
+					 const char *pstmt_name)
 {
 	/*
 	 * searching from newest state to oldest,
 	 * this means to search from tail to head of the plan deltas
 	 * and then on commited pstmts hashmap
+	 *
+	 * should not ref the returned pstmt because
+	 * it is already referenced by client or some plan entry
 	 */
 
 	for (int i = (int)mm_vector_size(&xp->entries) - 1; i >= 0; --i) {
@@ -590,14 +594,16 @@ static const od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp,
 	return od_client_get_pstmt(client, pstmt_name);
 }
 
-static const od_pstmt_t *plan_client_get_portal(od_xplan_t *xp,
-						od_client_t *client,
-						const char *portal_name)
+static od_pstmt_t *plan_client_get_portal(od_xplan_t *xp, od_client_t *client,
+					  const char *portal_name)
 {
 	/*
 	 * searching from newest state to oldest,
 	 * this means to search from tail to head of the plan deltas
 	 * and then on commited portals hashmap
+	 *
+	 * should not ref the returned pstmt because
+	 * it is already referenced by client or some plan entry
 	 */
 
 	for (int i = (int)mm_vector_size(&xp->entries) - 1; i >= 0; --i) {
@@ -696,7 +702,7 @@ static int plan_server_has_pstmt(od_xplan_t *xp, od_server_t *server,
 static inline od_frontend_status_t plan_predeploy_pstmt(od_xplan_t *xp,
 							od_server_t *server,
 							machine_msg_t *clmsg,
-							const od_pstmt_t *pstmt)
+							od_pstmt_t *pstmt)
 {
 	if (plan_server_has_pstmt(xp, server, pstmt)) {
 		return OD_OK;
@@ -716,6 +722,7 @@ static od_frontend_status_t plan_parse(od_relay_t *relay, od_xplan_t *xp,
 	od_client_t *client = relay->client;
 	od_server_t *server = client->server;
 	od_instance_t *instance = client->global->instance;
+	od_frontend_status_t st;
 
 	machine_msg_t *msg = m->msg;
 	char *pstmt_name = od_pstmt_name_from_parse(msg);
@@ -744,23 +751,36 @@ static od_frontend_status_t plan_parse(od_relay_t *relay, od_xplan_t *xp,
 		return xplan_append_virtual_error_response(xp, msg, vresp);
 	}
 
-	mm_hashmap_t *global_pstmts = od_instance_get_pstmts_map(instance);
+	od_global_pstmt_map_t *global_pstmts =
+		od_instance_get_pstmts_map(instance);
 	od_pstmt_t *pstmt = od_pstmt_create_or_get(global_pstmts, desc);
 	if (pstmt == NULL) {
 		return OD_EOOM;
 	}
+	/* we now hold the ref to pstmt */
 
 	if (plan_server_has_pstmt(xp, server, pstmt)) {
-		return xplan_append_virtual_parse_complete(xp, pstmt_name,
-							   pstmt, msg);
+		/*
+		 * note: xplan entry will hold the ref
+		 */
+		st = xplan_append_virtual_parse_complete(xp, pstmt_name, pstmt,
+							 msg);
+	} else {
+		machine_msg_t *pmsg = od_pstmt_parse_of(pstmt);
+		if (pmsg != NULL) {
+			/*
+			 * note: xplan entry will hold the ref
+			 */
+			st = xplan_append_parse(xp, pstmt_name, pstmt, msg,
+						pmsg);
+		} else {
+			st = OD_EOOM;
+		}
 	}
 
-	machine_msg_t *pmsg = od_pstmt_parse_of(pstmt);
-	if (pmsg == NULL) {
-		return OD_EOOM;
-	}
+	od_pstmt_unref(pstmt);
 
-	return xplan_append_parse(xp, pstmt_name, pstmt, msg, pmsg);
+	return st;
 }
 
 static od_frontend_status_t plan_describe(od_relay_t *relay, od_xplan_t *xp,
@@ -788,26 +808,34 @@ static od_frontend_status_t plan_describe(od_relay_t *relay, od_xplan_t *xp,
 						 NULL /* no rewrite */);
 	}
 
-	const od_pstmt_t *pstmt = plan_client_get_pstmt(xp, client, pstmt_name);
+	/*
+	 * note: pstmt was returned without ref holded because
+	 * it already belongs to client or some xplan entry
+	 */
+	od_pstmt_t *pstmt = plan_client_get_pstmt(xp, client, pstmt_name);
 	if (pstmt == NULL) {
 		machine_msg_t *vresp = pstmt_does_not_exists_msg(pstmt_name);
 		if (vresp == NULL) {
 			return OD_EOOM;
 		}
 
+		/* plan entry will take the additional ref to pstmt */
 		return xplan_append_virtual_error_response(xp, msg, vresp);
 	}
 
+	/* will create xplan entry with ref if needed */
 	od_frontend_status_t st = plan_predeploy_pstmt(xp, server, msg, pstmt);
 	if (st != OD_OK) {
 		return st;
 	}
 
+	/* will create copy of name for pstmt, so no ref needed */
 	machine_msg_t *dmsg = od_pstmt_describe_of(pstmt);
 	if (dmsg == NULL) {
 		return OD_EOOM;
 	}
 
+	/* additional ref to pstmt will be created */
 	return xplan_append_fwd_no_delta(xp, msg, dmsg);
 }
 
@@ -940,7 +968,8 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 		return OD_ECLIENT_PROTOCOL_ERROR;
 	}
 
-	const od_pstmt_t *pstmt = plan_client_get_pstmt(xp, client, pstmt_name);
+	/* no ref to pstmt: already owned by client map or some plan entry */
+	od_pstmt_t *pstmt = plan_client_get_pstmt(xp, client, pstmt_name);
 	if (pstmt == NULL) {
 		machine_msg_t *vresp = pstmt_does_not_exists_msg(pstmt_name);
 		if (vresp == NULL) {
@@ -955,6 +984,7 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 		return OD_ECLIENT_PROTOCOL_ERROR;
 	}
 
+	/* predeploy will create ref to pstmt if needed */
 	od_frontend_status_t st = plan_predeploy_pstmt(xp, server, msg, pstmt);
 	if (st != OD_OK) {
 		return st;
@@ -969,6 +999,8 @@ static od_frontend_status_t plan_bind(od_relay_t *relay, od_xplan_t *xp,
 
 	/*
 	 * forward the Bind and add portal -> pstmt mapping on client.
+	 *
+	 * the ref on pstmt created on plan entry
 	 */
 	return xplan_append_fwd_portal(xp, msg, bmsg, portal_name, pstmt);
 }
@@ -1001,8 +1033,11 @@ static od_frontend_status_t plan_execute(od_relay_t *relay, od_xplan_t *xp,
 		return OD_ECLIENT_PROTOCOL_ERROR;
 	}
 
-	const od_pstmt_t *pstmt =
-		plan_client_get_portal(xp, client, portal_name);
+	/*
+	 * no ref was created on pstmt
+	 * it is already holded by client map or some plan entry
+	 */
+	od_pstmt_t *pstmt = plan_client_get_portal(xp, client, portal_name);
 	if (pstmt == NULL) {
 		/*
 		 * portal not found - just forward, let the server
@@ -1036,8 +1071,10 @@ static od_frontend_status_t plan_execute(od_relay_t *relay, od_xplan_t *xp,
 	if (od_parse_discard_all(desc->data, strlen(desc->data))) {
 		od_debug(&instance->logger, "rewrite execute", client, server,
 			 "DISCARD ALL detected via portal, invalidate caches");
-		return xplan_append_fwd(xp, msg, NULL,
-					OD_XPLAN_DELTA_REMOVE_ALL, NULL, pstmt);
+
+		return xplan_append_fwd(
+			xp, msg, NULL, OD_XPLAN_DELTA_REMOVE_ALL, NULL,
+			NULL /* can not to pass the pstmt - it will not be used */);
 	}
 
 	size_t dealloc_name_len;


### PR DESCRIPTION
The global map of prepared statements was
append-only, which means extra memory consumption
for freed prepared statements, that will never be used.

This patch adds the ref counter for each pstmt, every
pstmt usage in client and server, and pstmt usage in client
portals will no 'hold' ref to pstmt, and the pstmt will
be freed and removed from global map each time, the ref
counters reaches 1.

Two new fields was added ad od_pstmt_t: ref and source, the
second one is used for correct unref impl. Also the owning
of the description bytes was moved to od_pstmt_t, to make
ASAN raise an error if the value was not freed.

Also the buckets count of global map was increased to 10k and
the locks count is 2 * workers count now

Signed-off-by: roman khapov <r.khapov@ya.ru>
