### PR TITLE
fix proctitle display

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -496,8 +496,8 @@ Specify Odyssey instance availability zone for host selection.
 *yes|no*
 
 Online restart feature.
-When setting to yes, restart odyssey simply with 
-running new version (old one will automatically perform graceful shutdown)
+When setting to yes, restart odyssey to new version simply with 
+SIGUSR2.
 
 `enable_online_restart no`
 

--- a/sources/config.c
+++ b/sources/config.c
@@ -451,21 +451,18 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 		od_log(logger, "config", NULL, NULL,
 		       "availability_zone       %s", config->availability_zone);
 	}
-	od_log(logger, "config", NULL, NULL, "enable_host_watcher.    %d",
+	od_log(logger, "config", NULL, NULL, "enable_host_watcher:    %d",
 	       config->host_watcher_enabled);
 
-	if (config->enable_online_restart_feature) {
-		od_log(logger, "config", NULL, NULL,
-		       "online restart enabled: OK");
-	}
-	if (config->graceful_die_on_errors) {
-		od_log(logger, "config", NULL, NULL,
-		       "graceful die enabled:   OK");
-	}
-	if (config->bindwith_reuseport) {
-		od_log(logger, "config", NULL, NULL,
-		       "socket bind with:       SO_REUSEPORT");
-	}
+	od_log(logger, "config", NULL, NULL, "online restart enabled: %d",
+	       config->enable_online_restart_feature);
+
+	od_log(logger, "config", NULL, NULL, "graceful die enabled:   %d",
+	       config->graceful_die_on_errors);
+
+	od_log(logger, "config", NULL, NULL, "bindwith_reuseport:     %d",
+	       config->bindwith_reuseport);
+
 	if (config->hba_file) {
 		od_log(logger, "config", NULL, NULL,
 		       "hba_file                %s", config->hba_file);

--- a/sources/main.c
+++ b/sources/main.c
@@ -39,6 +39,7 @@ static inline void init_tcmalloc_profile(void)
 #endif /* USE_TCMALLOC_PROFILE */
 
 extern char **environ;
+static char **previous_environ = NULL;
 
 /*
  * same preparation as in PostgreSQL (src/backend/utils/misc/ps_status.c, PS_USE_CLOBBER_ARGV).
@@ -90,6 +91,7 @@ static char **prepare_proctitle_buffer(od_instance_t *instance, int argc,
 		}
 	}
 	new_environ[i] = NULL;
+	previous_environ = environ;
 	environ = new_environ;
 
 	char **new_argv = (char **)malloc((argc + 1) * sizeof(char *));
@@ -140,6 +142,28 @@ int main(int argc, char *argv[], char *envp[])
 		rc = EXIT_FAILURE;
 	} else {
 		rc = EXIT_SUCCESS;
+	}
+
+	/* clear the allocation to make the ASAN be silent */
+	if (argv != argv_for_parse) {
+		for (char **p = argv_for_parse; *p != NULL; ++p) {
+			free(*p);
+		}
+		free(argv_for_parse);
+
+#ifdef __darwin__
+		*_NSGetArgv() = argv;
+#endif
+	}
+
+	if (previous_environ != NULL) {
+		char **allocated = environ;
+		environ = previous_environ;
+
+		for (char **p = allocated; *p != NULL; ++p) {
+			free(*p);
+		}
+		free(allocated);
 	}
 
 	return rc;

--- a/sources/main.c
+++ b/sources/main.c
@@ -9,6 +9,10 @@
 
 #include <instance.h>
 
+#ifdef __darwin__
+#include <crt_externs.h>
+#endif
+
 #ifdef USE_TCMALLOC_PROFILE
 #include <gperftools/heap-profiler.h>
 #include <gperftools/tcmalloc.h>
@@ -34,21 +38,94 @@ static inline void init_tcmalloc_profile(void)
 }
 #endif /* USE_TCMALLOC_PROFILE */
 
-int get_args_len_sum(int argc, char *argv[])
+extern char **environ;
+
+/*
+ * same preparation as in PostgreSQL (src/backend/utils/misc/ps_status.c, PS_USE_CLOBBER_ARGV).
+ */
+static char **prepare_proctitle_buffer(od_instance_t *instance, int argc,
+				       char **argv)
 {
-	/*
-	 * we will use argv[0] as a way to set proc title
-	 * and before write new title - previous content must be replace with
-	 * 0, otherwise, there might be some trash after result title
-	 */
+	char *end_of_area = NULL;
+	int i;
 
-	int sum = 0;
-
-	for (int i = 0; i < argc; ++i) {
-		sum += strlen(argv[i]) + 1 /* 0-byte */;
+	for (i = 0; i < argc; i++) {
+		if (i == 0 || end_of_area + 1 == argv[i]) {
+			end_of_area = argv[i] + strlen(argv[i]);
+		}
 	}
 
-	return sum;
+	if (end_of_area == NULL) {
+		instance->orig_argv_ptr = NULL;
+		instance->orig_argv_ptr_len = 0;
+		return argv;
+	}
+
+	for (i = 0; environ[i] != NULL; i++) {
+		if (end_of_area + 1 == environ[i]) {
+			end_of_area = environ[i] + strlen(environ[i]);
+		}
+	}
+
+	instance->orig_argv_ptr = argv[0];
+	instance->orig_argv_ptr_len = end_of_area - argv[0];
+
+	char **new_environ = (char **)malloc((i + 1) * sizeof(char *));
+	if (new_environ == NULL) {
+		instance->orig_argv_ptr = NULL;
+		instance->orig_argv_ptr_len = 0;
+		return argv;
+	}
+	for (i = 0; environ[i] != NULL; i++) {
+		new_environ[i] = strdup(environ[i]);
+		if (new_environ[i] == NULL) {
+			new_environ[i] = NULL;
+			while (--i >= 0) {
+				free(new_environ[i]);
+			}
+			free(new_environ);
+			instance->orig_argv_ptr = NULL;
+			instance->orig_argv_ptr_len = 0;
+			return argv;
+		}
+	}
+	new_environ[i] = NULL;
+	environ = new_environ;
+
+	char **new_argv = (char **)malloc((argc + 1) * sizeof(char *));
+	if (new_argv == NULL) {
+		return argv;
+	}
+	for (i = 0; i < argc; i++) {
+		new_argv[i] = strdup(argv[i]);
+		if (new_argv[i] == NULL) {
+			new_argv[i] = NULL;
+			while (--i >= 0) {
+				free(new_argv[i]);
+			}
+			free(new_argv);
+			return argv;
+		}
+	}
+	new_argv[argc] = NULL;
+
+#ifdef __darwin__
+	/*
+	 * macOS keeps a static copy of the argv pointer; update it
+	 */
+	*_NSGetArgv() = new_argv;
+#endif
+
+	/*
+	 * make the remaining original argv slots (beyond argv[0]) point at
+	 * the end of the clobber area (a NUL), so that ps shows a single
+	 * string instead of concatenating stale argv entries
+	 */
+	for (i = 1; i < argc; i++) {
+		argv[i] = end_of_area;
+	}
+
+	return new_argv;
 }
 
 int main(int argc, char *argv[], char *envp[])
@@ -56,10 +133,9 @@ int main(int argc, char *argv[], char *envp[])
 	init_tcmalloc_profile();
 
 	od_instance_t *odyssey = od_instance_create();
-	odyssey->orig_argv_ptr = argv[0];
-	odyssey->orig_argv_ptr_len = get_args_len_sum(argc, argv);
-
-	int rc = od_instance_main(odyssey, argc, argv, envp);
+	char **argv_for_parse = prepare_proctitle_buffer(odyssey, argc, argv);
+	(void)envp;
+	int rc = od_instance_main(odyssey, argc, argv_for_parse, environ);
 	if (rc == -1) {
 		rc = EXIT_FAILURE;
 	} else {

--- a/sources/setproctitle.c
+++ b/sources/setproctitle.c
@@ -7,18 +7,29 @@
 
 od_retcode_t od_setproctitlef(char **argv_ptr, int argv_len, char *fmt, ...)
 {
+	if (argv_ptr == NULL || *argv_ptr == NULL || argv_len <= 0) {
+		return NOT_OK_RESPONSE;
+	}
+
 	char title[OD_MAX_PROC_TITLE_LEN];
 	va_list args;
 	va_start(args, fmt);
-	size_t title_len = od_vsnprintf(title, sizeof(title), fmt, args);
+	int title_len = od_vsnprintf(title, sizeof(title), fmt, args);
 	va_end(args);
 
-	/* dirty hack */
+	if (title_len < 0) {
+		return NOT_OK_RESPONSE;
+	}
+
 	title[title_len] = '\0';
 
-	/* clean up previous string */
 	memset(*argv_ptr, 0, argv_len);
 
-	memcpy(*argv_ptr, title, title_len + 1);
+	size_t copy_len = title_len;
+	if (copy_len > (size_t)argv_len - 1) {
+		copy_len = (size_t)argv_len - 1;
+	}
+	memcpy(*argv_ptr, title, copy_len + 1);
+
 	return OK_RESPONSE;
 }


### PR DESCRIPTION
Sometimes there was some envp-replated
string at proctitle, this commit adds more
PG-way preparations: zeroing the envp region too