### PR TITLE
docs: document LDAP simple bind mode (ldapprefix / ldapsuffix)

### DIFF
--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -304,6 +304,34 @@ ldap_endpoint "ldap1" {
 }
 ```
 
+The way the client DN is determined depends on whether `ldapbasedn` is set:
+
+* **search+bind** — used when `ldapbasedn` is set. Odyssey searches the
+  directory below `ldapbasedn` for the entry matching the connecting user and
+  then binds with the DN it found.
+* **simple bind** — used when `ldapbasedn` is not set. No search is
+  performed: the client DN is formed by concatenating `ldapprefix`, the user
+  name the client connected with, and `ldapsuffix`.
+
+In both modes Odyssey first opens the connection to the LDAP server and binds
+with `ldapbinddn` / `ldapbindpasswd`, or anonymously when they are not set.
+`ldapprefix` and `ldapsuffix` are ignored when `ldapbasedn` is set. The names
+and the meaning of these two options follow the options of the same name in
+PostgreSQL `pg_hba.conf`.
+
+```
+ldap_endpoint "ldap2" {
+	ldapscheme "ldap"
+	ldapserver "192.168.233.16"
+	ldapport 389
+	ldapprefix "cn="
+	ldapsuffix ",ou=people,dc=example,dc=org"
+}
+```
+
+With this endpoint a client connecting as `user4` is authenticated as
+`cn=user4,ou=people,dc=example,dc=org`.
+
 ---
 
 ## **ldap\_pool\_size**


### PR DESCRIPTION
Closes #1525

## What changed

Added a short description and one example to the `ldap_endpoint` section of
`docs/configuration/rules.md`, covering how the client DN is determined:
search+bind when `ldapbasedn` is set, simple bind via `ldapprefix` /
`ldapsuffix` when it is not.

Documentation only. No source changes, no behaviour changes.

## Why

`ldapprefix` and `ldapsuffix` were not mentioned anywhere under `docs/`,
although they have been supported since 2021 and select an authentication
mode that needs no directory search. The existing example in this section
sets `ldapbasedn` and therefore illustrates search+bind only, so simple bind
was not discoverable from the documentation.

## Verification

The described behaviour is taken from `sources/ldap.c` at `c9e9297e`:

- `resolve_user` (line 439) builds the DN as `ldapprefix` +
  `client->startup.user.value` + `ldapsuffix` when `endp->ldapbasedn == NULL`,
  and searches the directory otherwise (line 495).
- `init_and_bind` (line 410) performs the initial bind with `ldapbinddn` /
  `ldapbindpasswd`, falling back to empty strings when they are unset. This
  happens in both modes, which is why the added text states so explicitly.
- The resulting DN is passed to `ldap_simple_bind_s` at line 580.

`make format` was not run: the change touches no C source, and `clang-format`
does not apply to Markdown. The added block follows the heading, list and
fenced-code conventions of the surrounding sections, and uses tabs inside the
config example to match the existing one.

## Environment

Ubuntu 22.04 (WSL2), x86_64. Branched from `upstream/master` at `c9e9297e`.
