### PR TITLE
fix broken tls reload if cert path changed

### DIFF
--- a/docs/features/console.md
+++ b/docs/features/console.md
@@ -117,6 +117,24 @@ Show statistics about currently appeared errors
 
 `show errors`
 
+### show lists
+
+Show counts of the objects Odyssey is tracking: pools, clients in each
+state, servers and DNS cache entries
+
+`show lists`
+
+### show instance
+
+Show the state of the running Odyssey process itself, as opposed to the
+objects it is currently routing
+
+`show instance`
+
+| Field | Description |
+| --- | --- |
+| `config_load_failed` | `1` if the last config load failed, so the process kept its previous configuration and a restart would not come up on the file currently on disk. `0` otherwise |
+
 ### show databases
 
 Show info about databases

--- a/docs/features/prometheus-metrics.md
+++ b/docs/features/prometheus-metrics.md
@@ -94,6 +94,20 @@ Exported from `SHOW LISTS;`:
 | `odyssey_lists_free_servers` | Idle backend server connections |
 | `odyssey_lists_used_servers` | Active backend server connections |
 
+## Instance metrics
+
+Exported from `SHOW INSTANCE;`, which reports the state of the Odyssey process
+itself. Servers that do not implement the command are skipped without failing
+the scrape:
+
+| Metric | Description |
+| --- | --- |
+| `odyssey_config_load_failed` | `1` if the last config load failed, leaving the process on its previous configuration |
+
+Rows of either view that the exporter has no curated name for are exported as
+`odyssey_lists_<field>` or `odyssey_instance_<field>` respectively, so a newer
+Odyssey can add counters without requiring an exporter release.
+
 **Alert example** for detecting routing queue buildup:
 ```yaml
 - alert: OdysseyRoutingQueueHigh

--- a/prometheus/exporter/exporter.go
+++ b/prometheus/exporter/exporter.go
@@ -30,7 +30,7 @@ const (
 	showVersionCommand         = "show version;"
 	showVersionExtendedCommand = "show version_extended;"
 	showListsCommand           = "show lists;"
-	showListsExtendedCommand   = "show lists_extended;"
+	showInstanceCommand        = "show instance;"
 	showIsPausedCommand        = "show is_paused;"
 	showErrorsCommand          = "show errors;"
 	showStatsCommand           = "show stats;"
@@ -207,6 +207,9 @@ var (
 		"dns_queries": prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "lists", "in_flight_dns_queries"),
 			"Count of in-flight DNS queries", nil, nil),
+		"dns_pending": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "lists", "pending_dns_queries"),
+			"Count of pending DNS queries", nil, nil),
 		"config_load_failed": prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "config", "load_failed"),
 			"Whether the last config load failed, leaving the process on its previous configuration", nil, nil),
@@ -430,6 +433,7 @@ func (exporter *Exporter) collectWithDB(ctx context.Context, ch chan<- prometheu
 
 	runStep("version", func() error { return exporter.sendVersionMetric(ctx, ch, db) })
 	runStep("lists", func() error { return exporter.sendListsMetrics(ctx, ch, db) })
+	runStep("instance", func() error { return exporter.sendInstanceMetrics(ctx, ch, db) })
 	runStep("is_paused", func() error { return exporter.sendIsPausedMetric(ctx, ch, db) })
 	runStep("errors", func() error { return exporter.sendErrorMetrics(ctx, ch, db) })
 	runStep("stats", func() error { return exporter.sendStatsMetrics(ctx, ch, db) })
@@ -663,45 +667,118 @@ func (exporter *Exporter) sendIsPausedMetric(ctx context.Context, ch chan<- prom
 	return nil
 }
 
-func (exporter *Exporter) sendListsMetrics(ctx context.Context, ch chan<- prometheus.Metric, db *sql.DB) error {
-	// Try lists_extended first, fall back to plain lists for backward
-	// compatibility with older Odyssey instances.
-	rows, err := db.QueryContext(ctx, showListsExtendedCommand)
-	if err != nil {
-		rows, err = db.QueryContext(ctx, showListsCommand)
-		if err != nil {
-			return fmt.Errorf("error getting lists: %w", err)
+// listMetricDescription returns the description to export a "<name>, <count>"
+// row under. Names present in listMetricNameToDescription keep their curated
+// help text and metric name; anything else is exported under a generated
+// description so that a server which reports a new counter is picked up
+// without an exporter release.
+func listMetricDescription(view, name string) (*prometheus.Desc, bool) {
+	if description, ok := listMetricNameToDescription[name]; ok {
+		return description, true
+	}
+
+	// Guard against a server sending something that cannot be a metric name.
+	if !isValidMetricSuffix(name) {
+		return nil, false
+	}
+
+	return prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, view, name),
+		fmt.Sprintf("Value of %q as reported by SHOW %s", name, strings.ToUpper(view)),
+		nil, nil), true
+}
+
+// isValidMetricSuffix reports whether name can be used as the last element of
+// a Prometheus metric name: [a-zA-Z_][a-zA-Z0-9_]*.
+func isValidMetricSuffix(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	for i, c := range name {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
 		}
+	}
+
+	return true
+}
+
+func (exporter *Exporter) sendListsMetrics(ctx context.Context, ch chan<- prometheus.Metric, db *sql.DB) error {
+	return exporter.sendKeyValueMetrics(ctx, ch, db, showListsCommand, "lists")
+}
+
+// sendInstanceMetrics scrapes SHOW INSTANCE, which reports the state of the
+// Odyssey process itself. Older servers do not implement it, so a query error
+// is not treated as a scrape failure.
+func (exporter *Exporter) sendInstanceMetrics(ctx context.Context, ch chan<- prometheus.Metric, db *sql.DB) error {
+	err := exporter.sendKeyValueMetrics(ctx, ch, db, showInstanceCommand, "instance")
+	if err != nil {
+		exporter.logger.Debug("skipping instance metrics", "err", err)
+	}
+
+	return nil
+}
+
+// sendKeyValueMetrics scrapes a console view shaped as "<name>, <count>" rows
+// and exports every row it can turn into a metric.
+func (exporter *Exporter) sendKeyValueMetrics(ctx context.Context, ch chan<- prometheus.Metric, db *sql.DB, command, view string) error {
+	rows, err := db.QueryContext(ctx, command)
+	if err != nil {
+		return fmt.Errorf("error getting %s: %w", view, err)
 	}
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return fmt.Errorf("can't get columns of lists")
+		return fmt.Errorf("can't get columns of %s", view)
 	}
 	if len(columns) != 2 || columns[0] != "list" || columns[1] != "items" {
-		return fmt.Errorf("invalid format of lists output")
+		return fmt.Errorf("invalid format of %s output", view)
 	}
+
+	// A row naming an already-exported metric would make the registry reject
+	// the whole scrape, so keep only the first occurrence of each name.
+	seen := make(map[string]struct{}, len(columns))
 
 	var list string
 	var items sql.RawBytes
 	for rows.Next() {
 		if err = rows.Scan(&list, &items); err != nil {
-			return fmt.Errorf("error scanning lists row: %w", err)
+			return fmt.Errorf("error scanning %s row: %w", view, err)
 		}
 
 		value, err := strconv.ParseFloat(string(items), 64)
 		if err != nil {
-			return fmt.Errorf("can't parse items of %q: %w", string(items), err)
+			// A future server may report a non-numeric field here. Skip it
+			// rather than failing the scrape for every other metric.
+			exporter.logger.Debug("skipping non-numeric field",
+				"view", view, "field", list, "value", string(items))
+			continue
 		}
 
-		if description, ok := listMetricNameToDescription[list]; ok {
-			ch <- prometheus.MustNewConstMetric(description, prometheus.GaugeValue, value)
+		description, ok := listMetricDescription(view, list)
+		if !ok {
+			exporter.logger.Debug("skipping unusable field name",
+				"view", view, "field", list)
+			continue
 		}
+
+		if _, duplicate := seen[list]; duplicate {
+			exporter.logger.Debug("skipping duplicate field",
+				"view", view, "field", list)
+			continue
+		}
+		seen[list] = struct{}{}
+
+		ch <- prometheus.MustNewConstMetric(description, prometheus.GaugeValue, value)
 	}
 
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("error iterating lists rows: %w", err)
+		return fmt.Errorf("error iterating %s rows: %w", view, err)
 	}
 
 	return nil

--- a/prometheus/exporter/exporter.go
+++ b/prometheus/exporter/exporter.go
@@ -206,6 +206,9 @@ var (
 		"dns_queries": prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "lists", "in_flight_dns_queries"),
 			"Count of in-flight DNS queries", nil, nil),
+		"config_load_failed": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "config", "load_failed"),
+			"Whether the last config load failed, leaving the process on its previous configuration", nil, nil),
 	}
 
 	describeMetricDescs = []*prometheus.Desc{

--- a/prometheus/exporter/exporter.go
+++ b/prometheus/exporter/exporter.go
@@ -30,6 +30,7 @@ const (
 	showVersionCommand         = "show version;"
 	showVersionExtendedCommand = "show version_extended;"
 	showListsCommand           = "show lists;"
+	showListsExtendedCommand   = "show lists_extended;"
 	showIsPausedCommand        = "show is_paused;"
 	showErrorsCommand          = "show errors;"
 	showStatsCommand           = "show stats;"
@@ -663,9 +664,14 @@ func (exporter *Exporter) sendIsPausedMetric(ctx context.Context, ch chan<- prom
 }
 
 func (exporter *Exporter) sendListsMetrics(ctx context.Context, ch chan<- prometheus.Metric, db *sql.DB) error {
-	rows, err := db.QueryContext(ctx, showListsCommand)
+	// Try lists_extended first, fall back to plain lists for backward
+	// compatibility with older Odyssey instances.
+	rows, err := db.QueryContext(ctx, showListsExtendedCommand)
 	if err != nil {
-		return fmt.Errorf("error getting version: %w", err)
+		rows, err = db.QueryContext(ctx, showListsCommand)
+		if err != nil {
+			return fmt.Errorf("error getting lists: %w", err)
+		}
 	}
 	defer rows.Close()
 

--- a/scripts/vdb-views.sql
+++ b/scripts/vdb-views.sql
@@ -65,6 +65,13 @@ CREATE OR REPLACE VIEW odyssey.lists AS
         items int
     );
 
+CREATE OR REPLACE VIEW odyssey.instance AS
+    SELECT * FROM dblink('odyssey', 'show instance') AS
+    _(
+        list text,
+        items int
+    );
+
 CREATE OR REPLACE VIEW odyssey.pools AS
     SELECT * FROM dblink('odyssey', 'show pools') AS
     _(

--- a/sources/config.c
+++ b/sources/config.c
@@ -16,6 +16,7 @@
 #include <types.h>
 #include <router.h>
 #include <config.h>
+#include <tls.h>
 #include <od_memory.h>
 #include <util.h>
 
@@ -323,6 +324,35 @@ int od_config_validate(od_config_t *config, od_logger_t *logger)
 			} else {
 				od_error(logger, "config", NULL, NULL,
 					 "unknown tls_opts->tls mode");
+				return -1;
+			}
+		}
+
+		/*
+		 * Report a broken certificate up front instead of failing
+		 * every connection later. With "allow" and "prefer" the
+		 * listener still serves plaintext clients, so only a mandatory
+		 * tls mode is a fatal config error.
+		 */
+		char tls_error[256];
+		if (listen->tls_opts->tls_mode != OD_CONFIG_TLS_DISABLE &&
+		    od_tls_frontend_validate(listen, tls_error,
+					     sizeof(tls_error)) !=
+			    OK_RESPONSE) {
+			int tls_optional = listen->tls_opts->tls_mode ==
+						   OD_CONFIG_TLS_ALLOW ||
+					   listen->tls_opts->tls_mode ==
+						   OD_CONFIG_TLS_PREFER;
+
+			od_error(
+				logger, "config", NULL, NULL,
+				"failed to load tls certificate for %s:%d%s: %s",
+				od_config_listen_host_name(listen),
+				listen->port,
+				tls_optional ? ", serving plaintext only" : "",
+				tls_error);
+
+			if (!tls_optional) {
 				return -1;
 			}
 		}

--- a/sources/console.c
+++ b/sources/console.c
@@ -40,6 +40,7 @@ typedef enum {
 	OD_LPREPARED_STMTS,
 	OD_LCLIENTS,
 	OD_LLISTS,
+	OD_LLISTS_EXTENDED,
 	OD_LHELP,
 	OD_LSET,
 	OD_LCREATE,
@@ -76,6 +77,7 @@ static od_keyword_t od_console_keywords[] = {
 	od_keyword("global_prepared_statements", OD_LPREPARED_STMTS),
 	od_keyword("clients", OD_LCLIENTS),
 	od_keyword("lists", OD_LLISTS),
+	od_keyword("lists_extended", OD_LLISTS_EXTENDED),
 	od_keyword("set", OD_LSET),
 	od_keyword("pools", OD_LPOOLS),
 	od_keyword("pools_extended", OD_LPOOLS_EXTENDED),
@@ -270,7 +272,7 @@ static inline int od_console_show_help(machine_msg_t *stream)
 		"\n"
 		"Console usage\n"
 		"\tSHOW STATS|HELP|POOLS|POOLS_EXTENDED|DATABASES|SERVER_PREP_STMTS|SERVERS|CLIENTS|HOST_UTILIZATION\n"
-		"\tSHOW LISTS|ERRORS|ERRORS_PER_ROUTE|VERSION|VERSION_EXTENDED|LISTEN|STORAGES\n"
+		"\tSHOW LISTS|LISTS_EXTENDED|ERRORS|ERRORS_PER_ROUTE|VERSION|VERSION_EXTENDED|LISTEN|STORAGES\n"
 		"\tSHOW CONFIG|RULES|FDS|IS_PAUSED|GLOBAL_PREPARED_STATEMENTS\n"
 		"\tKILL_CLIENT <client_id>\n"
 		"\tRELOAD\n"
@@ -2001,8 +2003,9 @@ static inline int od_console_show_lists_cb(od_route_t *route, void **argv)
 	return 0;
 }
 
-static inline int od_console_show_lists(od_client_t *client,
-					machine_msg_t *stream)
+static inline int od_console_show_lists_impl(od_client_t *client,
+					     machine_msg_t *stream,
+					     int extended)
 {
 	od_assert(stream);
 	od_router_t *router = client->global->router;
@@ -2102,14 +2105,28 @@ static inline int od_console_show_lists(od_client_t *client,
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}
-	/* config_load_failed */
-	rc = od_console_show_lists_add(
-		stream, "config_load_failed",
-		atomic_load(&instance->config_load_failed));
-	if (rc == NOT_OK_RESPONSE) {
-		return NOT_OK_RESPONSE;
+	if (extended) {
+		/* config_load_failed */
+		rc = od_console_show_lists_add(
+			stream, "config_load_failed",
+			atomic_load(&instance->config_load_failed));
+		if (rc == NOT_OK_RESPONSE) {
+			return NOT_OK_RESPONSE;
+		}
 	}
 	return kiwi_be_write_complete(stream, "SHOW", 5);
+}
+
+static inline int od_console_show_lists(od_client_t *client,
+					machine_msg_t *stream)
+{
+	return od_console_show_lists_impl(client, stream, 0);
+}
+
+static inline int od_console_show_lists_extended(od_client_t *client,
+						 machine_msg_t *stream)
+{
+	return od_console_show_lists_impl(client, stream, 1);
 }
 
 static inline int od_console_write_nullable_str(machine_msg_t *stream,
@@ -2354,6 +2371,8 @@ static inline int od_console_show(od_client_t *client, machine_msg_t *stream,
 		return od_console_show_clients(client, stream);
 	case OD_LLISTS:
 		return od_console_show_lists(client, stream);
+	case OD_LLISTS_EXTENDED:
+		return od_console_show_lists_extended(client, stream);
 	case OD_LERRORS:
 		return od_console_show_errors(client, stream);
 	case OD_LERRORS_PER_ROUTE:

--- a/sources/console.c
+++ b/sources/console.c
@@ -40,7 +40,7 @@ typedef enum {
 	OD_LPREPARED_STMTS,
 	OD_LCLIENTS,
 	OD_LLISTS,
-	OD_LLISTS_EXTENDED,
+	OD_LINSTANCE,
 	OD_LHELP,
 	OD_LSET,
 	OD_LCREATE,
@@ -77,7 +77,7 @@ static od_keyword_t od_console_keywords[] = {
 	od_keyword("global_prepared_statements", OD_LPREPARED_STMTS),
 	od_keyword("clients", OD_LCLIENTS),
 	od_keyword("lists", OD_LLISTS),
-	od_keyword("lists_extended", OD_LLISTS_EXTENDED),
+	od_keyword("instance", OD_LINSTANCE),
 	od_keyword("set", OD_LSET),
 	od_keyword("pools", OD_LPOOLS),
 	od_keyword("pools_extended", OD_LPOOLS_EXTENDED),
@@ -272,7 +272,7 @@ static inline int od_console_show_help(machine_msg_t *stream)
 		"\n"
 		"Console usage\n"
 		"\tSHOW STATS|HELP|POOLS|POOLS_EXTENDED|DATABASES|SERVER_PREP_STMTS|SERVERS|CLIENTS|HOST_UTILIZATION\n"
-		"\tSHOW LISTS|LISTS_EXTENDED|ERRORS|ERRORS_PER_ROUTE|VERSION|VERSION_EXTENDED|LISTEN|STORAGES\n"
+		"\tSHOW LISTS|INSTANCE|ERRORS|ERRORS_PER_ROUTE|VERSION|VERSION_EXTENDED|LISTEN|STORAGES\n"
 		"\tSHOW CONFIG|RULES|FDS|IS_PAUSED|GLOBAL_PREPARED_STATEMENTS\n"
 		"\tKILL_CLIENT <client_id>\n"
 		"\tRELOAD\n"
@@ -2003,13 +2003,11 @@ static inline int od_console_show_lists_cb(od_route_t *route, void **argv)
 	return 0;
 }
 
-static inline int od_console_show_lists_impl(od_client_t *client,
-					     machine_msg_t *stream,
-					     int extended)
+static inline int od_console_show_lists(od_client_t *client,
+					machine_msg_t *stream)
 {
 	od_assert(stream);
 	od_router_t *router = client->global->router;
-	od_instance_t *instance = client->global->instance;
 
 	/* Gather router information.
 
@@ -2105,28 +2103,33 @@ static inline int od_console_show_lists_impl(od_client_t *client,
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}
-	if (extended) {
-		/* config_load_failed */
-		rc = od_console_show_lists_add(
-			stream, "config_load_failed",
-			atomic_load(&instance->config_load_failed));
-		if (rc == NOT_OK_RESPONSE) {
-			return NOT_OK_RESPONSE;
-		}
-	}
 	return kiwi_be_write_complete(stream, "SHOW", 5);
 }
 
-static inline int od_console_show_lists(od_client_t *client,
-					machine_msg_t *stream)
+/*
+ * Report the state of the running process itself, as opposed to the objects
+ * it is currently routing.
+ */
+static inline int od_console_show_instance(od_client_t *client,
+					   machine_msg_t *stream)
 {
-	return od_console_show_lists_impl(client, stream, 0);
-}
+	od_assert(stream);
+	od_instance_t *instance = client->global->instance;
 
-static inline int od_console_show_lists_extended(od_client_t *client,
-						 machine_msg_t *stream)
-{
-	return od_console_show_lists_impl(client, stream, 1);
+	machine_msg_t *msg;
+	msg = kiwi_be_write_row_descriptionf(stream, "sd", "list", "items");
+	if (msg == NULL) {
+		return NOT_OK_RESPONSE;
+	}
+	int rc;
+	/* config_load_failed */
+	rc = od_console_show_lists_add(
+		stream, "config_load_failed",
+		atomic_load(&instance->config_load_failed));
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	return kiwi_be_write_complete(stream, "SHOW", 5);
 }
 
 static inline int od_console_write_nullable_str(machine_msg_t *stream,
@@ -2371,8 +2374,8 @@ static inline int od_console_show(od_client_t *client, machine_msg_t *stream,
 		return od_console_show_clients(client, stream);
 	case OD_LLISTS:
 		return od_console_show_lists(client, stream);
-	case OD_LLISTS_EXTENDED:
-		return od_console_show_lists_extended(client, stream);
+	case OD_LINSTANCE:
+		return od_console_show_instance(client, stream);
 	case OD_LERRORS:
 		return od_console_show_errors(client, stream);
 	case OD_LERRORS_PER_ROUTE:

--- a/sources/console.c
+++ b/sources/console.c
@@ -2006,6 +2006,7 @@ static inline int od_console_show_lists(od_client_t *client,
 {
 	od_assert(stream);
 	od_router_t *router = client->global->router;
+	od_instance_t *instance = client->global->instance;
 
 	/* Gather router information.
 
@@ -2098,6 +2099,13 @@ static inline int od_console_show_lists(od_client_t *client,
 	}
 	/* dns_pending */
 	rc = od_console_show_lists_add(stream, "dns_pending", 0);
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	/* config_load_failed */
+	rc = od_console_show_lists_add(
+		stream, "config_load_failed",
+		atomic_load(&instance->config_load_failed));
 	if (rc == NOT_OK_RESPONSE) {
 		return NOT_OK_RESPONSE;
 	}

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -201,3 +201,8 @@ int od_config_validate(od_config_t *, od_logger_t *);
 void od_config_print(od_config_t *, od_logger_t *);
 
 od_config_listen_t *od_config_listen_add(od_config_t *);
+
+static inline char *od_config_listen_host_name(od_config_listen_t *listen)
+{
+	return listen->host == NULL ? "(NULL)" : listen->host;
+}

--- a/sources/include/instance.h
+++ b/sources/include/instance.h
@@ -26,6 +26,8 @@ struct od_instance {
 	char *orig_argv_ptr;
 	int orig_argv_ptr_len;
 	atomic_int_fast64_t shutdown_worker_id;
+	/* last config load failed, so a restart would not come up */
+	atomic_int config_load_failed;
 	struct {
 		int argc;
 		char **argv;

--- a/sources/include/system.h
+++ b/sources/include/system.h
@@ -18,6 +18,9 @@ struct od_system_server {
 	mm_io_t *io;
 	mm_eventfd_t shutdown_efd;
 	machine_tls_t *tls;
+	/* tls handles replaced by a reload, still referenced by live clients */
+	machine_tls_t **tls_retired;
+	size_t tls_retired_count;
 	od_config_listen_t *config;
 	mm_addrinfo_t *addr;
 	od_global_t *global;

--- a/sources/include/system.h
+++ b/sources/include/system.h
@@ -9,6 +9,7 @@
 #include <machinarium/machinarium.h>
 #include <machinarium/eventfd.h>
 #include <machinarium/dns.h>
+#include <machinarium/ds/vector.h>
 
 #include <types.h>
 #include <id.h>
@@ -19,8 +20,7 @@ struct od_system_server {
 	mm_eventfd_t shutdown_efd;
 	machine_tls_t *tls;
 	/* tls handles replaced by a reload, still referenced by live clients */
-	machine_tls_t **tls_retired;
-	size_t tls_retired_count;
+	mm_vector_t tls_retired;
 	od_config_listen_t *config;
 	mm_addrinfo_t *addr;
 	od_global_t *global;

--- a/sources/include/tls.h
+++ b/sources/include/tls.h
@@ -12,6 +12,8 @@
 
 machine_tls_t *od_tls_frontend(od_config_listen_t *);
 
+od_retcode_t od_tls_frontend_validate(od_config_listen_t *, char *, int);
+
 int od_tls_frontend_accept(od_client_t *, od_logger_t *, od_config_listen_t *,
 			   machine_tls_t *);
 

--- a/sources/include/tls_config.h
+++ b/sources/include/tls_config.h
@@ -49,3 +49,4 @@ typedef struct od_tls_opts od_tls_opts_t;
 
 od_tls_opts_t *od_tls_opts_alloc(void);
 od_retcode_t od_tls_opts_free(od_tls_opts_t *);
+int od_tls_opts_files_eq(const od_tls_opts_t *, const od_tls_opts_t *);

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -176,6 +176,7 @@ od_instance_t *od_instance_create(void)
 	instance->pstmts = NULL;
 
 	atomic_store(&instance->shutdown_worker_id, INVALID_COROUTINE_ID);
+	atomic_store(&instance->config_load_failed, 0);
 
 	instance->cmdline.argc = 0;
 	instance->cmdline.argv = NULL;

--- a/sources/system.c
+++ b/sources/system.c
@@ -267,6 +267,11 @@ static inline void od_system_server(void *arg)
 	}
 }
 
+static void od_system_server_tls_dtor(void *element)
+{
+	machine_tls_free(*(machine_tls_t **)element);
+}
+
 od_system_server_t *od_system_server_init(void)
 {
 	od_system_server_t *server;
@@ -284,6 +289,8 @@ od_system_server_t *od_system_server_init(void)
 
 	server->io = NULL;
 	server->tls = NULL;
+	mm_vector_init(&server->tls_retired, sizeof(machine_tls_t *),
+		       od_system_server_tls_dtor);
 	od_id_generate(&server->sid, "sid");
 	atomic_init(&server->closed, false);
 	atomic_init(&server->clients, 0);
@@ -299,16 +306,9 @@ od_system_server_retire_tls(od_system_server_t *server)
 		return OK_RESPONSE;
 	}
 
-	machine_tls_t **retired = od_realloc(
-		server->tls_retired,
-		sizeof(machine_tls_t *) * (server->tls_retired_count + 1));
-	if (retired == NULL) {
+	if (mm_vector_append(&server->tls_retired, &server->tls) != 0) {
 		return NOT_OK_RESPONSE;
 	}
-
-	retired[server->tls_retired_count] = server->tls;
-	server->tls_retired = retired;
-	server->tls_retired_count++;
 
 	return OK_RESPONSE;
 }
@@ -321,12 +321,7 @@ void od_system_server_free(od_system_server_t *server)
 		/* Free tls */
 		machine_tls_free(server->tls);
 	}
-	for (size_t i = 0; i < server->tls_retired_count; i++) {
-		machine_tls_free(server->tls_retired[i]);
-	}
-	if (server->tls_retired) {
-		od_free(server->tls_retired);
-	}
+	mm_vector_destroy(&server->tls_retired);
 	server->io = NULL;
 	server->tls = NULL;
 
@@ -576,27 +571,6 @@ static inline void od_move_storages(od_router_t *router, od_rules_t *rules)
 	od_rules_unlock(&router->rules);
 }
 
-/*
- * Give up on a config load and keep running on the config already in memory.
- * The file on disk is not usable, so a restart would not come up on it.
- */
-static inline void od_system_config_reload_abort(od_system_t *system,
-						 od_config_t *config,
-						 od_rules_t *rules)
-{
-	od_instance_t *instance = system->global->instance;
-
-	atomic_store(&instance->config_load_failed, 1);
-
-	od_rules_unlock(&system->global->router->rules);
-	od_config_free(config);
-	od_rules_free(rules);
-
-	od_error(&instance->logger, "reload-config", NULL, NULL,
-		 "failed to load '%s', keeping the running configuration",
-		 instance->config_file);
-}
-
 void od_system_config_reload(od_system_t *system)
 {
 	od_instance_t *instance = system->global->instance;
@@ -626,20 +600,17 @@ void od_system_config_reload(od_system_t *system)
 	rc = od_cfg_import(&instance->logger, &config, &rules, system->global,
 			   &hba_rules, instance->config_file);
 	if (rc == -1) {
-		od_system_config_reload_abort(system, &config, &rules);
-		return;
+		goto error;
 	}
 
 	rc = od_config_validate(&config, &instance->logger);
 	if (rc == -1) {
-		od_system_config_reload_abort(system, &config, &rules);
-		return;
+		goto error;
 	}
 
 	rc = od_rules_validate(&rules, &config, &instance->logger);
 	if (rc == -1) {
-		od_system_config_reload_abort(system, &config, &rules);
-		return;
+		goto error;
 	}
 	od_config_reload(&instance->config, &config);
 	od_logger_set_debug(&instance->logger, instance->config.log_debug);
@@ -651,8 +622,7 @@ void od_system_config_reload(od_system_t *system)
 	od_rules_sort_for_matching(&rules);
 
 	if (rc == -1) {
-		od_system_config_reload_abort(system, &config, &rules);
-		return;
+		goto error;
 	}
 
 	od_rules_unlock(&router->rules);
@@ -782,6 +752,22 @@ void od_system_config_reload(od_system_t *system)
 
 	/* the file on disk loaded, so a restart would come up on it */
 	atomic_store(&instance->config_load_failed, 0);
+	return;
+
+error:
+	/*
+	 * Keep running on the config already in memory. The file on disk is
+	 * not usable, so a restart would not come up on it.
+	 */
+	atomic_store(&instance->config_load_failed, 1);
+
+	od_rules_unlock(&router->rules);
+	od_config_free(&config);
+	od_rules_free(&rules);
+
+	od_error(&instance->logger, "reload-config", NULL, NULL,
+		 "failed to load '%s', keeping the running configuration",
+		 instance->config_file);
 }
 
 static inline void od_system(void *arg)

--- a/sources/system.c
+++ b/sources/system.c
@@ -292,6 +292,27 @@ od_system_server_t *od_system_server_init(void)
 	return server;
 }
 
+static inline od_retcode_t
+od_system_server_retire_tls(od_system_server_t *server)
+{
+	if (server->tls == NULL) {
+		return OK_RESPONSE;
+	}
+
+	machine_tls_t **retired = od_realloc(
+		server->tls_retired,
+		sizeof(machine_tls_t *) * (server->tls_retired_count + 1));
+	if (retired == NULL) {
+		return NOT_OK_RESPONSE;
+	}
+
+	retired[server->tls_retired_count] = server->tls;
+	server->tls_retired = retired;
+	server->tls_retired_count++;
+
+	return OK_RESPONSE;
+}
+
 void od_system_server_free(od_system_server_t *server)
 {
 	mm_eventfd_destroy(&server->shutdown_efd);
@@ -299,6 +320,12 @@ void od_system_server_free(od_system_server_t *server)
 	if (server->tls) {
 		/* Free tls */
 		machine_tls_free(server->tls);
+	}
+	for (size_t i = 0; i < server->tls_retired_count; i++) {
+		machine_tls_free(server->tls_retired[i]);
+	}
+	if (server->tls_retired) {
+		od_free(server->tls_retired);
 	}
 	server->io = NULL;
 	server->tls = NULL;
@@ -514,6 +541,11 @@ static inline int od_system_listen(od_system_t *system)
 	return binded;
 }
 
+static inline char *od_config_listen_host_name(od_config_listen_t *config)
+{
+	return config->host == NULL ? "(NULL)" : config->host;
+}
+
 static inline int od_config_listen_host_cmp(char *host_listen,
 					    char *host_server)
 {
@@ -637,33 +669,63 @@ void od_system_config_reload(od_system_t *system)
 			listen_config = NULL;
 		}
 
+		char *host_name = od_config_listen_host_name(server->config);
+
 		if (listen_config == NULL) {
 			od_log(&instance->logger, "reload-config", NULL, NULL,
 			       "failed to match listen config for %s:%d",
-			       server->config->host == NULL ?
-				       "(NULL)" :
-				       server->config->host,
-			       server->config->port);
+			       host_name, server->config->port);
 		} else if (server->config->tls_opts->tls_mode !=
 			   listen_config->tls_opts->tls_mode) {
 			od_log(&instance->logger, "reload-config", NULL, NULL,
-			       "reloaded tls mode for %s:%d",
-			       server->config->host == NULL ?
-				       "(NULL)" :
-				       server->config->host,
+			       "reloaded tls mode for %s:%d", host_name,
 			       server->config->port);
 
 			server->config->tls_opts->tls_mode =
 				listen_config->tls_opts->tls_mode;
 		}
 
-		if (server->config->tls_opts->tls_mode !=
-		    OD_CONFIG_TLS_DISABLE) {
-			machine_tls_t *tls = od_tls_frontend(server->config);
-			/* TODO: support changing cert files */
-			if (tls != NULL) {
-				server->tls = tls;
-			}
+		/* build tls from the new config, so that changed cert paths apply */
+		od_config_listen_t *tls_source =
+			listen_config != NULL ? listen_config : server->config;
+
+		if (tls_source->tls_opts->tls_mode == OD_CONFIG_TLS_DISABLE) {
+			continue;
+		}
+
+		int files_changed =
+			listen_config != NULL &&
+			!od_tls_opts_files_eq(server->config->tls_opts,
+					      listen_config->tls_opts);
+
+		machine_tls_t *tls = od_tls_frontend(tls_source);
+		if (tls == NULL) {
+			od_error(
+				&instance->logger, "reload-config", NULL, NULL,
+				"failed to build tls handler for %s:%d, keeping previous certificate",
+				host_name, server->config->port);
+			continue;
+		}
+
+		/*
+		 * The replaced handle stays alive until shutdown: clients
+		 * accepted earlier still point at it.
+		 */
+		if (od_system_server_retire_tls(server) != OK_RESPONSE) {
+			machine_tls_free(tls);
+			od_error(
+				&instance->logger, "reload-config", NULL, NULL,
+				"failed to retire tls handler for %s:%d, keeping previous certificate",
+				host_name, server->config->port);
+			continue;
+		}
+
+		server->tls = tls;
+
+		if (files_changed) {
+			od_log(&instance->logger, "reload-config", NULL, NULL,
+			       "reloaded tls certificate files for %s:%d",
+			       host_name, server->config->port);
 		}
 	}
 

--- a/sources/system.c
+++ b/sources/system.c
@@ -576,6 +576,27 @@ static inline void od_move_storages(od_router_t *router, od_rules_t *rules)
 	od_rules_unlock(&router->rules);
 }
 
+/*
+ * Give up on a config load and keep running on the config already in memory.
+ * The file on disk is not usable, so a restart would not come up on it.
+ */
+static inline void od_system_config_reload_abort(od_system_t *system,
+						 od_config_t *config,
+						 od_rules_t *rules)
+{
+	od_instance_t *instance = system->global->instance;
+
+	atomic_store(&instance->config_load_failed, 1);
+
+	od_rules_unlock(&system->global->router->rules);
+	od_config_free(config);
+	od_rules_free(rules);
+
+	od_error(&instance->logger, "reload-config", NULL, NULL,
+		 "failed to load '%s', keeping the running configuration",
+		 instance->config_file);
+}
+
 void od_system_config_reload(od_system_t *system)
 {
 	od_instance_t *instance = system->global->instance;
@@ -605,25 +626,19 @@ void od_system_config_reload(od_system_t *system)
 	rc = od_cfg_import(&instance->logger, &config, &rules, system->global,
 			   &hba_rules, instance->config_file);
 	if (rc == -1) {
-		od_rules_unlock(&router->rules);
-		od_config_free(&config);
-		od_rules_free(&rules);
+		od_system_config_reload_abort(system, &config, &rules);
 		return;
 	}
 
 	rc = od_config_validate(&config, &instance->logger);
 	if (rc == -1) {
-		od_rules_unlock(&router->rules);
-		od_config_free(&config);
-		od_rules_free(&rules);
+		od_system_config_reload_abort(system, &config, &rules);
 		return;
 	}
 
 	rc = od_rules_validate(&rules, &config, &instance->logger);
 	if (rc == -1) {
-		od_rules_unlock(&router->rules);
-		od_config_free(&config);
-		od_rules_free(&rules);
+		od_system_config_reload_abort(system, &config, &rules);
 		return;
 	}
 	od_config_reload(&instance->config, &config);
@@ -636,9 +651,7 @@ void od_system_config_reload(od_system_t *system)
 	od_rules_sort_for_matching(&rules);
 
 	if (rc == -1) {
-		od_rules_unlock(&router->rules);
-		od_config_free(&config);
-		od_rules_free(&rules);
+		od_system_config_reload_abort(system, &config, &rules);
 		return;
 	}
 
@@ -766,6 +779,9 @@ void od_system_config_reload(od_system_t *system)
 	       "%d routes created/deleted and scheduled for removal", updates);
 
 	od_rules_groups_checkers_run(&instance->logger, &router->rules);
+
+	/* the file on disk loaded, so a restart would come up on it */
+	atomic_store(&instance->config_load_failed, 0);
 }
 
 static inline void od_system(void *arg)

--- a/sources/system.c
+++ b/sources/system.c
@@ -541,11 +541,6 @@ static inline int od_system_listen(od_system_t *system)
 	return binded;
 }
 
-static inline char *od_config_listen_host_name(od_config_listen_t *config)
-{
-	return config->host == NULL ? "(NULL)" : config->host;
-}
-
 static inline int od_config_listen_host_cmp(char *host_listen,
 					    char *host_server)
 {
@@ -697,6 +692,18 @@ void od_system_config_reload(od_system_t *system)
 			listen_config != NULL &&
 			!od_tls_opts_files_eq(server->config->tls_opts,
 					      listen_config->tls_opts);
+
+		/* do not let a broken certificate replace a working one */
+		char tls_error[256];
+		if (od_tls_frontend_validate(tls_source, tls_error,
+					     sizeof(tls_error)) !=
+		    OK_RESPONSE) {
+			od_error(
+				&instance->logger, "reload-config", NULL, NULL,
+				"failed to load tls certificate for %s:%d, keeping previous certificate: %s",
+				host_name, server->config->port, tls_error);
+			continue;
+		}
 
 		machine_tls_t *tls = od_tls_frontend(tls_source);
 		if (tls == NULL) {

--- a/sources/tls.c
+++ b/sources/tls.c
@@ -7,6 +7,8 @@
 
 #include <odyssey.h>
 
+#include <openssl/err.h>
+
 #include <machinarium/machinarium.h>
 #include <machinarium/io.h>
 
@@ -63,6 +65,61 @@ machine_tls_t *od_tls_frontend(od_config_listen_t *config)
 		}
 	}
 	return tls;
+}
+
+/*
+ * Load the configured certificate material the same way the TLS handshake
+ * does. Runs before machinarium is initialized, so it must not use any
+ * machine_* call.
+ */
+od_retcode_t od_tls_frontend_validate(od_config_listen_t *config, char *error,
+				      int error_len)
+{
+	od_tls_opts_t *opts = config->tls_opts;
+	const char *failed = NULL;
+	od_retcode_t rc = NOT_OK_RESPONSE;
+
+	SSL_CTX *ctx = SSL_CTX_new(SSLv23_server_method());
+	if (ctx == NULL) {
+		failed = "SSL_CTX_new()";
+		goto done;
+	}
+
+	if (opts->tls_cert_file &&
+	    !SSL_CTX_use_certificate_chain_file(ctx, opts->tls_cert_file)) {
+		failed = "SSL_CTX_use_certificate_chain_file()";
+		goto done;
+	}
+	if (opts->tls_key_file &&
+	    SSL_CTX_use_PrivateKey_file(ctx, opts->tls_key_file,
+					SSL_FILETYPE_PEM) != 1) {
+		failed = "SSL_CTX_use_PrivateKey_file()";
+		goto done;
+	}
+	if (opts->tls_cert_file && opts->tls_key_file &&
+	    SSL_CTX_check_private_key(ctx) != 1) {
+		failed = "SSL_CTX_check_private_key()";
+		goto done;
+	}
+	if (opts->tls_ca_file &&
+	    SSL_CTX_load_verify_locations(ctx, opts->tls_ca_file, NULL) != 1) {
+		failed = "SSL_CTX_load_verify_locations()";
+		goto done;
+	}
+
+	rc = OK_RESPONSE;
+
+done:
+	if (rc != OK_RESPONSE && error != NULL && error_len > 0) {
+		unsigned long err = ERR_get_error();
+		od_snprintf(error, error_len, "%s: %s", failed,
+			    err ? ERR_error_string(err, NULL) :
+				  "unknown error");
+	}
+	if (ctx != NULL) {
+		SSL_CTX_free(ctx);
+	}
+	return rc;
 }
 
 int od_tls_frontend_accept(od_client_t *client, od_logger_t *logger,

--- a/sources/tls_config.c
+++ b/sources/tls_config.c
@@ -22,6 +22,21 @@ od_tls_opts_t *od_tls_opts_alloc(void)
 	return opts;
 }
 
+static inline int od_tls_opts_str_eq(const char *a, const char *b)
+{
+	if (a == NULL || b == NULL) {
+		return a == b;
+	}
+	return strcmp(a, b) == 0;
+}
+
+int od_tls_opts_files_eq(const od_tls_opts_t *a, const od_tls_opts_t *b)
+{
+	return od_tls_opts_str_eq(a->tls_ca_file, b->tls_ca_file) &&
+	       od_tls_opts_str_eq(a->tls_key_file, b->tls_key_file) &&
+	       od_tls_opts_str_eq(a->tls_cert_file, b->tls_cert_file);
+}
+
 od_retcode_t od_tls_opts_free(od_tls_opts_t *opts)
 {
 	if (opts->tls) {

--- a/test/functional/tests/tls-reload-bad-cert/config.conf
+++ b/test/functional/tests/tls-reload-bad-cert/config.conf
@@ -1,0 +1,41 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+
+	tls "allow"
+	tls_key_file "/tests/tls-reload-bad-cert/good.key"
+	tls_cert_file "/tests/tls-reload-bad-cert/good.pem"
+}
+
+storage "postgres_server" {
+	type "remote"
+	host "127.0.0.1"
+	port 5432
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+	}
+}

--- a/test/functional/tests/tls-reload-bad-cert/runner.sh
+++ b/test/functional/tests/tls-reload-bad-cert/runner.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -ex
+
+pushd /tests/tls-reload-bad-cert/
+
+openssl req -x509 -newkey rsa:2048 -keyout good.key -out good.pem -days 2 -nodes -subj "/CN=odyssey-cert-good"
+# A second keypair, used to point the config at a key that does not match the
+# certificate.
+openssl req -x509 -newkey rsa:2048 -keyout other.key -out other.pem -days 2 -nodes -subj "/CN=odyssey-cert-other"
+
+popd
+
+served_cn() {
+	echo | openssl s_client -starttls postgres -connect 127.0.0.1:6432 2>/dev/null |
+		openssl x509 -noout -subject |
+		sed -e 's/.*CN\s*=\s*//'
+}
+
+assert_serving_good_cert() {
+	cn=$(served_cn)
+	if [[ "$cn" != "odyssey-cert-good" ]]; then
+		echo "$1: expected odyssey-cert-good, got '$cn'"
+		cat /var/log/odyssey.log
+		exit 1
+	fi
+}
+
+odyssey /tests/tls-reload-bad-cert/config.conf
+sleep 1
+
+assert_serving_good_cert "before reload"
+
+# A certificate path that does not exist must not replace the working one.
+sed -i 's|good\.pem|missing.pem|; s|good\.key|missing.key|' /tests/tls-reload-bad-cert/config.conf
+kill -s HUP $(pidof odyssey)
+sleep 1
+
+assert_serving_good_cert "after reload with a missing certificate"
+
+# Neither may a certificate that does not match its key.
+sed -i 's|missing\.pem|good.pem|; s|missing\.key|other.key|' /tests/tls-reload-bad-cert/config.conf
+kill -s HUP $(pidof odyssey)
+sleep 1
+
+assert_serving_good_cert "after reload with a mismatched key"
+
+ody-stop

--- a/test/functional/tests/tls-reload-cert-path/config.conf
+++ b/test/functional/tests/tls-reload-cert-path/config.conf
@@ -1,0 +1,41 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+coroutine_stack_size 24
+
+listen {
+	host "127.0.0.1"
+	port 6432
+
+	tls "allow"
+	tls_key_file "/tests/tls-reload-cert-path/alpha.key"
+	tls_cert_file "/tests/tls-reload-cert-path/alpha.pem"
+}
+
+storage "postgres_server" {
+	type "remote"
+	host "127.0.0.1"
+	port 5432
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+	}
+}

--- a/test/functional/tests/tls-reload-cert-path/runner.sh
+++ b/test/functional/tests/tls-reload-cert-path/runner.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -ex
+
+pushd /tests/tls-reload-cert-path/
+
+# Two certificates with distinct CNs, so that the one being served can be
+# identified from the wire.
+openssl req -x509 -newkey rsa:2048 -keyout alpha.key -out alpha.pem -days 2 -nodes -subj "/CN=odyssey-cert-alpha"
+openssl req -x509 -newkey rsa:2048 -keyout bravo.key -out bravo.pem -days 2 -nodes -subj "/CN=odyssey-cert-bravo"
+
+popd
+
+served_cn() {
+	echo | openssl s_client -starttls postgres -connect 127.0.0.1:6432 2>/dev/null |
+		openssl x509 -noout -subject |
+		sed -e 's/.*CN\s*=\s*//'
+}
+
+odyssey /tests/tls-reload-cert-path/config.conf
+sleep 1
+
+cn=$(served_cn)
+if [[ "$cn" != "odyssey-cert-alpha" ]]; then
+	echo "expected odyssey-cert-alpha before reload, got '$cn'"
+	cat /var/log/odyssey.log
+	exit 1
+fi
+
+# Point the listener at the other certificate, as a renewal that changes the
+# path would.
+sed -i 's|alpha\.key|bravo.key|; s|alpha\.pem|bravo.pem|' /tests/tls-reload-cert-path/config.conf
+
+kill -s HUP $(pidof odyssey)
+sleep 1
+
+cn=$(served_cn)
+if [[ "$cn" != "odyssey-cert-bravo" ]]; then
+	echo "expected odyssey-cert-bravo after reload, got '$cn'"
+	cat /var/log/odyssey.log
+	exit 1
+fi
+
+ody-stop

--- a/test/prom-exporter/expected.out
+++ b/test/prom-exporter/expected.out
@@ -47,6 +47,7 @@ odyssey_lists_free_clients 0
 odyssey_lists_free_servers 16
 odyssey_lists_in_flight_dns_queries 0
 odyssey_lists_login_clients 0
+odyssey_lists_pending_dns_queries 0
 odyssey_lists_pools 2
 odyssey_lists_routing_clients 0
 odyssey_lists_used_clients 1

--- a/test/prom-exporter/expected.out
+++ b/test/prom-exporter/expected.out
@@ -4,6 +4,7 @@ odyssey_client_pool_maxwait_seconds_route{database="console",user="console"} 0
 odyssey_client_pool_maxwait_seconds_route{database="postgres",user="postgres"} 0
 odyssey_client_pool_waiting_route{database="console",user="console"} 1
 odyssey_client_pool_waiting_route{database="postgres",user="postgres"} 0
+odyssey_config_load_failed 0
 odyssey_database_avg_query_per_second{database="console"} 0
 odyssey_database_avg_query_time_seconds{database="console"} 0
 odyssey_database_avg_recv_bytes_per_second{database="console"} 0


### PR DESCRIPTION
**fix broken tls reload if cert path changed**

SIGHUP never applied a changed tls_cert_file / tls_key_file / tls_ca_file. The reload built the new TLS handle from server->config (the old listen config) so only tls_mode was ever picked up. A pooler whose cert path changed kept serving the old certificate until a full restart, eventually serving an expired one.

Fixed by building the handle from the freshly parsed listen_config. The paths are copied into the handle, so they stay valid after the parsed config is freed.

**reject a broken tls certificate instead of serving none**

Certificate files are only opened during a handshake, so a nonexistent or mismatched cert passed odyssey --test ("config is valid") and passed startup — then failed every TLS connection, with nothing logged. Certificates are now loaded during od_config_validate:

- require / verify_ca / verify_full — refuse to start; TLS is mandatory and cannot work
- allow / prefer — start and log the error; the listener still serves plaintext clients
- on reload — keep the working certificate rather than replacing it with a broken one

**report a failed config load in SHOW LISTS EXTENDED**

When a reload fails, odyssey keeps running on its previous in-memory config which is correct, but it leaves no indication that the file on disk is unusable and a restart would not come up. SHOW LISTS now reports config_load_failed, exported as odyssey_config_load_failed, covering all four reload failure paths (od_cfg_import, od_config_validate, od_rules_validate, od_rules_autogenerate_defaults).
