### PR TITLE
docs: state that the LDAP search scope is not configurable

### DIFF
--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -313,6 +313,12 @@ The way the client DN is determined depends on whether `ldapbasedn` is set:
   performed: the client DN is formed by concatenating `ldapprefix`, the user
   name the client connected with, and `ldapsuffix`.
 
+The scope of the search in search+bind mode is not configurable: Odyssey
+always searches the whole subtree below `ldapbasedn`. The `ldapscope` option
+is accepted by the configuration parser and shown when the configuration is
+dumped, but its value is not used. PostgreSQL behaves the same way and has no
+separate option for the search scope either.
+
 In both modes Odyssey first opens the connection to the LDAP server and binds
 with `ldapbinddn` / `ldapbindpasswd`, or anonymously when they are not set.
 `ldapprefix` and `ldapsuffix` are ignored when `ldapbasedn` is set. The names


### PR DESCRIPTION
Closes #1529

## What changed

Added one paragraph to the `ldap_endpoint` section of
`docs/configuration/rules.md`, stating that the search scope is not
configurable and that `ldapscope` is accepted but not used.

Documentation only. No source changes, no behaviour changes.

## Why

`ldapscope` is parsed, stored in the configuration model and printed back
when the configuration is dumped, so a value set there looks like it took
effect. The search always passes the constant `LDAP_SCOPE_SUBTREE`
(`sources/ldap.c:495`, the only `ldap_search_s` call in the tree), and the
documentation did not mention the option at all.

The paragraph describes the current behaviour and does not prejudge whether
the option should later become effective or be removed.

## Verification

- `sources/ldap.c:495` is the only call to `ldap_search_s`; its scope
  argument is the literal `LDAP_SCOPE_SUBTREE`.
- All other occurrences of `ldapscope` (`sources/cfg/convert.c:1702`,
  `keywords.c:127`, `model.c:160` and `:664`, `include/cfg/model.h:251`,
  `include/ldap_endpoint.h:25`, `ldap.c:142`, `:192`) register, copy, dump or
  free the value; none reads it.
- The statement about PostgreSQL follows its documentation of LDAP
  authentication, which describes the search+bind search as covering the
  subtree at `ldapbasedn` and offers no separate scope option.

`make format` was not run: the change touches no C source, and `clang-format`
does not apply to Markdown. The added paragraph follows the wording and
layout of the surrounding text in the same section.

## Environment

Ubuntu 22.04 (WSL2), x86_64. Branched from `upstream/master` at `82243bde`.
