### PR TITLE
introduce show config command

### DIFF
--- a/docs/features/console.md
+++ b/docs/features/console.md
@@ -136,6 +136,44 @@ console=> show host_utilization;
 ```
 
 
+### show config
+
+Reports the global configuration of the running process.
+
+`show config`
+
+```plain
+console=> show config;
+             key             | value | default | changeable
+-----------------------------+-------+---------+------------
+ workers                     | 4     | 1       | no
+ log_query                   | yes   | no      | yes
+ ...
+```
+
+| Column | Meaning |
+| --- | --- |
+| `key` | parameter name, as accepted by the configuration parser |
+| `value` | value the running process is using right now |
+| `default` | built-in value used when the parameter is absent from the configuration file |
+| `changeable` | whether `RELOAD` applies a new value without a restart |
+
+Reading `odyssey.conf` tells you what was asked for, not what is in
+effect. `RELOAD` applies only part of the global configuration; the rest
+keeps the value the process started with, and no error is reported. The
+`changeable` column tells the two apart, so comparing `value` against the
+file is enough to spot a parameter that needs a restart.
+
+Notes:
+
+- `default` is the built-in initial value. A few parameters are derived
+  from others when left unset - `client_max_routing`, for instance,
+  becomes `workers * 64` - so `value` can differ from `default` even
+  though the configuration file does not mention the parameter.
+- Values longer than 255 characters are truncated in the output.
+- Per-route settings are not reported here, see `show rules`. Listen
+  sockets are reported by `show listen`, storages by `show storages`.
+
 ## pause
 
 Pause Odyssey execution. This will drop any session connections and

--- a/docs/features/console.md
+++ b/docs/features/console.md
@@ -174,6 +174,7 @@ Notes:
 - Per-route settings are not reported here, see `show rules`. Listen
   sockets are reported by `show listen`, storages by `show storages`.
 
+
 ## pause
 
 Pause Odyssey execution. This will drop any session connections and

--- a/sources/config.c
+++ b/sources/config.c
@@ -17,6 +17,7 @@
 #include <router.h>
 #include <config.h>
 #include <od_memory.h>
+#include <util.h>
 
 void od_config_init(od_config_t *config)
 {
@@ -334,6 +335,187 @@ int od_config_validate(od_config_t *config, od_logger_t *logger)
 static inline char *od_config_yes_no(int value)
 {
 	return value ? "yes" : "no";
+}
+
+/*
+ * Description of the global configuration for SHOW CONFIG.
+ *
+ * The default column is not stored here on purpose: od_config_field_default()
+ * initializes a throwaway od_config_t through od_config_init() and reads the
+ * same offset, so the reported defaults cannot drift away from the real ones.
+ *
+ * The reloadable flag has no such source and must be kept in sync with
+ * od_config_reload() by hand.
+ */
+
+#define OD_CONFIG_FIELD_NOT_SET "(not set)"
+
+static const od_config_field_t od_config_fields[] = {
+	{ "daemonize", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, daemonize),
+	  0 },
+	{ "priority", OD_CONFIG_FIELD_INT, offsetof(od_config_t, priority), 0 },
+	{ "sequential_routing", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, sequential_routing), 0 },
+	{ "log_to_stdout", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, log_to_stdout), 0 },
+	{ "log_debug", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_debug),
+	  1 },
+	{ "log_config", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_config),
+	  1 },
+	{ "log_session", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, log_session), 1 },
+	{ "log_query", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_query),
+	  1 },
+	{ "log_queue_depth", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, log_queue_depth), 0 },
+	{ "log_async", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_async),
+	  0 },
+	{ "log_file", OD_CONFIG_FIELD_STRING, offsetof(od_config_t, log_file),
+	  0 },
+	{ "log_format", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, log_format), 0 },
+	{ "log_stats", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_stats),
+	  1 },
+	{ "log_general_stats_prom", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, log_general_stats_prom), 0 },
+	{ "log_route_stats_prom", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, log_route_stats_prom), 0 },
+	{ "log_syslog", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, log_syslog),
+	  0 },
+	{ "log_syslog_ident", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, log_syslog_ident), 0 },
+	{ "log_syslog_facility", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, log_syslog_facility), 0 },
+	{ "stats_interval", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, stats_interval), 1 },
+	{ "pid_file", OD_CONFIG_FIELD_STRING, offsetof(od_config_t, pid_file),
+	  0 },
+	{ "unix_socket_dir", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, unix_socket_dir), 0 },
+	{ "unix_socket_mode", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, unix_socket_mode), 0 },
+	{ "locks_dir", OD_CONFIG_FIELD_STRING, offsetof(od_config_t, locks_dir),
+	  0 },
+	{ "external_auth_socket_path", OD_CONFIG_FIELD_STRING,
+	  offsetof(od_config_t, external_auth_socket_path), 0 },
+	{ "graceful_die_on_errors", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, graceful_die_on_errors), 0 },
+	{ "graceful_shutdown_timeout_ms", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, graceful_shutdown_timeout_ms), 1 },
+	{ "enable_online_restart", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, enable_online_restart_feature), 0 },
+	{ "bindwith_reuseport", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, bindwith_reuseport), 0 },
+	{ "readahead", OD_CONFIG_FIELD_INT, offsetof(od_config_t, readahead),
+	  0 },
+	{ "nodelay", OD_CONFIG_FIELD_BOOL, offsetof(od_config_t, nodelay), 0 },
+	{ "disable_nolinger", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, disable_nolinger), 1 },
+	{ "keepalive", OD_CONFIG_FIELD_INT, offsetof(od_config_t, keepalive),
+	  1 },
+	{ "keepalive_keep_interval", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, keepalive_keep_interval), 1 },
+	{ "keepalive_probes", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, keepalive_probes), 1 },
+	{ "keepalive_usr_timeout", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, keepalive_usr_timeout), 1 },
+	{ "workers", OD_CONFIG_FIELD_INT, offsetof(od_config_t, workers), 0 },
+	{ "resolvers", OD_CONFIG_FIELD_INT, offsetof(od_config_t, resolvers),
+	  0 },
+	{ "client_max", OD_CONFIG_FIELD_INT, offsetof(od_config_t, client_max),
+	  1 },
+	{ "client_max_routing", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, client_max_routing), 1 },
+	{ "server_login_retry", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, server_login_retry), 1 },
+	{ "cache_coroutine", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cache_coroutine), 0 },
+	{ "cache_msg_gc_size", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cache_msg_gc_size), 0 },
+	{ "coroutine_stack_size", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, coroutine_stack_size), 0 },
+	{ "system_coroutine_stack_size", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, system_coroutine_stack_size), 0 },
+	{ "dns_cache_ttl", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, dns_ttl_ms), 0 },
+	{ "hba_file", OD_CONFIG_FIELD_STRING, offsetof(od_config_t, hba_file),
+	  0 },
+	{ "group_checker_interval", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, group_checker_interval), 0 },
+	{ "backend_connect_timeout_ms", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, backend_connect_timeout_ms), 1 },
+	{ "cancel_timeout_ms", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cancel_timeout_ms), 1 },
+	{ "cancel_queue_timeout_ms", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cancel_queue_timeout_ms), 0 },
+	{ "cancel_max_inflight", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cancel_max_inflight), 0 },
+	{ "virtual_processing", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, virtual_processing), 0 },
+	{ "virtual_transaction", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, virtual_transaction), 0 },
+	{ "availability_zone", OD_CONFIG_FIELD_STRING_INLINE,
+	  offsetof(od_config_t, availability_zone), 0 },
+	{ "max_sigterms_to_die", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, max_sigterms_to_die), 1 },
+	{ "enable_host_watcher", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, host_watcher_enabled), 0 },
+	{ "smart_search_path_enquoting", OD_CONFIG_FIELD_BOOL,
+	  offsetof(od_config_t, smart_search_path_enquoting), 1 },
+};
+
+size_t od_config_fields_count(void)
+{
+	return sizeof(od_config_fields) / sizeof(od_config_fields[0]);
+}
+
+const od_config_field_t *od_config_field_at(size_t index)
+{
+	if (index >= od_config_fields_count()) {
+		return NULL;
+	}
+	return &od_config_fields[index];
+}
+
+void od_config_field_value(od_config_t *config, const od_config_field_t *field,
+			   char *buf, size_t size)
+{
+	char *at = (char *)config + field->offset;
+
+	switch (field->type) {
+	case OD_CONFIG_FIELD_INT:
+		od_snprintf(buf, size, "%d", *(int *)at);
+		break;
+	case OD_CONFIG_FIELD_BOOL:
+		od_snprintf(buf, size, "%s", *(int *)at ? "yes" : "no");
+		break;
+	case OD_CONFIG_FIELD_STRING: {
+		char *value = *(char **)at;
+		od_snprintf(buf, size, "%s",
+			    value ? value : OD_CONFIG_FIELD_NOT_SET);
+		break;
+	}
+	case OD_CONFIG_FIELD_STRING_INLINE:
+		od_snprintf(buf, size, "%s",
+			    at[0] ? at : OD_CONFIG_FIELD_NOT_SET);
+		break;
+	default:
+		od_snprintf(buf, size, "%s", OD_CONFIG_FIELD_NOT_SET);
+		break;
+	}
+}
+
+void od_config_field_default(const od_config_field_t *field, char *buf,
+			     size_t size)
+{
+	od_config_t defaults;
+
+	/*
+	 * od_config_init() allocates nothing, so the throwaway config needs
+	 * no matching od_config_free().
+	 */
+	od_config_init(&defaults);
+	od_config_field_value(&defaults, field, buf, size);
 }
 
 void od_config_print(od_config_t *config, od_logger_t *logger)

--- a/sources/config.c
+++ b/sources/config.c
@@ -505,17 +505,25 @@ void od_config_field_value(od_config_t *config, const od_config_field_t *field,
 	}
 }
 
+/*
+ * Defaults are shared by every caller and never change, so they are built
+ * once per process. od_config_t is too large to keep on a coroutine stack,
+ * and od_config_init() allocates nothing, so this instance needs no
+ * matching od_config_free().
+ */
+static od_config_t od_config_defaults;
+static pthread_once_t od_config_defaults_ctrl = PTHREAD_ONCE_INIT;
+
+static void od_config_defaults_build(void)
+{
+	od_config_init(&od_config_defaults);
+}
+
 void od_config_field_default(const od_config_field_t *field, char *buf,
 			     size_t size)
 {
-	od_config_t defaults;
-
-	/*
-	 * od_config_init() allocates nothing, so the throwaway config needs
-	 * no matching od_config_free().
-	 */
-	od_config_init(&defaults);
-	od_config_field_value(&defaults, field, buf, size);
+	pthread_once(&od_config_defaults_ctrl, od_config_defaults_build);
+	od_config_field_value(&od_config_defaults, field, buf, size);
 }
 
 void od_config_print(od_config_t *config, od_logger_t *logger)

--- a/sources/console.c
+++ b/sources/console.c
@@ -61,6 +61,7 @@ typedef enum {
 	OD_LIS_PAUSED,
 	OD_LHOST_UTILIZATION,
 	OD_LRULES,
+	OD_LCONFIG,
 } od_console_keywords_t;
 
 static od_keyword_t od_console_keywords[] = {
@@ -95,6 +96,7 @@ static od_keyword_t od_console_keywords[] = {
 	od_keyword("is_paused", OD_LIS_PAUSED),
 	od_keyword("host_utilization", OD_LHOST_UTILIZATION),
 	od_keyword("rules", OD_LRULES),
+	od_keyword("config", OD_LCONFIG),
 	{ 0, 0, 0 }
 };
 
@@ -267,9 +269,12 @@ static inline int od_console_show_help(machine_msg_t *stream)
 		"\n"
 		"Console usage\n"
 		"\tSHOW STATS|HELP|POOLS|POOLS_EXTENDED|DATABASES|SERVER_PREP_STMTS|SERVERS|CLIENTS|HOST_UTILIZATION\n"
-		"\tSHOW LISTS|ERRORS|ERRORS_PER_ROUTE|VERSION|LISTEN|STORAGES\n"
+		"\tSHOW LISTS|ERRORS|ERRORS_PER_ROUTE|VERSION|VERSION_EXTENDED|LISTEN|STORAGES\n"
+		"\tSHOW CONFIG|RULES|FDS|IS_PAUSED|GLOBAL_PREPARED_STATEMENTS\n"
 		"\tKILL_CLIENT <client_id>\n"
 		"\tRELOAD\n"
+		"\tPAUSE\n"
+		"\tRESUME\n"
 		"\tSET key=arg\n"
 		"\tCREATE <module_path>\n"
 		"\tDROP SERVERS|MODULE <servers>|<module>";
@@ -1605,6 +1610,88 @@ static inline int od_console_show_host_utilization(od_client_t *client,
 				      sizeof("HOST_UTILIZATION"));
 }
 
+static inline int od_console_show_config_add(machine_msg_t *stream, char *key,
+					     char *value, char *fallback,
+					     char *changeable)
+{
+	int offset;
+	machine_msg_t *msg;
+	msg = kiwi_be_write_data_row(stream, &offset);
+	if (msg == NULL) {
+		return NOT_OK_RESPONSE;
+	}
+	int rc;
+	/* key */
+	rc = kiwi_be_write_data_row_add(stream, offset, key, strlen(key));
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	/* value */
+	rc = kiwi_be_write_data_row_add(stream, offset, value, strlen(value));
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	/* default */
+	rc = kiwi_be_write_data_row_add(stream, offset, fallback,
+					strlen(fallback));
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	/* changeable */
+	rc = kiwi_be_write_data_row_add(stream, offset, changeable,
+					strlen(changeable));
+	if (rc == NOT_OK_RESPONSE) {
+		return NOT_OK_RESPONSE;
+	}
+	return 0;
+}
+
+/*
+ * SHOW CONFIG
+ *
+ * Reports the global configuration of the running process: the value
+ * currently in effect, the built-in default, and whether the parameter
+ * is picked up by RELOAD. Reading odyssey.conf shows what was asked
+ * for, not what is in effect - od_config_reload() copies only part of
+ * the parsed configuration into the running instance.
+ */
+static inline int od_console_show_config(od_client_t *client,
+					 machine_msg_t *stream)
+{
+	od_assert(stream);
+
+	od_instance_t *instance = client->global->instance;
+
+	machine_msg_t *msg;
+	msg = kiwi_be_write_row_descriptionf(stream, "ssss", "key", "value",
+					     "default", "changeable");
+	if (msg == NULL) {
+		return NOT_OK_RESPONSE;
+	}
+
+	size_t count = od_config_fields_count();
+	for (size_t i = 0; i < count; i++) {
+		const od_config_field_t *field = od_config_field_at(i);
+		if (field == NULL) {
+			return NOT_OK_RESPONSE;
+		}
+		char value[OD_CONFIG_FIELD_VALUE_MAX];
+		char fallback[OD_CONFIG_FIELD_VALUE_MAX];
+
+		od_config_field_value(&instance->config, field, value,
+				      sizeof(value));
+		od_config_field_default(field, fallback, sizeof(fallback));
+
+		int rc = od_console_show_config_add(
+			stream, field->key, value, fallback,
+			field->reloadable ? "yes" : "no");
+		if (rc == NOT_OK_RESPONSE) {
+			return NOT_OK_RESPONSE;
+		}
+	}
+	return kiwi_be_write_complete(stream, "SHOW", 5);
+}
+
 static inline int od_console_show_rules(machine_msg_t *stream)
 {
 	int offset;
@@ -2288,6 +2375,8 @@ static inline int od_console_show(od_client_t *client, machine_msg_t *stream,
 		return od_console_show_host_utilization(client, stream);
 	case OD_LRULES:
 		return od_console_show_rules(stream);
+	case OD_LCONFIG:
+		return od_console_show_config(client, stream);
 	}
 	return NOT_OK_RESPONSE;
 }

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -158,6 +158,33 @@ struct od_config {
 	od_affinity_config_t *cpu_affinity;
 };
 
+/* longest configuration value the console is willing to print */
+#define OD_CONFIG_FIELD_VALUE_MAX 256
+
+typedef enum {
+	OD_CONFIG_FIELD_INT,
+	OD_CONFIG_FIELD_BOOL,
+	OD_CONFIG_FIELD_STRING,
+	OD_CONFIG_FIELD_STRING_INLINE,
+} od_config_field_type_t;
+
+typedef struct {
+	/* name accepted by the configuration parser */
+	char *key;
+	od_config_field_type_t type;
+	/* offset of the field inside od_config_t */
+	size_t offset;
+	/* whether RELOAD applies a new value, see od_config_reload() */
+	int reloadable;
+} od_config_field_t;
+
+size_t od_config_fields_count(void);
+const od_config_field_t *od_config_field_at(size_t index);
+void od_config_field_value(od_config_t *config, const od_config_field_t *field,
+			   char *buf, size_t size);
+void od_config_field_default(const od_config_field_t *field, char *buf,
+			     size_t size);
+
 void od_config_init(od_config_t *);
 void od_config_free(od_config_t *);
 void od_config_reload(od_config_t *, od_config_t *);

--- a/test/functional/tests/show-config/conf.conf
+++ b/test/functional/tests/show-config/conf.conf
@@ -1,0 +1,51 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+
+unix_socket_dir "/tmp"
+unix_socket_mode "0644"
+
+locks_dir "/tmp"
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+log_config yes
+log_debug no
+log_session yes
+log_stats no
+log_query no
+
+workers 2
+resolvers 1
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}
+
+storage "postgres_server" {
+	type "remote"
+	host "127.0.0.1"
+	port 5432
+}
+
+storage "local" {
+	type "local"
+}
+
+database "postgres" {
+	user "postgres" {
+		authentication "none"
+		storage "postgres_server"
+		pool "session"
+	}
+}
+
+database "console" {
+	user default {
+		authentication "none"
+		role "admin"
+		pool "session"
+		storage "local"
+	}
+}

--- a/test/functional/tests/show-config/runner.sh
+++ b/test/functional/tests/show-config/runner.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# SHOW CONFIG reports the configuration of the running process, not the
+# file on disk. RELOAD applies only part of the global configuration, so
+# editing odyssey.conf and reloading is not enough to tell what is in
+# effect - that is what this test checks.
+
+set -uex
+
+CONF=/tmp/show-config.conf
+cp /tests/show-config/conf.conf "$CONF"
+
+/usr/bin/odyssey "$CONF"
+sleep 1
+
+console() {
+	psql -h 127.0.0.1 -p 6432 -U console -d console \
+		--quiet --no-align --tuples-only -F '|' -c "$1"
+}
+
+value_of() {
+	console 'show config' | awk -F '|' -v key="$1" '$1 == key { print $2 }'
+}
+
+changeable_of() {
+	console 'show config' | awk -F '|' -v key="$1" '$1 == key { print $4 }'
+}
+
+expect() {
+	local what="$1" got="$2" want="$3"
+	if [ "$got" != "$want" ]; then
+		echo "$what: got '$got', expected '$want'" >&2
+		cat /var/log/odyssey.log >&2 || true
+		exit 1
+	fi
+}
+
+# the output is not empty
+test "$(console 'show config' | grep -c '|')" -gt 0 || {
+	echo "show config returned no rows" >&2
+	exit 1
+}
+
+# every row carries all four columns
+console 'show config' | awk -F '|' 'NF != 4 {
+	print "unexpected column count: " $0 > "/dev/stderr"; exit 1
+}'
+
+# changeable is a yes/no flag
+console 'show config' | awk -F '|' '$4 != "yes" && $4 != "no" {
+	print "unexpected changeable value: " $0 > "/dev/stderr"; exit 1
+}'
+
+# no value is left empty
+console 'show config' | awk -F '|' '$2 == "" || $3 == "" {
+	print "empty value or default: " $0 > "/dev/stderr"; exit 1
+}'
+
+# starting point, taken from conf.conf
+expect "log_debug value" "$(value_of log_debug)" "no"
+expect "log_debug changeable" "$(changeable_of log_debug)" "yes"
+expect "workers value" "$(value_of workers)" "2"
+expect "workers changeable" "$(changeable_of workers)" "no"
+
+# the file changes, RELOAD is not issued: the output must not follow
+sed -i 's/^log_debug no$/log_debug yes/' "$CONF"
+expect "log_debug before reload" "$(value_of log_debug)" "no"
+
+# RELOAD applies log_debug
+psql -h 127.0.0.1 -p 6432 -U console -d console -c 'reload'
+sleep 1
+expect "log_debug after reload" "$(value_of log_debug)" "yes"
+
+# RELOAD does not apply workers: the process keeps the old value and the
+# output has to show that
+sed -i 's/^workers 2$/workers 8/' "$CONF"
+psql -h 127.0.0.1 -p 6432 -U console -d console -c 'reload'
+sleep 1
+expect "workers after reload" "$(value_of workers)" "2"
+expect "workers changeable after reload" "$(changeable_of workers)" "no"
+
+# defaults come from od_config_init and do not depend on the file
+expect "workers default" \
+	"$(console 'show config' | awk -F '|' '$1 == "workers" { print $3 }')" "1"
+
+ody-stop


### PR DESCRIPTION
Closes #1532

Adds `SHOW CONFIG` to the admin console. For every global configuration
parameter it reports the name accepted by the configuration parser, the value
the running process is using, the built-in default, and whether `RELOAD`
applies a new value without a restart.

```
console=> show config;
             key             | value | default | changeable
-----------------------------+-------+---------+------------
 workers                     | 2     | 1       | no
 log_query                   | yes   | no      | yes
 ...
(57 rows)
```

The column set — `key`, `value`, `default`, `changeable` — matches
PgBouncer's `SHOW CONFIG`, so tooling written against it sees a familiar
shape.

### Why the command is not the same as reading odyssey.conf

`od_config_reload()` copies twenty fields into the running instance; the rest
keep the value the process started with, and `RELOAD` reports success either
way. The `changeable` column makes the difference visible, so comparing the
output against the file is enough to spot a parameter that needs a restart.

### Implementation notes

`od_config_fields[]` in `sources/config.c` describes each parameter by name,
type, offset inside `od_config_t` and reloadability. The console walks the
table and stays unaware of how the configuration is laid out.

Defaults are not stored in the table. `od_config_field_default()` initialises
a throwaway `od_config_t` through `od_config_init()` and reads the same
offset, so the reported defaults cannot drift away from the real ones, and
computed defaults such as `readahead` are reported correctly.

The `reloadable` flag has no such source and is kept in sync with
`od_config_reload()` by hand; there is a comment above the table saying so.

`od_config_print()` is left untouched. It could be rebuilt on the same table
later, but that would change the format of an existing log output, which
seems better kept out of this change.

### Credentials

`od_config_t` holds no secrets — passwords, SCRAM secrets and LDAP bind
credentials live in `od_rule_t` and are reported by `SHOW RULES`. This
addresses the condition raised in #210.

### Scope

Global scalar parameters only, 57 of them. Not included: the `listen`
section (`SHOW LISTEN`), the nested `soft_oom`, `query_parsing`,
`conn_drop_options` and `cpu_affinity` structures, and per-route settings
(`SHOW RULES`). Those are not key/value pairs and would not fit the same
output.

### Other changes

`SHOW HELP` did not list `RULES`, `FDS`, `IS_PAUSED`, `VERSION_EXTENDED`,
`GLOBAL_PREPARED_STATEMENTS`, `PAUSE` or `RESUME`, all of which the
dispatcher handles. Adding `CONFIG` to the same text made that obvious, so
the list is brought in line with the code. Happy to split this out if
preferred.

### Testing

`test/functional/tests/show-config/` covers three cases:

- the file changes and no `RELOAD` is issued — the output does not follow;
- `RELOAD` applies a reloadable parameter — the output changes;
- `RELOAD` does not apply `workers` — the output keeps the old value and
  `changeable` says `no`.

Plus output shape: four columns on every row, `changeable` is `yes` or `no`,
no empty values, defaults independent of the file.

Values longer than 255 characters are truncated; this is documented.

`docs/features/console.md` describes the command, the columns, the truncation
limit, and the one parameter whose default is derived from another
(`client_max_routing` becomes `workers * 64` when unset).
