### PR TITLE
listen-level balancing_method override

### DIFF
--- a/docs/configuration/listen.md
+++ b/docs/configuration/listen.md
@@ -129,6 +129,20 @@ host is primary or not.
 
 `target_session_attrs "read-write"`
 
+## **balancing_method**
+*string*
+
+Overrides the load-balancing strategy for this listen endpoint. When not set,
+the balancing method configured on the matched storage is used. See
+[balancing](../features/balancing.md) for details.
+
+Possible values are:
+
+- roundrobin - distribute connections across endpoints in round-robin order (default)
+- leastconn - select the endpoint with the fewest active connections
+
+`balancing_method "leastconn"`
+
 ## **client_login_timeout**
 *integer*
 

--- a/docs/features/balancing.md
+++ b/docs/features/balancing.md
@@ -43,3 +43,20 @@ Endpoints with equals target session attributes will be tried third.
 The pools in unique per each endpoint in host, so if you set `pool_size` to 10,
 you will get 10 pools per each host, and if there is 3 hosts, you will get 30
 total connections.
+
+## Per-listen override
+
+The balancing method can be overridden per listen endpoint using
+[`balancing_method`](../configuration/listen.md#balancing_method) in the
+`listen` section. When set, it takes precedence over the storage-level
+`balancing { method ... }` configuration, while the round-robin counter and
+other shared state remain in the storage, ensuring fair distribution across
+all listeners that reference the same storage.
+
+```
+listen {
+    host "*"
+    port 6432
+    balancing_method "leastconn"
+}
+```

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -410,6 +410,14 @@ listen {
 #
 #	target_session_attrs "read-write"
 #
+#   balancing_method
+#   Override the load balancing strategy for this listen. When not set, the
+#   storage-level balancing method is used. Supported values:
+#     roundrobin   - round-robin among endpoints (default)
+#     leastconn    - pick endpoint with least active connections
+#
+#	balancing_method "roundrobin"
+#
 
 
 #

--- a/sources/backend.c
+++ b/sources/backend.c
@@ -519,7 +519,7 @@ int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
 			return -1;
 		}
 	}
-	od_unreachable();
+	OD_UNREACHABLE();
 	return 0;
 }
 

--- a/sources/balancing.c
+++ b/sources/balancing.c
@@ -7,6 +7,8 @@
 #include <multi_pool.h>
 #include <route.h>
 #include <util.h>
+#include <client.h>
+#include <config.h>
 
 #define METHOD_RR_STR "roundrobin"
 #define METHOD_LEASTCONN_STR "leastconn"
@@ -42,6 +44,26 @@ od_balancing_method_t od_balancing_method_from_str(const char *str, size_t len)
 	}
 
 	return OD_BALANCING_METHOD_UNDEF;
+}
+
+const char *od_balancing_method_to_str(od_balancing_method_t method)
+{
+	switch (method) {
+	case OD_BALANCING_METHOD_ROUNDROBIN:
+		return METHOD_RR_STR;
+	case OD_BALANCING_METHOD_LEASTCONN:
+		return METHOD_LEASTCONN_STR;
+	case OD_BALANCING_METHOD_WEIGHTED:
+		return METHOD_WEIGHTED_STR;
+	case OD_BALANCING_METHOD_WEIGHTED_LEASTCONN:
+		return METHOD_WEIGHTED_LEASTCONN;
+	case OD_BALANCING_METHOD_RESPONSETIME:
+		return METHOD_RESPONSETIME;
+	case OD_BALANCING_METHOD_UNDEF:
+		return "no specified";
+	default:
+		od_abort();
+	}
 }
 
 void od_storage_balancing_init(od_storage_balancing_t *b)
@@ -298,6 +320,7 @@ static size_t responsetime(od_storage_balancing_t *b, od_route_t *route,
 }
 
 size_t od_storage_balancing_select(od_storage_balancing_t *b,
+				   od_balancing_method_t override_method,
 				   od_rule_storage_t *storage,
 				   od_route_t *route,
 				   od_storage_endpoint_t **out, size_t max,
@@ -312,7 +335,12 @@ size_t od_storage_balancing_select(od_storage_balancing_t *b,
 		return 1;
 	}
 
-	switch (b->method.type) {
+	od_balancing_method_t method =
+		(override_method != OD_BALANCING_METHOD_UNDEF) ?
+			override_method :
+			b->method.type;
+
+	switch (method) {
 	case OD_BALANCING_METHOD_UNDEF:
 	case OD_BALANCING_METHOD_ROUNDROBIN:
 		return roundrobin(b, storage, out, max, filter, arg);
@@ -327,4 +355,22 @@ size_t od_storage_balancing_select(od_storage_balancing_t *b,
 	default:
 		abort();
 	}
+}
+
+od_balancing_method_t od_balancing_get_effective(od_client_t *client,
+						 od_rule_storage_t *storage)
+{
+	od_config_listen_t *l = client->config_listen;
+
+	if (l == NULL) {
+		return storage->balancing.method.type;
+	}
+
+	od_balancing_method_t listen_method = l->balancing_method;
+
+	if (listen_method != OD_BALANCING_METHOD_UNDEF) {
+		return listen_method;
+	}
+
+	return storage->balancing.method.type;
 }

--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -101,6 +101,30 @@ static int parse_tsa(const char *s, od_target_session_attrs_t *out)
 		}                                                                     \
 	} while (0)
 
+static int parse_balance_method(const char *s, od_balancing_method_t *out)
+{
+	od_balancing_method_t m = od_balancing_method_from_str(s, strlen(s));
+	if (m == OD_BALANCING_METHOD_UNDEF) {
+		return 1;
+	}
+	*out = m;
+	return 0;
+}
+
+#define COPY_BALANCE_METHOD(field, out, diags)                                    \
+	do {                                                                      \
+		if ((field).seen.is_set) {                                        \
+			int rc = parse_balance_method((field).value, &out);       \
+			if (rc) {                                                 \
+				od_cfg_diag_error(                                \
+					diags, (field).seen.location,             \
+					"can't parse balancing method from '%s'", \
+					(field).value);                           \
+				goto error;                                       \
+			}                                                         \
+		}                                                                 \
+	} while (0)
+
 static inline void ldap_not_supported(od_cfg_diag_list_t *diags,
 				      od_cfg_location_t location)
 	__attribute__((unused));
@@ -1011,6 +1035,8 @@ static int convert_listen(convert_ctx_t *ctx, const od_cfg_listen_t *cfg)
 	COPY_INT(cfg->port, listen->port);
 	COPY_TSA(cfg->target_session_attrs, listen->target_session_attrs,
 		 diags);
+	COPY_BALANCE_METHOD(cfg->balancing_method, listen->balancing_method,
+			    diags);
 	COPY_INT(cfg->client_login_timeout, listen->client_login_timeout);
 	COPY_INT(cfg->catchup_timeout, listen->catchup_timeout);
 	COPY_INT(cfg->backlog, listen->backlog);

--- a/sources/cfg/keywords.c
+++ b/sources/cfg/keywords.c
@@ -85,6 +85,7 @@ static const od_cfg_keyword_t keywords[] = {
 	{ "host", HOST },
 	{ "port", PORT },
 	{ "target_session_attrs", TARGET_SESSION_ATTRS },
+	{ "balancing_method", BALANCING_METHOD },
 	{ "client_login_timeout", CLIENT_LOGIN_TIMEOUT },
 	{ "backlog", BACKLOG },
 	{ "tls", TLS },

--- a/sources/cfg/model.c
+++ b/sources/cfg/model.c
@@ -82,6 +82,7 @@ static void dump_listen(FILE *file, const od_cfg_listen_t *l)
 	dump_string(file, "host", 1, &l->host);
 	dump_int(file, "port", 1, &l->port);
 	dump_string(file, "target_session_attrs", 1, &l->target_session_attrs);
+	dump_string(file, "balancing_method", 1, &l->balancing_method);
 	dump_int(file, "client_login_timeout", 1, &l->client_login_timeout);
 	dump_int(file, "backlog", 1, &l->backlog);
 	dump_string(file, "tls", 1, &l->tls);
@@ -575,6 +576,7 @@ static void od_cfg_listen_free(od_cfg_listen_t *listen)
 	od_cfg_string_field_free(&listen->host);
 	od_cfg_int_field_free(&listen->port);
 	od_cfg_string_field_free(&listen->target_session_attrs);
+	od_cfg_string_field_free(&listen->balancing_method);
 	od_cfg_int_field_free(&listen->client_login_timeout);
 	od_cfg_int_field_free(&listen->backlog);
 	od_cfg_string_field_free(&listen->tls);

--- a/sources/cfg/parse.y
+++ b/sources/cfg/parse.y
@@ -205,6 +205,7 @@
 %token HOST "host"
 %token PORT "port"
 %token TARGET_SESSION_ATTRS "target_session_attrs"
+%token BALANCING_METHOD "balancing_method"
 %token CLIENT_LOGIN_TIMEOUT "client_login_timeout"
 %token BACKLOG "backlog"
 %token TLS "tls"
@@ -2310,6 +2311,15 @@ listen_item:
 							  $2,
 							  @1,
 							  "target_session_attrs");
+			$2 = NULL;
+		}
+	| BALANCING_METHOD string_value
+		{
+			od_cfg_set_string(ctx->diags,
+							  &ctx->current_listen->balancing_method,
+							  $2,
+							  @1,
+							  "balancing_method");
 			$2 = NULL;
 		}
 	| CLIENT_LOGIN_TIMEOUT int_value

--- a/sources/config.c
+++ b/sources/config.c
@@ -202,6 +202,7 @@ od_config_listen_t *od_config_listen_add(od_config_t *config)
 	listen->backlog = 128;
 	listen->client_login_timeout = 15000;
 	listen->target_session_attrs = OD_TARGET_SESSION_ATTRS_UNDEF;
+	listen->balancing_method = OD_BALANCING_METHOD_UNDEF;
 
 	od_list_init(&listen->link);
 	od_list_append(&config->listen, &listen->link);
@@ -511,6 +512,8 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 		       "  target_session_attrs %s",
 		       od_target_session_attrs_to_str(
 			       listen->target_session_attrs));
+		od_log(logger, "config", NULL, NULL, "  balancing_method %s",
+		       od_balancing_method_to_str(listen->balancing_method));
 		if (listen->catchup_timeout) {
 			od_log(logger, "config", NULL, NULL,
 			       "  catchup_timeout %d", listen->catchup_timeout);

--- a/sources/console.c
+++ b/sources/console.c
@@ -2476,9 +2476,9 @@ static inline int od_console_create(od_client_t *client, machine_msg_t *stream,
 	return NOT_OK_RESPONSE;
 }
 
-static inline int od_console_drop_server_cb(od_server_t *server,
-					    od_attribute_unused() void **argv)
+static inline int od_console_drop_server_cb(od_server_t *server, void **argv)
 {
+	(void)argv;
 	server->offline = 1;
 	return OK_RESPONSE;
 }

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -793,8 +793,10 @@ static od_frontend_status_t attach_with_storage(od_client_t *client,
 
 	od_storage_endpoint_t *endpoints[OD_STORAGE_MAX_ENDPOINTS];
 	size_t count;
+	od_balancing_method_t bal_method =
+		od_balancing_get_effective(client, storage);
 	count = od_storage_balancing_select(
-		&storage->balancing, storage, route, endpoints,
+		&storage->balancing, bal_method, storage, route, endpoints,
 		sizeof(endpoints) / sizeof(endpoints[0]), host_filter, &arg);
 
 	if (tsa == OD_TARGET_SESSION_ATTRS_PREFER_STANDBY && count > 1) {

--- a/sources/include/balancing.h
+++ b/sources/include/balancing.h
@@ -17,6 +17,8 @@ typedef enum {
 
 od_balancing_method_t od_balancing_method_from_str(const char *str, size_t len);
 
+const char *od_balancing_method_to_str(od_balancing_method_t method);
+
 typedef struct {
 	/*
 	 * high 32 bit is counter for local endpoints
@@ -50,12 +52,10 @@ typedef struct {
 	struct {
 		od_balancing_method_t type;
 		int az_aware;
-		union {
-			od_method_roundroubin_t roundrobin;
-			od_method_weighted_t weighted;
-			od_method_weighted_leastconn_t weighted_leastconn;
-			od_method_responsetime_t responsetime;
-		};
+		od_method_roundroubin_t roundrobin;
+		od_method_weighted_t weighted;
+		od_method_weighted_leastconn_t weighted_leastconn;
+		od_method_responsetime_t responsetime;
 	} method;
 
 	int debug_notice;
@@ -70,7 +70,11 @@ void od_storage_balancing_copy(od_storage_balancing_t *dest,
 			       const od_storage_balancing_t *src);
 
 size_t od_storage_balancing_select(od_storage_balancing_t *b,
+				   od_balancing_method_t override_method,
 				   od_rule_storage_t *storage,
 				   od_route_t *route,
 				   od_storage_endpoint_t **out, size_t max,
 				   od_balancing_filter_fn filter, void *arg);
+
+od_balancing_method_t od_balancing_get_effective(od_client_t *client,
+						 od_rule_storage_t *storage);

--- a/sources/include/cfg/model.h
+++ b/sources/include/cfg/model.h
@@ -116,6 +116,7 @@ typedef struct od_cfg_listen {
 	od_cfg_string_field_t host;
 	od_cfg_int_field_t port;
 	od_cfg_string_field_t target_session_attrs;
+	od_cfg_string_field_t balancing_method;
 
 	od_cfg_int_field_t client_login_timeout;
 	od_cfg_int_field_t backlog;

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -9,6 +9,7 @@
 #include <tls_config.h>
 #include <list.h>
 #include <tsa.h>
+#include <balancing.h>
 #include <types.h>
 #include <affinity.h>
 #include <logger.h>
@@ -32,6 +33,7 @@ struct od_config_listen {
 	od_list_t link;
 
 	od_target_session_attrs_t target_session_attrs;
+	od_balancing_method_t balancing_method;
 	int catchup_timeout;
 
 	char **storage_names;

--- a/sources/include/od_assert.h
+++ b/sources/include/od_assert.h
@@ -14,7 +14,7 @@
  * stderr is unavailable
  */
 
-#include <stdlib.h>
+#include <od_c.h>
 
 extern void od_assert_fail(const char *expr, const char *file, int line);
 
@@ -35,3 +35,5 @@ extern void od_assert_fail(const char *expr, const char *file, int line);
 			od_assert_fail(#expr, __FILE__, __LINE__); \
 		}                                                  \
 	} while (0)
+
+OD_NORETURN void od_abort(void);

--- a/sources/include/od_c.h
+++ b/sources/include/od_c.h
@@ -11,7 +11,6 @@
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <od_assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <limits.h>
@@ -55,31 +54,15 @@ typedef int od_retcode_t;
 
 #define INVALID_COROUTINE_ID -1
 
-/* only GCC supports the unused attribute */
-#ifdef __GNUC__
-#define od_attribute_unused() __attribute__((unused))
+#if defined(__GNUC__) || defined(__clang__)
+#define OD_NORETURN __attribute__((noreturn))
+#define OD_UNREACHABLE() __builtin_unreachable()
 #else
-#define od_attribute_unused()
-#endif
-
-/* GCC support aligned, packed and noreturn */
-#ifdef __GNUC__
-#define od_attribute_aligned(a) __attribute__((aligned(a)))
-#define od_attribute_noreturn() __attribute__((noreturn))
-#define od_attribute_packed() __attribute__((packed))
+#define OD_NORETURN
+#define OD_UNREACHABLE() abort()
 #endif
 
 #define FLEXIBLE_ARRAY_MEMBER /* empty */
-
-#if defined __has_builtin
-#if __has_builtin(__builtin_unreachable) /* odyssey unreachable code */
-#define od_unreachable() __builtin_unreachable()
-#endif
-#endif
-
-#ifndef od_unreachable
-#define od_unreachable() abort()
-#endif
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #define OD_THREAD_LOCAL thread_local
@@ -147,3 +130,6 @@ static inline void od_explicit_bzero(void *buf, size_t len)
 #if !defined(explicit_bzero)
 #define explicit_bzero od_explicit_bzero
 #endif
+
+/* included there, because it uses some macroses from this file */
+#include <od_assert.h>

--- a/sources/od_assert.c
+++ b/sources/od_assert.c
@@ -79,3 +79,9 @@ void od_assert_fail(const char *expr, const char *file, int line)
 
 	abort();
 }
+
+void od_abort(void)
+{
+	od_release_assert(0);
+	OD_UNREACHABLE();
+}

--- a/test/pg_regress/conf/listen_balancer
+++ b/test/pg_regress/conf/listen_balancer
@@ -1,0 +1,107 @@
+daemonize yes
+
+log_format "%p %t %l [%i %s] (%c) %m\n"
+
+log_to_stdout no
+
+log_syslog no
+log_syslog_ident "odyssey"
+log_syslog_facility "daemon"
+
+log_debug no
+log_config no
+log_session no
+log_query no
+log_stats no
+log_file "/tmp/odyssey.log"
+stats_interval 60
+
+workers 1
+resolvers 1
+
+readahead 4096
+
+cache_coroutine 0
+
+
+nodelay yes
+
+keepalive 15
+keepalive_keep_interval 75
+keepalive_probes 9
+
+keepalive_usr_timeout 0
+
+virtual_processing yes
+
+listen {
+	host "*"
+	port 6432
+	backlog 128
+	tls "disable"
+}
+
+listen {
+	host "*"
+	port 7432
+	backlog 128
+	tls "disable"
+	balancing_method "leastconn"
+}
+
+storage "rr-hosts" {
+	type "remote"
+	host "localhost:5432,localhost:5433,localhost:5434"
+	endpoints_status_poll_interval 5000
+	balancing {
+		method "roundrobin" {}
+		show_notice_messages yes
+	}
+}
+
+database "postgres" {
+	user "rruser" {
+		authentication "none"
+		storage "rr-hosts"
+		storage_user "postgres"
+		pool "transaction"
+		pool_size 32
+		pool_timeout 1000
+		client_show_id no
+	}
+
+	user "lcuser" {
+		authentication "none"
+		storage "rr-hosts"
+		storage_user "postgres"
+		pool "transaction"
+		pool_size 32
+		pool_timeout 1000
+		client_show_id no
+	}
+
+	user "postgres" {
+		authentication "none"
+		storage "rr-hosts"
+		storage_user "postgres"
+		pool "transaction"
+		pool_size 32
+		pool_timeout 1000
+		client_show_id no
+	}
+}
+
+storage "local" {
+	type "local"
+}
+
+database "console" {
+	user default {
+		authentication "none"
+		role "admin"
+		pool "session"
+		storage "local"
+	}
+}
+
+bindwith_reuseport yes

--- a/test/pg_regress/entrypoint.sh
+++ b/test/pg_regress/entrypoint.sh
@@ -79,6 +79,8 @@ do_test broken_conn 6432 tuser
 
 do_test balancer 6432 postgres
 
+do_test listen_balancer 6432 postgres
+
 do_test tsa 6432 postgres
 
 do_test az_aware 6432 postgres

--- a/test/pg_regress/schedule/listen_balancer
+++ b/test/pg_regress/schedule/listen_balancer
@@ -1,0 +1,2 @@
+test: listen_rr_default
+test: listen_leastconn_override

--- a/test/pg_regress/tests/listen_balancer/expected/listen_leastconn_override.out
+++ b/test/pg_regress/tests/listen_balancer/expected/listen_leastconn_override.out
@@ -1,0 +1,64 @@
+\connect 'host=localhost port=7432 user=lcuser dbname=postgres'
+select 42;
+NOTICE:  select host tcp://localhost:5433
+ ?column? 
+----------
+       42
+(1 row)
+
+select 43;
+NOTICE:  select host tcp://localhost:5434
+ ?column? 
+----------
+       43
+(1 row)
+
+select 44;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       44
+(1 row)
+
+select 45;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       45
+(1 row)
+
+select 46;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       46
+(1 row)
+
+select 47;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       47
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       67
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       67
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       67
+(1 row)
+

--- a/test/pg_regress/tests/listen_balancer/expected/listen_rr_default.out
+++ b/test/pg_regress/tests/listen_balancer/expected/listen_rr_default.out
@@ -1,0 +1,64 @@
+\connect 'host=localhost port=6432 user=rruser dbname=postgres'
+select 42;
+NOTICE:  select host tcp://localhost:5434
+ ?column? 
+----------
+       42
+(1 row)
+
+select 43;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       43
+(1 row)
+
+select 44;
+NOTICE:  select host tcp://localhost:5433
+ ?column? 
+----------
+       44
+(1 row)
+
+select 45;
+NOTICE:  select host tcp://localhost:5434
+ ?column? 
+----------
+       45
+(1 row)
+
+select 46;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       46
+(1 row)
+
+select 47;
+NOTICE:  select host tcp://localhost:5433
+ ?column? 
+----------
+       47
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5434
+ ?column? 
+----------
+       67
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5432
+ ?column? 
+----------
+       67
+(1 row)
+
+select 67;
+NOTICE:  select host tcp://localhost:5433
+ ?column? 
+----------
+       67
+(1 row)
+

--- a/test/pg_regress/tests/listen_balancer/sql/listen_leastconn_override.sql
+++ b/test/pg_regress/tests/listen_balancer/sql/listen_leastconn_override.sql
@@ -1,0 +1,11 @@
+\connect 'host=localhost port=7432 user=lcuser dbname=postgres'
+
+select 42;
+select 43;
+select 44;
+select 45;
+select 46;
+select 47;
+select 67;
+select 67;
+select 67;

--- a/test/pg_regress/tests/listen_balancer/sql/listen_rr_default.sql
+++ b/test/pg_regress/tests/listen_balancer/sql/listen_rr_default.sql
@@ -1,0 +1,11 @@
+\connect 'host=localhost port=6432 user=rruser dbname=postgres'
+
+select 42;
+select 43;
+select 44;
+select 45;
+select 46;
+select 47;
+select 67;
+select 67;
+select 67;


### PR DESCRIPTION
Add the ability to override the load-balancing strategy per listen endpoint, similarly to target_session_attrs. When `balancing_method` is set on a listen, it takes precedence over the storage-level `balancing { method ... }` configuration, while the round-robin counter and other shared state remain in the storage, ensuring fair distribution across all listeners referencing the same storage.