### PR TITLE
listen-level balancing section override

### DIFF
--- a/docs/configuration/listen.md
+++ b/docs/configuration/listen.md
@@ -129,19 +129,25 @@ host is primary or not.
 
 `target_session_attrs "read-write"`
 
-## **balancing_method**
-*string*
+## **balancing**
 
-Overrides the load-balancing strategy for this listen endpoint. When not set,
-the balancing method configured on the matched storage is used. See
-[balancing](../features/balancing.md) for details.
+Optional sub-section that overrides the load-balancing behaviour for this
+listen endpoint. When not set, the `balancing` section configured on the
+matched storage is used. See [balancing](../features/balancing.md) for
+details on the available methods and options.
 
-Possible values are:
-
-- roundrobin - distribute connections across endpoints in round-robin order (default)
-- leastconn - select the endpoint with the fewest active connections
-
-`balancing_method "leastconn"`
+```plain
+listen {
+    host "*"
+    port 6432
+    balancing {
+        method "leastconn" {
+            az_aware no
+        }
+        show_notice_messages yes
+    }
+}
+```
 
 ## **client_login_timeout**
 *integer*

--- a/docs/features/balancing.md
+++ b/docs/features/balancing.md
@@ -46,17 +46,22 @@ total connections.
 
 ## Per-listen override
 
-The balancing method can be overridden per listen endpoint using
-[`balancing_method`](../configuration/listen.md#balancing_method) in the
-`listen` section. When set, it takes precedence over the storage-level
-`balancing { method ... }` configuration, while the round-robin counter and
-other shared state remain in the storage, ensuring fair distribution across
-all listeners that reference the same storage.
+The entire `balancing` section can be overridden per listen endpoint using
+[`balancing`](../configuration/listen.md#balancing) in the `listen` section.
+When set, it takes precedence over the storage-level `balancing` configuration,
+while the round-robin counter and other shared state remain in the storage,
+ensuring fair distribution across all listeners that reference the same
+storage.
 
 ```
 listen {
     host "*"
     port 6432
-    balancing_method "leastconn"
+    balancing {
+        method "leastconn" {
+            az_aware no
+        }
+        show_notice_messages yes
+    }
 }
 ```

--- a/odyssey.conf
+++ b/odyssey.conf
@@ -410,13 +410,17 @@ listen {
 #
 #	target_session_attrs "read-write"
 #
-#   balancing_method
-#   Override the load balancing strategy for this listen. When not set, the
-#   storage-level balancing method is used. Supported values:
-#     roundrobin   - round-robin among endpoints (default)
-#     leastconn    - pick endpoint with least active connections
+#   balancing
+#   Override the load balancing behaviour for this listen. When not set,
+#   the storage-level balancing section is used. See the balancing docs
+#   for available methods and options.
 #
-#	balancing_method "roundrobin"
+#	balancing {
+#		method "roundrobin" {
+#			az_aware no
+#		}
+#		show_notice_messages yes
+#	}
 #
 
 

--- a/sources/balancing.c
+++ b/sources/balancing.c
@@ -149,8 +149,14 @@ static size_t roundrobin(od_storage_balancing_t *b, od_rule_storage_t *storage,
 
 	od_instance_t *instance = od_global_get_instance();
 
+	/*
+	 * round-robin counter always comes from the storage so that
+	 * multiple listen endpoints referencing the same storage share it,
+	 * ensuring fair distribution. az_aware flag (and any other
+	 * per-listen override) is taken from the effective balancing struct
+	 */
 	uint32_t local, global;
-	rr_next(&b->method.roundrobin, &local, &global);
+	rr_next(&storage->balancing.method.roundrobin, &local, &global);
 
 	size_t count = 0;
 	for (size_t i = 0; i < storage->endpoints_count && count < max; ++i) {
@@ -320,7 +326,6 @@ static size_t responsetime(od_storage_balancing_t *b, od_route_t *route,
 }
 
 size_t od_storage_balancing_select(od_storage_balancing_t *b,
-				   od_balancing_method_t override_method,
 				   od_rule_storage_t *storage,
 				   od_route_t *route,
 				   od_storage_endpoint_t **out, size_t max,
@@ -335,12 +340,7 @@ size_t od_storage_balancing_select(od_storage_balancing_t *b,
 		return 1;
 	}
 
-	od_balancing_method_t method =
-		(override_method != OD_BALANCING_METHOD_UNDEF) ?
-			override_method :
-			b->method.type;
-
-	switch (method) {
+	switch (b->method.type) {
 	case OD_BALANCING_METHOD_UNDEF:
 	case OD_BALANCING_METHOD_ROUNDROBIN:
 		return roundrobin(b, storage, out, max, filter, arg);
@@ -357,20 +357,14 @@ size_t od_storage_balancing_select(od_storage_balancing_t *b,
 	}
 }
 
-od_balancing_method_t od_balancing_get_effective(od_client_t *client,
-						 od_rule_storage_t *storage)
+od_storage_balancing_t *od_balancing_get_effective(od_client_t *client,
+						   od_rule_storage_t *storage)
 {
 	od_config_listen_t *l = client->config_listen;
 
-	if (l == NULL) {
-		return storage->balancing.method.type;
+	if (l != NULL && l->balancing_override_set) {
+		return &l->balancing_override;
 	}
 
-	od_balancing_method_t listen_method = l->balancing_method;
-
-	if (listen_method != OD_BALANCING_METHOD_UNDEF) {
-		return listen_method;
-	}
-
-	return storage->balancing.method.type;
+	return &storage->balancing;
 }

--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -101,29 +101,43 @@ static int parse_tsa(const char *s, od_target_session_attrs_t *out)
 		}                                                                     \
 	} while (0)
 
-static int parse_balance_method(const char *s, od_balancing_method_t *out)
+static int convert_balancing(const od_cfg_balancing_t *cfg,
+			     od_storage_balancing_t *out,
+			     od_cfg_diag_list_t *diags)
 {
-	od_balancing_method_t m = od_balancing_method_from_str(s, strlen(s));
-	if (m == OD_BALANCING_METHOD_UNDEF) {
-		return 1;
+	od_storage_balancing_init(out);
+
+	if (!cfg->seen.is_set) {
+		return 0;
 	}
-	*out = m;
+
+	if (cfg->method.seen.is_set) {
+		int mlen = (int)strlen(cfg->method.name);
+		od_balancing_method_t method =
+			od_balancing_method_from_str(cfg->method.name, mlen);
+		if (method == OD_BALANCING_METHOD_UNDEF) {
+			od_cfg_diag_error(diags, cfg->method.seen.location,
+					  "unexpected balancing method '%s'",
+					  cfg->method.name);
+			return -1;
+		}
+
+		if (method != OD_BALANCING_METHOD_ROUNDROBIN &&
+		    method != OD_BALANCING_METHOD_LEASTCONN) {
+			od_cfg_diag_error(
+				diags, cfg->method.seen.location,
+				"not implemented balancing method '%s'",
+				cfg->method.name);
+			return -1;
+		}
+
+		out->method.type = method;
+		COPY_BOOL(cfg->method.az_aware, out->method.az_aware);
+	}
+
+	COPY_BOOL(cfg->show_notice_messages, out->debug_notice);
 	return 0;
 }
-
-#define COPY_BALANCE_METHOD(field, out, diags)                                    \
-	do {                                                                      \
-		if ((field).seen.is_set) {                                        \
-			int rc = parse_balance_method((field).value, &out);       \
-			if (rc) {                                                 \
-				od_cfg_diag_error(                                \
-					diags, (field).seen.location,             \
-					"can't parse balancing method from '%s'", \
-					(field).value);                           \
-				goto error;                                       \
-			}                                                         \
-		}                                                                 \
-	} while (0)
 
 static inline void ldap_not_supported(od_cfg_diag_list_t *diags,
 				      od_cfg_location_t location)
@@ -1035,8 +1049,14 @@ static int convert_listen(convert_ctx_t *ctx, const od_cfg_listen_t *cfg)
 	COPY_INT(cfg->port, listen->port);
 	COPY_TSA(cfg->target_session_attrs, listen->target_session_attrs,
 		 diags);
-	COPY_BALANCE_METHOD(cfg->balancing_method, listen->balancing_method,
-			    diags);
+	{
+		int rc = convert_balancing(&cfg->balancing,
+					   &listen->balancing_override, diags);
+		if (rc != 0) {
+			goto error;
+		}
+		listen->balancing_override_set = cfg->balancing.seen.is_set;
+	}
 	COPY_INT(cfg->client_login_timeout, listen->client_login_timeout);
 	COPY_INT(cfg->catchup_timeout, listen->catchup_timeout);
 	COPY_INT(cfg->backlog, listen->backlog);
@@ -1186,38 +1206,12 @@ static int convert_storage(const od_cfg_storage_t *cfg, od_list_t *spools,
 		}
 	}
 
-	if (cfg->balancing.seen.is_set) {
-		if (cfg->balancing.method.seen.is_set) {
-			int mlen = (int)strlen(cfg->balancing.method.name);
-			od_balancing_method_t method =
-				od_balancing_method_from_str(
-					cfg->balancing.method.name, mlen);
-			if (method == OD_BALANCING_METHOD_UNDEF) {
-				od_cfg_diag_error(
-					diags,
-					cfg->balancing.method.seen.location,
-					"unexpected balancing method '%s'",
-					cfg->balancing.method.name);
-				goto error;
-			}
-
-			if (method != OD_BALANCING_METHOD_ROUNDROBIN &&
-			    method != OD_BALANCING_METHOD_LEASTCONN) {
-				od_cfg_diag_error(
-					diags,
-					cfg->balancing.method.seen.location,
-					"not implemented balancing method '%s'",
-					cfg->balancing.method.name);
-				goto error;
-			}
-
-			storage->balancing.method.type = method;
-			COPY_BOOL(cfg->balancing.method.az_aware,
-				  storage->balancing.method.az_aware);
+	{
+		int rc = convert_balancing(&cfg->balancing, &storage->balancing,
+					   diags);
+		if (rc != 0) {
+			goto error;
 		}
-
-		COPY_BOOL(cfg->balancing.show_notice_messages,
-			  storage->balancing.debug_notice);
 	}
 
 	if (cfg->watchdog != NULL) {

--- a/sources/cfg/keywords.c
+++ b/sources/cfg/keywords.c
@@ -85,7 +85,6 @@ static const od_cfg_keyword_t keywords[] = {
 	{ "host", HOST },
 	{ "port", PORT },
 	{ "target_session_attrs", TARGET_SESSION_ATTRS },
-	{ "balancing_method", BALANCING_METHOD },
 	{ "client_login_timeout", CLIENT_LOGIN_TIMEOUT },
 	{ "backlog", BACKLOG },
 	{ "tls", TLS },

--- a/sources/cfg/model.c
+++ b/sources/cfg/model.c
@@ -76,13 +76,31 @@ static void dump_conn_drop(FILE *file, const od_cfg_conn_drop_options_t *cd)
 	}
 }
 
+static void dump_balancing(FILE *file, int indent, const od_cfg_balancing_t *b)
+{
+	if (!b->seen.is_set) {
+		return;
+	}
+
+	fprintf(file, "%*sbalancing {\n", indent, "");
+	if (b->method.seen.is_set) {
+		fprintf(file, "%*smethod \"%s\" {\n", indent + 1, "",
+			b->method.name);
+		dump_bool(file, "az_aware", indent + 2, &b->method.az_aware);
+		fprintf(file, "%*s}\n", indent + 1, "");
+	}
+	dump_bool(file, "show_notice_messages", indent + 1,
+		  &b->show_notice_messages);
+	fprintf(file, "%*s}\n", indent, "");
+}
+
 static void dump_listen(FILE *file, const od_cfg_listen_t *l)
 {
 	fprintf(file, "listen {\n");
 	dump_string(file, "host", 1, &l->host);
 	dump_int(file, "port", 1, &l->port);
 	dump_string(file, "target_session_attrs", 1, &l->target_session_attrs);
-	dump_string(file, "balancing_method", 1, &l->balancing_method);
+	dump_balancing(file, 1, &l->balancing);
 	dump_int(file, "client_login_timeout", 1, &l->client_login_timeout);
 	dump_int(file, "backlog", 1, &l->backlog);
 	dump_string(file, "tls", 1, &l->tls);
@@ -112,16 +130,7 @@ static void dump_storage(FILE *file, const od_cfg_storage_t *s)
 	dump_int(file, "endpoints_status_poll_interval_ms", 1,
 		 &s->endpoints_status_poll_interval_ms);
 
-	if (s->balancing.seen.is_set) {
-		fprintf(file, "\tbalancing {\n");
-		if (s->balancing.method.seen.is_set) {
-			fprintf(file, "\t\tmethod \"%s\" {}\n",
-				s->balancing.method.name);
-		}
-		dump_bool(file, "show_notice_messages", 2,
-			  &s->balancing.show_notice_messages);
-		fprintf(file, "\t}\n");
-	}
+	dump_balancing(file, 1, &s->balancing);
 
 	if (s->watchdog != NULL) {
 		dump_user(file, "watchdog", s->watchdog);
@@ -567,6 +576,17 @@ od_cfg_listen_storage_t *od_cfg_listen_add_storage(od_cfg_listen_t *listen,
 	return storage;
 }
 
+static void od_cfg_balancing_free(od_cfg_balancing_t *b)
+{
+	od_cfg_seen_free(&b->seen);
+	od_cfg_location_free(&b->location);
+	od_cfg_bool_field_free(&b->show_notice_messages);
+	od_cfg_seen_free(&b->method.seen);
+	od_cfg_location_free(&b->method.location);
+	od_cfg_bool_field_free(&b->method.az_aware);
+	od_free(b->method.name);
+}
+
 static void od_cfg_listen_free(od_cfg_listen_t *listen)
 {
 	if (listen == NULL) {
@@ -576,7 +596,7 @@ static void od_cfg_listen_free(od_cfg_listen_t *listen)
 	od_cfg_string_field_free(&listen->host);
 	od_cfg_int_field_free(&listen->port);
 	od_cfg_string_field_free(&listen->target_session_attrs);
-	od_cfg_string_field_free(&listen->balancing_method);
+	od_cfg_balancing_free(&listen->balancing);
 	od_cfg_int_field_free(&listen->client_login_timeout);
 	od_cfg_int_field_free(&listen->backlog);
 	od_cfg_string_field_free(&listen->tls);
@@ -623,13 +643,7 @@ static void od_cfg_storage_free(od_cfg_storage_t *storage)
 	od_cfg_int_field_free(&storage->server_max_routing);
 	od_cfg_int_field_free(&storage->endpoints_status_poll_interval_ms);
 
-	od_cfg_seen_free(&storage->balancing.seen);
-	od_cfg_location_free(&storage->balancing.location);
-	od_cfg_bool_field_free(&storage->balancing.show_notice_messages);
-	od_cfg_seen_free(&storage->balancing.method.seen);
-	od_cfg_location_free(&storage->balancing.method.location);
-	od_cfg_bool_field_free(&storage->balancing.method.az_aware);
-	od_free(storage->balancing.method.name);
+	od_cfg_balancing_free(&storage->balancing);
 
 	od_cfg_location_free(&storage->location);
 	od_cfg_location_free(&storage->name_location);

--- a/sources/cfg/parse.y
+++ b/sources/cfg/parse.y
@@ -205,7 +205,6 @@
 %token HOST "host"
 %token PORT "port"
 %token TARGET_SESSION_ATTRS "target_session_attrs"
-%token BALANCING_METHOD "balancing_method"
 %token CLIENT_LOGIN_TIMEOUT "client_login_timeout"
 %token BACKLOG "backlog"
 %token TLS "tls"
@@ -2174,31 +2173,42 @@ storage_item:
 			ctx->current_watchdog = NULL;
 			ctx->current_user = NULL;
 		}
-	| balancing_section
+	| storage_balancing_section
+	;
+
+storage_balancing_section:
+	  /* set current_balancing before entering balancing_section */
+	  {
+		ctx->current_balancing = &ctx->current_storage->balancing;
+	  }
+	  balancing_section
 	;
 
 balancing_section:
 	  BALANCING
 		{
-			od_cfg_balancing_t *b = &ctx->current_storage->balancing;
+			od_cfg_balancing_t *b = ctx->current_balancing;
+
+			if (b == NULL) {
+				od_cfg_diag_error(ctx->diags, @1,
+								  "balancing section is not allowed here");
+				YYERROR;
+			}
 
 			if (b->seen.is_set) {
 				od_cfg_diag_error(ctx->diags, @1,
-								  "balancing section is redefined for storage '%s'",
-								  ctx->current_storage->name);
+								  "balancing section is redefined");
 				YYERROR;
 			}
 
 			od_cfg_seen_set(&b->seen, @1);
 			b->location = od_cfg_location_copy(@1);
-
-			ctx->current_balancing = b;
 		}
 	  '{' balancing_items '}'
 		{
 			ctx->current_balancing = NULL;
 		}
-	;
+  ;
 
 
 balancing_items:
@@ -2280,6 +2290,14 @@ listen_section:
 		}
 	;
 
+listen_balancing_section:
+	  /* set current_balancing before entering balancing_section */
+	  {
+		ctx->current_balancing = &ctx->current_listen->balancing;
+	  }
+	  balancing_section
+	;
+
 listen_items:
 	  %empty
 	| listen_items listen_item
@@ -2313,15 +2331,7 @@ listen_item:
 							  "target_session_attrs");
 			$2 = NULL;
 		}
-	| BALANCING_METHOD string_value
-		{
-			od_cfg_set_string(ctx->diags,
-							  &ctx->current_listen->balancing_method,
-							  $2,
-							  @1,
-							  "balancing_method");
-			$2 = NULL;
-		}
+	| listen_balancing_section
 	| CLIENT_LOGIN_TIMEOUT int_value
 		{
 			od_cfg_set_int_range_from_i64(ctx->diags,

--- a/sources/config.c
+++ b/sources/config.c
@@ -203,7 +203,8 @@ od_config_listen_t *od_config_listen_add(od_config_t *config)
 	listen->backlog = 128;
 	listen->client_login_timeout = 15000;
 	listen->target_session_attrs = OD_TARGET_SESSION_ATTRS_UNDEF;
-	listen->balancing_method = OD_BALANCING_METHOD_UNDEF;
+	listen->balancing_override_set = 0;
+	od_storage_balancing_init(&listen->balancing_override);
 
 	od_list_init(&listen->link);
 	od_list_append(&config->listen, &listen->link);
@@ -220,6 +221,8 @@ static void od_config_listen_free(od_config_listen_t *config)
 	if (config->tls_opts) {
 		od_tls_opts_free(config->tls_opts);
 	}
+
+	od_storage_balancing_destroy(&config->balancing_override);
 
 	for (size_t i = 0; i < config->storage_count; ++i) {
 		od_free(config->storage_names[i]);
@@ -702,8 +705,13 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 		       "  target_session_attrs %s",
 		       od_target_session_attrs_to_str(
 			       listen->target_session_attrs));
-		od_log(logger, "config", NULL, NULL, "  balancing_method %s",
-		       od_balancing_method_to_str(listen->balancing_method));
+		if (listen->balancing_override_set) {
+			od_log(logger, "config", NULL, NULL,
+			       "  balancing override: method %s, az_aware %d",
+			       od_balancing_method_to_str(
+				       listen->balancing_override.method.type),
+			       listen->balancing_override.method.az_aware);
+		}
 		if (listen->catchup_timeout) {
 			od_log(logger, "config", NULL, NULL,
 			       "  catchup_timeout %d", listen->catchup_timeout);

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -793,10 +793,10 @@ static od_frontend_status_t attach_with_storage(od_client_t *client,
 
 	od_storage_endpoint_t *endpoints[OD_STORAGE_MAX_ENDPOINTS];
 	size_t count;
-	od_balancing_method_t bal_method =
+	od_storage_balancing_t *balancing =
 		od_balancing_get_effective(client, storage);
 	count = od_storage_balancing_select(
-		&storage->balancing, bal_method, storage, route, endpoints,
+		balancing, storage, route, endpoints,
 		sizeof(endpoints) / sizeof(endpoints[0]), host_filter, &arg);
 
 	if (tsa == OD_TARGET_SESSION_ATTRS_PREFER_STANDBY && count > 1) {

--- a/sources/include/balancing.h
+++ b/sources/include/balancing.h
@@ -70,11 +70,10 @@ void od_storage_balancing_copy(od_storage_balancing_t *dest,
 			       const od_storage_balancing_t *src);
 
 size_t od_storage_balancing_select(od_storage_balancing_t *b,
-				   od_balancing_method_t override_method,
 				   od_rule_storage_t *storage,
 				   od_route_t *route,
 				   od_storage_endpoint_t **out, size_t max,
 				   od_balancing_filter_fn filter, void *arg);
 
-od_balancing_method_t od_balancing_get_effective(od_client_t *client,
-						 od_rule_storage_t *storage);
+od_storage_balancing_t *od_balancing_get_effective(od_client_t *client,
+						   od_rule_storage_t *storage);

--- a/sources/include/cfg/model.h
+++ b/sources/include/cfg/model.h
@@ -110,13 +110,29 @@ typedef struct od_cfg_listen_storage {
 	od_cfg_location_t location;
 } od_cfg_listen_storage_t;
 
+typedef struct od_cfg_balancing_method {
+	od_cfg_seen_t seen;
+	od_cfg_location_t location;
+
+	char *name;
+	od_cfg_bool_field_t az_aware;
+} od_cfg_balancing_method_t;
+
+typedef struct od_cfg_balancing {
+	od_cfg_seen_t seen;
+	od_cfg_location_t location;
+
+	od_cfg_balancing_method_t method;
+	od_cfg_bool_field_t show_notice_messages;
+} od_cfg_balancing_t;
+
 typedef struct od_cfg_listen {
 	od_cfg_location_t location;
 
 	od_cfg_string_field_t host;
 	od_cfg_int_field_t port;
 	od_cfg_string_field_t target_session_attrs;
-	od_cfg_string_field_t balancing_method;
+	od_cfg_balancing_t balancing;
 
 	od_cfg_int_field_t client_login_timeout;
 	od_cfg_int_field_t backlog;
@@ -137,22 +153,6 @@ typedef struct od_cfg_listen {
 od_cfg_listen_storage_t *od_cfg_listen_add_storage(od_cfg_listen_t *listen,
 						   od_cfg_location_t location,
 						   const char *name);
-
-typedef struct od_cfg_balancing_method {
-	od_cfg_seen_t seen;
-	od_cfg_location_t location;
-
-	char *name;
-	od_cfg_bool_field_t az_aware;
-} od_cfg_balancing_method_t;
-
-typedef struct od_cfg_balancing {
-	od_cfg_seen_t seen;
-	od_cfg_location_t location;
-
-	od_cfg_balancing_method_t method;
-	od_cfg_bool_field_t show_notice_messages;
-} od_cfg_balancing_t;
 
 typedef struct od_cfg_route od_cfg_route_t;
 

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -33,7 +33,8 @@ struct od_config_listen {
 	od_list_t link;
 
 	od_target_session_attrs_t target_session_attrs;
-	od_balancing_method_t balancing_method;
+	od_storage_balancing_t balancing_override;
+	int balancing_override_set;
 	int catchup_timeout;
 
 	char **storage_names;

--- a/test/pg_regress/conf/listen_balancer
+++ b/test/pg_regress/conf/listen_balancer
@@ -46,7 +46,10 @@ listen {
 	port 7432
 	backlog 128
 	tls "disable"
-	balancing_method "leastconn"
+	balancing {
+		method "leastconn" {}
+		show_notice_messages yes
+	}
 }
 
 storage "rr-hosts" {


### PR DESCRIPTION
Follow up to 89c48ea2: instead of overriding only
the balancing method name, allow the entire
`balancing { ... }` section to be overridden per listen endpoint.  This lets each listen configure method, az_aware and show_notice_messages independently, reusing the same grammar as the storage-level section. The round-robin counter always comes from the storage, so multiple listen endpoints referencing the same storage still share it, ensuring fair distribution across all listeners.