### PR TITLE
introduce mm_vector_shrink_to_fit

### DIFF
--- a/sources/include/machinarium/ds/vector.h
+++ b/sources/include/machinarium/ds/vector.h
@@ -32,3 +32,4 @@ void mm_vector_clear(mm_vector_t *vec);
 void *mm_vector_get(mm_vector_t *vec, size_t idx);
 void *mm_vector_back(mm_vector_t *vec);
 int mm_vector_append(mm_vector_t *vec, const void *val);
+int mm_vector_shrink_to_fit(mm_vector_t *vec);

--- a/sources/machinarium/ds/vector.c
+++ b/sources/machinarium/ds/vector.c
@@ -59,20 +59,22 @@ void mm_vector_clear(mm_vector_t *vec)
 
 int mm_vector_shrink_to_fit(mm_vector_t *vec)
 {
-	if (vec->capacity <= MIN_CAPACITY) {
+	size_t new_cap = vec->size;
+	if (new_cap < MIN_CAPACITY) {
+		new_cap = MIN_CAPACITY;
+	}
+
+	if (new_cap >= vec->capacity) {
 		return 0;
 	}
 
-	size_t new_cap = vec->size;
-	if (new_cap != vec->capacity) {
-		void *ne = mm_realloc(vec->elements, new_cap * vec->elsize);
-		if (ne == NULL) {
-			return -1;
-		}
-
-		vec->elements = ne;
-		vec->capacity = new_cap;
+	void *ne = mm_realloc(vec->elements, new_cap * vec->elsize);
+	if (ne == NULL) {
+		return -1;
 	}
+
+	vec->elements = ne;
+	vec->capacity = new_cap;
 
 	return 0;
 }

--- a/sources/machinarium/ds/vector.c
+++ b/sources/machinarium/ds/vector.c
@@ -4,6 +4,8 @@
 #include <machinarium/memory.h>
 #include <machinarium/ds/vector.h>
 
+#define MIN_CAPACITY 16
+
 void mm_vector_init(mm_vector_t *vec, size_t elsize,
 		    mm_vector_element_dtor_fn eldtor)
 {
@@ -55,6 +57,26 @@ void mm_vector_clear(mm_vector_t *vec)
 	vec->size = 0;
 }
 
+int mm_vector_shrink_to_fit(mm_vector_t *vec)
+{
+	if (vec->capacity <= MIN_CAPACITY) {
+		return 0;
+	}
+
+	size_t new_cap = vec->size;
+	if (new_cap != vec->capacity) {
+		void *ne = mm_realloc(vec->elements, new_cap * vec->elsize);
+		if (ne == NULL) {
+			return -1;
+		}
+
+		vec->elements = ne;
+		vec->capacity = new_cap;
+	}
+
+	return 0;
+}
+
 void *mm_vector_get(mm_vector_t *vec, size_t idx)
 {
 	if (idx < vec->size) {
@@ -72,7 +94,8 @@ void *mm_vector_back(mm_vector_t *vec)
 int mm_vector_append(mm_vector_t *vec, const void *val)
 {
 	if (vec->size >= vec->capacity) {
-		size_t nc = vec->capacity == 0 ? 16 : vec->capacity * 2;
+		size_t nc =
+			vec->capacity == 0 ? MIN_CAPACITY : vec->capacity * 2;
 		void *ne = mm_realloc(vec->elements, nc * vec->elsize);
 		if (ne == NULL) {
 			return -1;

--- a/sources/relay.c
+++ b/sources/relay.c
@@ -62,6 +62,7 @@ static void xbuf_init(od_relay_xbuf_t *xbuf)
 static void xbuf_destroy_msgs(od_relay_xbuf_t *xbuf)
 {
 	/* TODO: do not ignore error? */
+	mm_vector_clear(&xbuf->msgs);
 	mm_vector_shrink_to_fit(&xbuf->msgs);
 }
 

--- a/sources/relay.c
+++ b/sources/relay.c
@@ -61,7 +61,8 @@ static void xbuf_init(od_relay_xbuf_t *xbuf)
 
 static void xbuf_destroy_msgs(od_relay_xbuf_t *xbuf)
 {
-	mm_vector_clear(&xbuf->msgs);
+	/* TODO: do not ignore error? */
+	mm_vector_shrink_to_fit(&xbuf->msgs);
 }
 
 static void xbuf_destroy(od_relay_xbuf_t *xbuf)

--- a/sources/xplan.c
+++ b/sources/xplan.c
@@ -532,6 +532,7 @@ void od_xplan_destroy(od_xplan_t *xp)
 void od_xplan_clear(od_xplan_t *xp)
 {
 	/* TODO: do not ignore error? */
+	mm_vector_clear(&xp->entries);
 	mm_vector_shrink_to_fit(&xp->entries);
 }
 

--- a/sources/xplan.c
+++ b/sources/xplan.c
@@ -531,7 +531,8 @@ void od_xplan_destroy(od_xplan_t *xp)
 
 void od_xplan_clear(od_xplan_t *xp)
 {
-	mm_vector_clear(&xp->entries);
+	/* TODO: do not ignore error? */
+	mm_vector_shrink_to_fit(&xp->entries);
 }
 
 static od_pstmt_t *plan_client_get_pstmt(od_xplan_t *xp, od_client_t *client,


### PR DESCRIPTION
And use it in xplan entries and msgs

Sometimes user can send large batches of extended
messages, and it will consume momory for vector entries until the client disconnects. This patch adds
shrinking the vectors to at most 16 elements, fixing extra memory consumtion after the batches.