### PR TITLE
add cache_msg_gc_count to limit message cache size

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -66,7 +66,8 @@ for all Odyssey rules.
 | `cancel_max_inflight`                      | int              | `-1` (none) | SIGHUP  | Max concurrent in-flight cancel requests; -1 = unlimited          |
 | `virtual_transaction`                           | int (bool)       | `yes`       | restart  | Enable virtual transaction features    |
 | `dns_cache_ttl`                            | int (ms)         | `30000`     | SIGHUP  | TTL for DNS cache entries                                         |
-| `cache_msg_gc_size`                        | int              | `0`         | SIGHUP  | Message GC cache size; 0 = disabled                               |
+| `cache_msg_gc_size`                        | int (bytes)      | `0`         | SIGHUP  | Max single message buffer size for caching; 0 = caching disabled   |
+| `cache_msg_gc_count`                      | int              | `0`         | SIGHUP  | Message GC cache max count; 0 = unlimited                         |
 | `graceful_die_on_errors`                   | int (bool)       | `no`        | runtime | **Deprecated.** Use SIGUSR2 signal directly instead               |
 | `pipeline`                                 | int              | —           | —       | **Deprecated.** Ignored.                                          |
 | `cache`                                    | int              | —           | —       | **Deprecated.** Ignored.                                          |
@@ -679,11 +680,21 @@ Default: 30000 (30 seconds). Set to 0 to disable caching.
 ## **cache\_msg\_gc\_size**
 *integer*
 
-Size of the internal message garbage-collection cache (number of reusable
-message objects). Larger values reduce allocator pressure under high
-message rates. Default: 0 (disabled).
+Maximum buffer size (in bytes) of a single message that may be retained
+in the internal message garbage-collection cache. Messages whose buffer
+exceeds this threshold are freed immediately instead of being cached.
+Default: 0 (caching disabled — all messages are freed).
 
-`cache_msg_gc_size 100`
+`cache_msg_gc_size 12288`
+
+## **cache\_msg\_gc\_count**
+*integer*
+
+Maximum number of message objects retained in the internal
+garbage-collection cache. When the cache exceeds this limit, the oldest
+cached messages are freed. Default: 1024.
+
+`cache_msg_gc_count 1000`
 
 ## **virtual\_transaction**
 *yes|no*

--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -489,6 +489,7 @@ int convert_global(const od_cfg_global_t *cfg, od_config_t *config,
 	COPY_INT(cfg->resolvers, config->resolvers);
 	COPY_INT(cfg->dns_cache_ttl, config->dns_ttl_ms);
 	COPY_INT(cfg->cache_msg_gc_size, config->cache_msg_gc_size);
+	COPY_INT(cfg->cache_msg_gc_count, config->cache_msg_gc_count);
 	COPY_INT(cfg->cache_coroutine, config->cache_coroutine);
 	COPY_INT(cfg->coroutine_stack_size, config->coroutine_stack_size);
 	if (config->coroutine_stack_size < 16) {

--- a/sources/cfg/keywords.c
+++ b/sources/cfg/keywords.c
@@ -69,6 +69,7 @@ static const od_cfg_keyword_t keywords[] = {
 	{ "resolvers", RESOLVERS },
 	{ "dns_cache_ttl", DNS_CACHE_TTL },
 	{ "cache_msg_gc_size", CACHE_MSG_GC_SIZE },
+	{ "cache_msg_gc_count", CACHE_MSG_GC_COUNT },
 	{ "cache_coroutine", CACHE_COROUTINE },
 	{ "coroutine_stack_size", COROUTINE_STACK_SIZE },
 	{ "system_coroutine_stack_size", SYSTEM_COROUTINE_STACK_SIZE },

--- a/sources/cfg/model.c
+++ b/sources/cfg/model.c
@@ -466,6 +466,8 @@ void od_cfg_model_dumpf(FILE *file, const od_cfg_model_t *model)
 	dump_int(file, "dns_cache_ttl", 0, &model->global.dns_cache_ttl);
 	dump_int(file, "cache_msg_gc_size", 0,
 		 &model->global.cache_msg_gc_size);
+	dump_int(file, "cache_msg_gc_count", 0,
+		 &model->global.cache_msg_gc_count);
 	dump_int(file, "cache_coroutine", 0, &model->global.cache_coroutine);
 	dump_int(file, "coroutine_stack_size", 0,
 		 &model->global.coroutine_stack_size);
@@ -903,6 +905,7 @@ void od_cfg_model_free(od_cfg_model_t *model)
 	od_cfg_int_field_free(&model->global.resolvers);
 	od_cfg_int_field_free(&model->global.dns_cache_ttl);
 	od_cfg_int_field_free(&model->global.cache_msg_gc_size);
+	od_cfg_int_field_free(&model->global.cache_msg_gc_count);
 	od_cfg_int_field_free(&model->global.cache_coroutine);
 	od_cfg_int_field_free(&model->global.coroutine_stack_size);
 	od_cfg_int_field_free(&model->global.system_coroutine_stack_size);

--- a/sources/cfg/parse.y
+++ b/sources/cfg/parse.y
@@ -189,6 +189,7 @@
 %token RESOLVERS "resolvers"
 %token DNS_CACHE_TTL "dns_cache_ttl"
 %token CACHE_MSG_GC_SIZE "cache_msg_gc_size"
+%token CACHE_MSG_GC_COUNT "cache_msg_gc_count"
 %token CACHE_COROUTINE "cache_coroutine"
 %token COROUTINE_STACK_SIZE "coroutine_stack_size"
 %token SYSTEM_COROUTINE_STACK_SIZE "system_coroutine_stack_size"
@@ -792,6 +793,14 @@ top_item:
 							$2,
 							@1,
 							"cache_msg_gc_size");
+		}
+	| CACHE_MSG_GC_COUNT int_value
+		{
+			od_cfg_set_int_from_i64(ctx->diags,
+							&ctx->model->global.cache_msg_gc_count,
+							$2,
+							@1,
+							"cache_msg_gc_count");
 		}
 	| CACHE_COROUTINE int_value
 		{

--- a/sources/config.c
+++ b/sources/config.c
@@ -75,6 +75,7 @@ void od_config_init(od_config_t *config)
 	config->server_login_retry = 1;
 	config->cache_coroutine = 1024;
 	config->cache_msg_gc_size = 0;
+	config->cache_msg_gc_count = 1024;
 	config->coroutine_stack_size = 16;
 	config->system_coroutine_stack_size = 32;
 	config->hba_file = NULL;
@@ -436,6 +437,8 @@ static const od_config_field_t od_config_fields[] = {
 	  offsetof(od_config_t, cache_coroutine), 0 },
 	{ "cache_msg_gc_size", OD_CONFIG_FIELD_INT,
 	  offsetof(od_config_t, cache_msg_gc_size), 0 },
+	{ "cache_msg_gc_count", OD_CONFIG_FIELD_INT,
+	  offsetof(od_config_t, cache_msg_gc_count), 0 },
 	{ "coroutine_stack_size", OD_CONFIG_FIELD_INT,
 	  offsetof(od_config_t, coroutine_stack_size), 0 },
 	{ "system_coroutine_stack_size", OD_CONFIG_FIELD_INT,
@@ -611,6 +614,8 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 	       config->server_login_retry);
 	od_log(logger, "config", NULL, NULL, "cache_msg_gc_size       %d",
 	       config->cache_msg_gc_size);
+	od_log(logger, "config", NULL, NULL, "cache_msg_gc_count      %d",
+	       config->cache_msg_gc_count);
 	od_log(logger, "config", NULL, NULL, "cache_coroutine         %d",
 	       config->cache_coroutine);
 	od_log(logger, "config", NULL, NULL, "coroutine_stack_size    %d",

--- a/sources/include/cfg/model.h
+++ b/sources/include/cfg/model.h
@@ -96,6 +96,7 @@ typedef struct od_cfg_global {
 	od_cfg_int_field_t resolvers;
 	od_cfg_int_field_t dns_cache_ttl;
 	od_cfg_int_field_t cache_msg_gc_size;
+	od_cfg_int_field_t cache_msg_gc_count;
 	od_cfg_int_field_t cache_coroutine;
 	od_cfg_int_field_t coroutine_stack_size;
 	od_cfg_int_field_t system_coroutine_stack_size;

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -130,6 +130,7 @@ struct od_config {
 	/*  */
 	int cache_coroutine;
 	int cache_msg_gc_size;
+	int cache_msg_gc_count;
 	int coroutine_stack_size;
 	int system_coroutine_stack_size;
 	int dns_ttl_ms;

--- a/sources/include/machinarium/machinarium.h
+++ b/sources/include/machinarium/machinarium.h
@@ -73,6 +73,8 @@ MACHINE_API void machinarium_set_coroutine_cache_size(int size);
 
 MACHINE_API void machinarium_set_msg_cache_gc_size(int size);
 
+MACHINE_API void machinarium_set_msg_cache_gc_count(int count);
+
 MACHINE_API void machinarium_set_dns_ttl_ms(int ttl_ms);
 
 /* main */

--- a/sources/include/machinarium/mm.h
+++ b/sources/include/machinarium/mm.h
@@ -19,6 +19,7 @@ struct mm_config {
 	int pool_size;
 	int coroutine_cache_size;
 	int msg_cache_gc_size;
+	int msg_cache_gc_count;
 	uint64_t dns_ttl_ms;
 };
 

--- a/sources/include/machinarium/msg_cache.h
+++ b/sources/include/machinarium/msg_cache.h
@@ -19,7 +19,8 @@ struct mm_msgcache {
 	uint64_t count_allocated;
 	uint64_t count_gc;
 	uint64_t size;
-	int gc_watermark;
+	int gc_size_watermark;
+	int gc_count_watermark;
 };
 
 void mm_msgcache_init(mm_msgcache_t *);
@@ -31,9 +32,16 @@ mm_msg_t *mm_msgcache_pop(mm_msgcache_t *);
 
 void mm_msgcache_push(mm_msgcache_t *, mm_msg_t *);
 
-static inline void mm_msgcache_set_gc_watermark(mm_msgcache_t *cache, int wm)
+static inline void mm_msgcache_set_gc_watermark(mm_msgcache_t *cache,
+						int size_wm)
 {
-	cache->gc_watermark = wm;
+	cache->gc_size_watermark = size_wm;
+}
+
+static inline void mm_msgcache_set_gc_count_watermark(mm_msgcache_t *cache,
+						      int count_wm)
+{
+	cache->gc_count_watermark = count_wm;
 }
 
 static inline void mm_msg_ref(mm_msg_t *msg)

--- a/sources/instance.c
+++ b/sources/instance.c
@@ -561,6 +561,7 @@ int od_instance_main(od_instance_t *instance, int argc, char **argv,
 	machinarium_set_pool_size(instance->config.resolvers);
 	machinarium_set_coroutine_cache_size(instance->config.cache_coroutine);
 	machinarium_set_msg_cache_gc_size(instance->config.cache_msg_gc_size);
+	machinarium_set_msg_cache_gc_count(instance->config.cache_msg_gc_count);
 	machinarium_set_dns_ttl_ms(instance->config.dns_ttl_ms);
 	rc = machinarium_init();
 	if (rc == -1) {

--- a/sources/machinarium/machine.c
+++ b/sources/machinarium/machine.c
@@ -158,6 +158,8 @@ MACHINE_API int64_t machine_create(char *name, machine_coroutine_t function,
 	mm_msgcache_init(&machine->msg_cache);
 	mm_msgcache_set_gc_watermark(&machine->msg_cache,
 				     machinarium.config.msg_cache_gc_size);
+	mm_msgcache_set_gc_count_watermark(
+		&machine->msg_cache, machinarium.config.msg_cache_gc_count);
 
 	mm_coroutine_cache_init(&machine->system_coroutine_cache,
 				machinarium.config.system_stack_size *

--- a/sources/machinarium/mm.c
+++ b/sources/machinarium/mm.c
@@ -14,6 +14,7 @@ static int machinarium_system_stack_size = 0;
 static int machinarium_pool_size = 0;
 static int machinarium_coroutine_cache_size = 0;
 static int machinarium_msg_cache_gc_size = 0;
+static int machinarium_msg_cache_gc_count = 0;
 static int machinarium_initialized = 0;
 static int machinarium_dns_ttl_ms = -1;
 mm_t machinarium;
@@ -46,6 +47,11 @@ MACHINE_API void machinarium_set_coroutine_cache_size(int size)
 MACHINE_API void machinarium_set_msg_cache_gc_size(int size)
 {
 	machinarium_msg_cache_gc_size = size;
+}
+
+MACHINE_API void machinarium_set_msg_cache_gc_count(int count)
+{
+	machinarium_msg_cache_gc_count = count;
 }
 
 MACHINE_API void machinarium_set_dns_ttl_ms(int ttl_ms)
@@ -82,6 +88,7 @@ MACHINE_API int machinarium_init(void)
 	machinarium.config.coroutine_cache_size =
 		machinarium_coroutine_cache_size;
 	machinarium.config.msg_cache_gc_size = machinarium_msg_cache_gc_size;
+	machinarium.config.msg_cache_gc_count = machinarium_msg_cache_gc_count;
 	machinarium.config.dns_ttl_ms = machinarium_dns_ttl_ms;
 
 	mm_machinemgr_init(&machinarium.machine_mgr);

--- a/sources/machinarium/msg_cache.c
+++ b/sources/machinarium/msg_cache.c
@@ -16,7 +16,8 @@ void mm_msgcache_init(mm_msgcache_t *cache)
 	cache->count_allocated = 0;
 	cache->count_gc = 0;
 	cache->size = 0;
-	cache->gc_watermark = 0;
+	cache->gc_size_watermark = 0;
+	cache->gc_count_watermark = 0;
 }
 
 void mm_msgcache_free(mm_msgcache_t *cache)
@@ -67,8 +68,11 @@ init:
 
 void mm_msgcache_push(mm_msgcache_t *cache, mm_msg_t *msg)
 {
-	if (msg->machine_id != mm_self->id ||
-	    mm_buf_size(&msg->data) > cache->gc_watermark) {
+	int too_many = cache->count >= (uint64_t)cache->gc_count_watermark;
+	int too_large = mm_buf_size(&msg->data) > cache->gc_size_watermark;
+	int not_own = msg->machine_id != mm_self->id;
+
+	if (not_own || too_many || too_large) {
 		cache->count_gc++;
 		mm_buf_free(&msg->data);
 		mm_free(msg);


### PR DESCRIPTION
Also rename `gc_watermark` -> `gc_size_watermark` for clarity and fix the `cache_msg_gc_size` documentation, which incorrectly described it as the number of cached objects rather than the per-message buffer size threshold (0 = caching disabled).