### PR TITLE
allow to redefine client_max at listen section

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -42,7 +42,7 @@ for all Odyssey rules.
 | `backend_connect_timeout_ms`               | int (ms)         | `30000`     | SIGHUP  | Backend connection timeout                            |
 | `coroutine_stack_size`                     | int (pages)      | `16`        | restart | Coroutine stack size (client/worker coroutines); values below 16 are not recommended |
 | `system_coroutine_stack_size`              | int (pages)      | `32`        | restart | Coroutine stack size for internal system coroutines   |
-| `client_max`                               | int              | `0`         | SIGHUP  | Max client connections (0/unset = no global limit)    |
+| `client_max`                               | int              | `0`         | SIGHUP  | Max client connections (0/unset = no global limit); per-listen reserve via `reserved_clients` |
 | `client_max_routing`                       | int              | `0`         | SIGHUP  | 0/unset → auto (typically `64 * workers`)             |
 | `server_login_retry`                       | int              | `1`         | SIGHUP  | Retry delay on "Too many clients"                     |
 | `hba_file`                                 | string           | unset       | SIGHUP  | Path to pg\_hba-like rules                            |
@@ -435,6 +435,9 @@ Global limit of client connections.
 
 Comment 'client_max' to disable the limit. On client limit reach, Odyssey will
 reply with 'too many connections'.
+
+Individual listen endpoints can be granted a reserve that bypasses this limit
+via the [`reserved_clients`](listen.md#reserved_clients) listen option.
 
 `client_max 100`
 

--- a/docs/configuration/listen.md
+++ b/docs/configuration/listen.md
@@ -149,6 +149,27 @@ listen {
 }
 ```
 
+## **reserved_clients**
+*integer*
+
+Number of client connections reserved for this listen endpoint that are
+**exempt from the global `client_max` limit**.
+
+When the global `client_max` is reached, Odyssey starts rejecting new
+connections on listen endpoints that have no reserve. An endpoint with
+`reserved_clients` set can still accept connections up to its reserve value,
+even while the global limit is exceeded.
+
+Set to `-1` (the default) to disable the reserve for this endpoint —
+connections on it are rejected as soon as the global `client_max` is hit.
+A value of `0` means the endpoint has no reserve budget either, and behaves
+the same as `-1`.
+
+Only takes effect when `client_max` is set in the global section. See also
+[client_max](global.md#client_max).
+
+`reserved_clients 2`
+
 ## **client_login_timeout**
 *integer*
 

--- a/sources/balancing.c
+++ b/sources/balancing.c
@@ -9,6 +9,7 @@
 #include <util.h>
 #include <client.h>
 #include <config.h>
+#include <system.h>
 
 #define METHOD_RR_STR "roundrobin"
 #define METHOD_LEASTCONN_STR "leastconn"
@@ -360,10 +361,10 @@ size_t od_storage_balancing_select(od_storage_balancing_t *b,
 od_storage_balancing_t *od_balancing_get_effective(od_client_t *client,
 						   od_rule_storage_t *storage)
 {
-	od_config_listen_t *l = client->config_listen;
+	od_system_server_t *l = client->source;
 
-	if (l != NULL && l->balancing_override_set) {
-		return &l->balancing_override;
+	if (l != NULL && l->config->balancing_override_set) {
+		return &l->config->balancing_override;
 	}
 
 	return &storage->balancing;

--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -1062,6 +1062,7 @@ static int convert_listen(convert_ctx_t *ctx, const od_cfg_listen_t *cfg)
 	}
 	COPY_INT(cfg->client_login_timeout, listen->client_login_timeout);
 	COPY_INT(cfg->catchup_timeout, listen->catchup_timeout);
+	COPY_INT(cfg->reserved_clients, listen->reserved_clients);
 	COPY_INT(cfg->backlog, listen->backlog);
 	COPY_STR(cfg->tls, listen->tls_opts->tls, diags);
 	COPY_STR(cfg->tls_ca_file, listen->tls_opts->tls_ca_file, diags);

--- a/sources/cfg/keywords.c
+++ b/sources/cfg/keywords.c
@@ -205,6 +205,7 @@ static const od_cfg_keyword_t keywords[] = {
 	{ "minimal", MINIMAL },
 	{ "full", FULL },
 	{ "mem_limit", MEM_LIMIT },
+	{ "reserved_clients", RESERVED_CLIENTS },
 
 	{ NULL, 0 }
 };

--- a/sources/cfg/model.c
+++ b/sources/cfg/model.c
@@ -102,6 +102,7 @@ static void dump_listen(FILE *file, const od_cfg_listen_t *l)
 	dump_string(file, "target_session_attrs", 1, &l->target_session_attrs);
 	dump_balancing(file, 1, &l->balancing);
 	dump_int(file, "client_login_timeout", 1, &l->client_login_timeout);
+	dump_int(file, "reserved_clients", 1, &l->reserved_clients);
 	dump_int(file, "backlog", 1, &l->backlog);
 	dump_string(file, "tls", 1, &l->tls);
 	dump_string(file, "tls_ca_file", 1, &l->tls_ca_file);
@@ -607,6 +608,7 @@ static void od_cfg_listen_free(od_cfg_listen_t *listen)
 	od_cfg_string_field_free(&listen->tls_cert_file);
 	od_cfg_string_field_free(&listen->tls_protocols);
 	od_cfg_int_field_free(&listen->catchup_timeout);
+	od_cfg_int_field_free(&listen->reserved_clients);
 
 	for (size_t i = 0; i < listen->storages_count; ++i) {
 		od_cfg_location_free(&listen->storages[i]->location);

--- a/sources/cfg/parse.y
+++ b/sources/cfg/parse.y
@@ -322,6 +322,7 @@
 %token MINIMAL "minimal"
 %token FULL "full"
 %token MEM_LIMIT "mem_limit"
+%token RESERVED_CLIENTS "reserved_clients"
 
 %type <boolean> bool_value
 %type <str> string_value
@@ -2440,6 +2441,15 @@ listen_item:
 								  "failed to allocate storage");
 				YYERROR;
 			}
+		}
+	| RESERVED_CLIENTS int_value
+		{
+			od_cfg_set_int_range_from_i64(ctx->diags,
+								&ctx->current_listen->reserved_clients,
+								$2,
+								0, INT_MAX,
+								@1,
+								"reserved_clients");
 		}
 	;
 

--- a/sources/client.c
+++ b/sources/client.c
@@ -12,6 +12,7 @@
 #include <status.h>
 #include <client.h>
 #include <atomic.h>
+#include <system.h>
 #include <config.h>
 #include <list.h>
 
@@ -22,7 +23,7 @@ void od_client_init(od_client_t *client)
 	client->coroutine_id = 0;
 	client->tls = NULL;
 	client->rule = NULL;
-	client->config_listen = NULL;
+	client->source = NULL;
 	client->server = NULL;
 	client->route = NULL;
 	client->global = NULL;
@@ -106,8 +107,8 @@ void od_client_free(od_client_t *client)
 
 uint32_t od_client_login_timeout(const od_client_t *client)
 {
-	if (client->config_listen != NULL) {
-		return (uint32_t)client->config_listen->client_login_timeout;
+	if (client->source != NULL) {
+		return (uint32_t)client->source->config->client_login_timeout;
 	}
 
 	/* TODO: do not use infinite timeout */

--- a/sources/config.c
+++ b/sources/config.c
@@ -204,6 +204,7 @@ od_config_listen_t *od_config_listen_add(od_config_t *config)
 	listen->port = 6432;
 	listen->backlog = 128;
 	listen->client_login_timeout = 15000;
+	listen->reserved_clients = -1; /* disabled */
 	listen->target_session_attrs = OD_TARGET_SESSION_ATTRS_UNDEF;
 	listen->balancing_override_set = 0;
 	od_storage_balancing_init(&listen->balancing_override);
@@ -705,6 +706,8 @@ void od_config_print(od_config_t *config, od_logger_t *logger)
 		od_log(logger, "config", NULL, NULL,
 		       "  client_login_timeout %d",
 		       listen->client_login_timeout);
+		od_log(logger, "config", NULL, NULL, "  reserved_clients %d",
+		       listen->reserved_clients);
 		od_log(logger, "config", NULL, NULL,
 		       "  target_session_attrs %s",
 		       od_target_session_attrs_to_str(

--- a/sources/console.c
+++ b/sources/console.c
@@ -2017,7 +2017,8 @@ static inline int od_console_show_lists(od_client_t *client,
 	int router_used_servers = 0;
 	int router_free_servers = 0;
 	int router_pools = router->route_pool.count;
-	int router_clients = od_atomic_u32_of(&router->clients);
+	int router_clients = (int)atomic_load_explicit(&router->clients,
+						       memory_order_relaxed);
 
 	void *argv[] = { &router_used_servers, &router_free_servers };
 	od_route_pool_foreach(&router->route_pool, od_console_show_lists_cb,

--- a/sources/cron.c
+++ b/sources/cron.c
@@ -181,7 +181,8 @@ static inline void od_cron_stat(od_cron_t *cron)
 		request_logger_stats(&instance->logger);
 
 		od_log(&instance->logger, "stats", NULL, NULL, "clients %d",
-		       od_atomic_u32_of(&router->clients));
+		       (int)atomic_load_explicit(&router->clients,
+						 memory_order_relaxed));
 	}
 
 	/* update stats per route and print info */

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -29,6 +29,7 @@
 #include <cancel.h>
 #include <auth.h>
 #include <reset.h>
+#include <system.h>
 #include <hba.h>
 #include <dns.h>
 #include <backend.h>
@@ -46,8 +47,10 @@ static inline void od_frontend_close(od_client_t *client)
 	od_assert(client->server == NULL);
 
 	od_router_t *router = client->global->router;
-	od_atomic_u32_dec(&router->clients);
-
+	atomic_fetch_sub(&router->clients, 1);
+	if (client->source != NULL) {
+		atomic_fetch_sub(&client->source->clients, 1);
+	}
 	od_io_close(&client->io);
 	od_client_free(client);
 }
@@ -177,7 +180,7 @@ static int read_and_parse_startup(od_client_t *client, int *parse_rc)
 	od_instance_t *instance = client->global->instance;
 
 	machine_msg_t *msg = od_read_startup(
-		&client->io, client->config_listen->client_login_timeout);
+		&client->io, client->source->config->client_login_timeout);
 	if (msg == NULL) {
 		if (parse_rc) {
 			*parse_rc = KIWI_STARTUP_READ_LEN_ERROR;
@@ -299,7 +302,7 @@ static int od_frontend_startup(od_client_t *client)
 
 		if (client->startup.is_ssl_request && !ssl_done) {
 			if (od_tls_frontend_accept(client, &instance->logger,
-						   client->config_listen,
+						   client->source->config,
 						   client->tls) == -1) {
 				goto error;
 			}
@@ -332,7 +335,7 @@ static int od_frontend_startup(od_client_t *client)
 		return 0;
 	}
 
-	if (client->config_listen->tls_opts->tls_mode >=
+	if (client->source->config->tls_opts->tls_mode >=
 		    OD_CONFIG_TLS_REQUIRE &&
 	    !ssl_done) {
 		od_log(&instance->logger, "tls", client, NULL,
@@ -354,7 +357,7 @@ static int od_frontend_startup(od_client_t *client)
 		}
 	}
 
-	if (od_compression_frontend_setup(client, client->config_listen,
+	if (od_compression_frontend_setup(client, client->source->config,
 					  &instance->logger) == -1) {
 		od_error(&instance->logger, "startup", client, NULL,
 			 "can't setup compression, errno=%d (%s)",
@@ -531,7 +534,7 @@ static inline od_frontend_status_t od_frontend_attach_to_endpoint(
 			int rc;
 			od_atomic_u32_inc(&router->servers_routing);
 
-			od_assert(client->config_listen != NULL);
+			od_assert(client->source != NULL);
 			rc = od_backend_connect(server, context, route_params,
 						client, storage);
 
@@ -621,7 +624,7 @@ static uint32_t get_effective_catchup_timeout(od_client_t *client)
 	 * var from pgoption > value from rule > value from listen
 	 */
 
-	od_config_listen_t *listen = client->config_listen;
+	od_config_listen_t *listen = client->source->config;
 
 	int default_timeout = 0;
 	if (listen != NULL) {
@@ -851,7 +854,7 @@ static od_frontend_status_t attach_impl(od_client_t *client, char *context,
 					int is_deploy)
 {
 	od_instance_t *instance = client->global->instance;
-	od_config_listen_t *listen = client->config_listen;
+	od_config_listen_t *listen = client->source->config;
 
 	if (listen != NULL && listen->storage_count > 0) {
 		od_router_t *router = client->global->router;

--- a/sources/include/cfg/model.h
+++ b/sources/include/cfg/model.h
@@ -146,6 +146,8 @@ typedef struct od_cfg_listen {
 
 	od_cfg_int_field_t catchup_timeout;
 
+	od_cfg_int_field_t reserved_clients;
+
 	od_cfg_listen_storage_t **storages;
 	size_t storages_count;
 	size_t storages_capacity;

--- a/sources/include/client.h
+++ b/sources/include/client.h
@@ -43,7 +43,7 @@ struct od_client {
 	od_io_t io;
 	od_relay_t relay;
 	od_rule_t *rule;
-	od_config_listen_t *config_listen;
+	od_system_server_t *source;
 
 	uint64_t time_accept;
 	uint64_t time_setup;

--- a/sources/include/config.h
+++ b/sources/include/config.h
@@ -6,6 +6,8 @@
  * Scalable PostgreSQL connection pooler.
  */
 
+#include <stdatomic.h>
+
 #include <tls_config.h>
 #include <list.h>
 #include <tsa.h>
@@ -39,6 +41,8 @@ struct od_config_listen {
 
 	char **storage_names;
 	size_t storage_count;
+
+	int reserved_clients;
 };
 
 struct od_config_conn_drop_options {

--- a/sources/include/router.h
+++ b/sources/include/router.h
@@ -18,7 +18,7 @@ struct od_router {
 	od_rules_t rules;
 	od_route_pool_t route_pool;
 	/* clients */
-	od_atomic_u32_t clients;
+	atomic_uint_fast64_t clients;
 	/* servers */
 	od_atomic_u32_t servers_routing;
 	/* error logging */

--- a/sources/include/system.h
+++ b/sources/include/system.h
@@ -27,6 +27,8 @@ struct od_system_server {
 	atomic_bool closed;
 
 	int64_t coro_id;
+
+	atomic_uint_fast64_t clients;
 };
 
 void od_system_server_free(od_system_server_t *server);

--- a/sources/router.c
+++ b/sources/router.c
@@ -29,7 +29,7 @@ void od_router_init(od_router_t *router, od_global_t *global)
 	od_rules_init(&router->rules);
 	od_list_init(&router->servers);
 	od_route_pool_init(&router->route_pool);
-	router->clients = 0;
+	atomic_init(&router->clients, 0);
 	router->servers_routing = 0;
 
 	router->global = global;

--- a/sources/system.c
+++ b/sources/system.c
@@ -53,6 +53,43 @@ void od_system_server_shutdown(od_system_server_t *server)
 	mm_eventfd_write(&server->shutdown_efd, UINT32_MAX);
 }
 
+static int check_client_max(od_system_server_t *server, od_global_t *global,
+			    od_instance_t *instance)
+{
+	/*
+	 * if global limit is reached - check if limit
+	 * for this listen is not reached
+	 */
+
+	uint64_t global_cnt = atomic_fetch_add(&global->router->clients, 1);
+	uint64_t local_cnt = atomic_fetch_add(&server->clients, 1);
+
+	if (instance->config.client_max_set &&
+	    global_cnt >= (uint64_t)instance->config.client_max) {
+		if (server->config->reserved_clients == -1) {
+			/* no reserve on this port - give up */
+			goto fail;
+		}
+
+		if (local_cnt >= (uint64_t)server->config->reserved_clients) {
+			/* reserve exhausted */
+			goto fail;
+		}
+
+		/* ok, we have some reserve, continue */
+	} else {
+		/* global client_max is not reached - no need to check reserve */
+	}
+
+	return 0;
+
+fail:
+	atomic_fetch_sub(&server->clients, 1);
+	atomic_fetch_sub(&global->router->clients, 1);
+
+	return 1;
+}
+
 static inline void od_system_server(void *arg)
 {
 	od_system_server_t *server = arg;
@@ -116,10 +153,7 @@ static inline void od_system_server(void *arg)
 			continue;
 		}
 
-		/* ensure global client_max limit */
-		uint32_t clients = od_atomic_u32_inc(&global->router->clients);
-		if (instance->config.client_max_set &&
-		    clients >= (uint32_t)instance->config.client_max) {
+		if (check_client_max(server, global, instance)) {
 			/*
 			 * writing error message could not be displayed correctly, if
 			 * client requested ssl establishment, which can not be afforded
@@ -127,7 +161,6 @@ static inline void od_system_server(void *arg)
 			 *
 			 * so the fatal sending is just best effort
 			 */
-			od_atomic_u32_dec(&global->router->clients);
 			mm_io_attach(client_io);
 			od_error(
 				&instance->logger, "server", NULL, NULL,
@@ -178,7 +211,7 @@ static inline void od_system_server(void *arg)
 			continue;
 		}
 		client->rule = NULL;
-		client->config_listen = server->config;
+		client->source = server;
 		client->tls = server->tls;
 		client->time_accept = 0;
 		client->time_accept = machine_time_us();
@@ -253,6 +286,7 @@ od_system_server_t *od_system_server_init(void)
 	server->tls = NULL;
 	od_id_generate(&server->sid, "sid");
 	atomic_init(&server->closed, false);
+	atomic_init(&server->clients, 0);
 	server->coro_id = -1;
 
 	return server;

--- a/sources/tsa.c
+++ b/sources/tsa.c
@@ -13,13 +13,16 @@
 #include <route.h>
 #include <rules.h>
 #include <config.h>
+#include <system.h>
 
 od_target_session_attrs_t od_tsa_get_effective(od_client_t *client)
 {
 	od_route_t *route = client->route;
 
-	od_target_session_attrs_t default_tsa =
-		client->config_listen->target_session_attrs;
+	od_target_session_attrs_t default_tsa = OD_TARGET_SESSION_ATTRS_UNDEF;
+	if (client->source != NULL) {
+		default_tsa = client->source->config->target_session_attrs;
+	}
 	od_target_session_attrs_t effective_tsa = OD_TARGET_SESSION_ATTRS_UNDEF;
 
 	if (route->rule->target_session_attrs !=

--- a/test/functional/tests/client_max/odyssey.conf
+++ b/test/functional/tests/client_max/odyssey.conf
@@ -32,3 +32,9 @@ listen {
 	host "127.0.0.1"
 	port 6432
 }
+
+listen {
+	host "127.0.0.1"
+	port 9999
+	reserved_clients 2
+}

--- a/test/functional/tests/client_max/runner.sh
+++ b/test/functional/tests/client_max/runner.sh
@@ -13,9 +13,25 @@ if psql 'host=localhost port=6432 user=postgres dbname=postgres sslmode=disable'
 	exit 1
 fi
 
+# reserve_clients for listen allows to add some connections
+psql 'host=localhost port=9999 user=postgres dbname=postgres sslmode=disable' -c 'select pg_sleep(10000)' &
+p1=$!
+
+psql 'host=localhost port=9999 user=postgres dbname=postgres sslmode=disable' -c 'select pg_sleep(10000)' &
+p2=$!
+
+if psql 'host=localhost port=9999 user=postgres dbname=postgres sslmode=disable' -c 'select 42'; then
+	echo "the connect must fail"
+	exit 1
+fi
+
+kill -9 $p2
+kill -9 $p1
+
 kill -9 $p
 sleep 0.1
 
 psql 'host=localhost port=6432 user=postgres dbname=postgres sslmode=disable' -c 'select 42'
+psql 'host=localhost port=9999 user=postgres dbname=postgres sslmode=disable' -c 'select 42'
 
 ody-stop


### PR DESCRIPTION
If set to global client_max + N, the
N additional connections will be accepted on port
of the section. This will allow to create some
VIP ports, that will allow to establish new connections in case of heavy load debugging