### PR TITLE
Reuse per-client read message buffer instead of allocating per request

### DIFF
--- a/sources/client.c
+++ b/sources/client.c
@@ -68,6 +68,8 @@ void od_client_init(od_client_t *client)
 	memset(client->scram_server_key, 0, sizeof(client->scram_server_key));
 	client->scram_key_valid = 0;
 
+	client->read_msg = NULL;
+
 	/* Init GUCs. */
 	client->backend_pin = false;
 }
@@ -101,6 +103,8 @@ void od_client_free(od_client_t *client)
 	memset(client->scram_client_key, 0, sizeof(client->scram_client_key));
 	memset(client->scram_server_key, 0, sizeof(client->scram_server_key));
 	client->scram_key_valid = 0;
+
+	machine_msg_free_safe(client->read_msg);
 
 	od_free(client);
 }

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -1815,11 +1815,16 @@ client_read_full_msg(od_client_t *client, const kiwi_header_t *header,
 {
 	*out = NULL;
 
-	machine_msg_t *msg;
-	msg = machine_msg_create(sizeof(kiwi_header_t) + size);
+	machine_msg_t *msg = client->read_msg;
+	if (msg != NULL) {
+		machine_msg_reset(msg);
+	}
+
+	msg = machine_msg_create_or_advance(msg, sizeof(kiwi_header_t) + size);
 	if (msg == NULL) {
 		return OD_EOOM;
 	}
+	client->read_msg = msg;
 
 	char *dest;
 	dest = machine_msg_data(msg);
@@ -1828,7 +1833,6 @@ client_read_full_msg(od_client_t *client, const kiwi_header_t *header,
 
 	int rc = od_io_read(&client->io, dest, size, timeout_ms);
 	if (rc == -1) {
-		machine_msg_free(msg);
 		return OD_ECLIENT_READ;
 	}
 
@@ -2091,7 +2095,9 @@ static od_frontend_status_t client_process_message(od_client_t *client,
 
 	status = client_process_message_full(client, msg, timeout_ms);
 
-	machine_msg_free(msg);
+	if (client->read_msg != NULL) {
+		machine_msg_shrink(client->read_msg, PQ_SMALL_MESSAGE_LIMIT);
+	}
 
 	if (status != OD_OK) {
 		return status;

--- a/sources/include/client.h
+++ b/sources/include/client.h
@@ -101,6 +101,8 @@ struct od_client {
 	uint8_t scram_server_key[OD_SCRAM_MAX_KEY_LEN];
 	int scram_key_valid;
 
+	machine_msg_t *read_msg;
+
 	od_client_query_ctx_t query_ctx;
 };
 

--- a/sources/include/machinarium/buf.h
+++ b/sources/include/machinarium/buf.h
@@ -57,6 +57,22 @@ static inline void mm_buf_reset(mm_buf_t *buf)
 	buf->pos = buf->start;
 }
 
+static inline int mm_buf_shrink(mm_buf_t *buf, int size)
+{
+	if (mm_buf_size(buf) <= size) {
+		mm_buf_reset(buf);
+		return 0;
+	}
+	char *p = mm_realloc(buf->start, size);
+	if (p == NULL) {
+		return -1;
+	}
+	buf->start = p;
+	buf->pos = p;
+	buf->end = p + size;
+	return 0;
+}
+
 static inline int mm_buf_ensure(mm_buf_t *buf, int size)
 {
 	if (buf->end - buf->pos >= size) {

--- a/sources/include/machinarium/machinarium.h
+++ b/sources/include/machinarium/machinarium.h
@@ -177,6 +177,10 @@ MACHINE_API void *machine_msg_data(machine_msg_t *);
 
 MACHINE_API int machine_msg_size(machine_msg_t *);
 
+MACHINE_API void machine_msg_reset(machine_msg_t *);
+
+MACHINE_API int machine_msg_shrink(machine_msg_t *, int size);
+
 MACHINE_API int machine_msg_write(machine_msg_t *, void *buf, int size);
 
 MACHINE_API machine_msg_t *machine_msg_copy(machine_msg_t *msg);

--- a/sources/machinarium/msg.c
+++ b/sources/machinarium/msg.c
@@ -86,6 +86,18 @@ MACHINE_API int machine_msg_size(machine_msg_t *obj)
 	return mm_buf_used(&msg->data);
 }
 
+MACHINE_API void machine_msg_reset(machine_msg_t *obj)
+{
+	mm_msg_t *msg = mm_cast(mm_msg_t *, obj);
+	mm_buf_reset(&msg->data);
+}
+
+MACHINE_API int machine_msg_shrink(machine_msg_t *obj, int size)
+{
+	mm_msg_t *msg = mm_cast(mm_msg_t *, obj);
+	return mm_buf_shrink(&msg->data, size);
+}
+
 MACHINE_API int machine_msg_write(machine_msg_t *obj, void *buf, int size)
 {
 	mm_msg_t *msg = mm_cast(mm_msg_t *, obj);


### PR DESCRIPTION
Add a reusable `machine_msg_t` buffer to `od_client_t` to avoid allocating and freeing a message on every client request. The buffer grows on demand via `machine_msg_create_or_advance` and is shrunk back to `PQ_SMALL_MESSAGE_LIMIT` (10000) after each message if it has grown larger, preventing long-lived oversized allocations.