### PR TITLE
Make readahead's cache thread-local

### DIFF
--- a/sources/include/machinarium/ds/vrb.h
+++ b/sources/include/machinarium/ds/vrb.h
@@ -8,8 +8,6 @@
 
 #include <stdint.h>
 
-#include <machinarium/spinlock.h>
-
 #include <sys/uio.h>
 
 /*
@@ -48,7 +46,6 @@ typedef struct {
 	mm_virtual_rbuf_t **rbufs;
 	size_t max;
 	size_t count;
-	mm_spinlock_t lock;
 } mm_virtual_rbuf_cache_t;
 
 int mm_virtual_rbuf_cache_init(mm_virtual_rbuf_cache_t *cache, size_t max_bufs);

--- a/sources/machinarium/ds/vrb.c
+++ b/sources/machinarium/ds/vrb.c
@@ -242,8 +242,6 @@ int mm_virtual_rbuf_cache_init(mm_virtual_rbuf_cache_t *cache, size_t max_bufs)
 	cache->count = 0;
 	cache->max = max_bufs;
 
-	mm_spinlock_init(&cache->lock);
-
 	if (max_bufs == 0) {
 		return 0;
 	}
@@ -265,15 +263,11 @@ void mm_virtual_rbuf_cache_destroy(mm_virtual_rbuf_cache_t *cache)
 	}
 
 	mm_free(cache->rbufs);
-
-	mm_spinlock_destroy(&cache->lock);
 }
 
 mm_virtual_rbuf_t *mm_virtual_rbuf_cache_get(mm_virtual_rbuf_cache_t *cache)
 {
 	mm_virtual_rbuf_t *vrb = NULL;
-
-	mm_spinlock_lock(&cache->lock);
 
 	if (cache->count > 0) {
 		--cache->count;
@@ -281,8 +275,6 @@ mm_virtual_rbuf_t *mm_virtual_rbuf_cache_get(mm_virtual_rbuf_cache_t *cache)
 		vrb = cache->rbufs[cache->count];
 		cache->rbufs[cache->count] = NULL;
 	}
-
-	mm_spinlock_unlock(&cache->lock);
 
 	if (vrb != NULL) {
 		memset(vrb->data, 0, vrb->capacity);
@@ -296,17 +288,11 @@ mm_virtual_rbuf_t *mm_virtual_rbuf_cache_get(mm_virtual_rbuf_cache_t *cache)
 void mm_virtual_rbuf_cache_put(mm_virtual_rbuf_cache_t *cache,
 			       mm_virtual_rbuf_t *vrb)
 {
-	mm_spinlock_lock(&cache->lock);
-
 	if (cache->count == cache->max) {
 		mm_virtual_rbuf_free(vrb);
-
-		mm_spinlock_unlock(&cache->lock);
 		return;
 	}
 
 	cache->rbufs[cache->count] = vrb;
 	cache->count++;
-
-	mm_spinlock_unlock(&cache->lock);
 }

--- a/sources/readahead.c
+++ b/sources/readahead.c
@@ -7,7 +7,6 @@
 #include <odyssey.h>
 
 #include <arpa/inet.h>
-#include <pthread.h>
 
 #include <machinarium/machine.h>
 #include <machinarium/ds/vrb.h>
@@ -18,33 +17,76 @@
 #include <instance.h>
 #include <readahead.h>
 
-static mm_virtual_rbuf_cache_t vrb_cache;
-static pthread_once_t vrb_cache_init_ctrl = PTHREAD_ONCE_INIT;
+/*
+ * Per-thread vrb cache.
+ *
+ * Each machinarium thread (worker, od_system, etc.) gets its own cache
+ * instance, eliminating spinlock contention on the hot read/return path.
+ *
+ * Because od_readahead_prepare() is now only called from worker threads
+ * (for both client and server io), every buffer is obtained from and
+ * returned to the same per-thread cache — no cross-thread ownership transfer.
+ */
 
-static void destroy_vrb_cache(void)
+static OD_THREAD_LOCAL mm_virtual_rbuf_cache_t *tls_vrb_cache = NULL;
+static OD_THREAD_LOCAL int tls_vrb_cache_initialized = 0;
+
+static void destroy_vrb_cache(void *arg)
 {
-	mm_virtual_rbuf_cache_destroy(&vrb_cache);
+	mm_virtual_rbuf_cache_t *cache = (mm_virtual_rbuf_cache_t *)arg;
+	if (cache == NULL) {
+		return;
+	}
+
+	mm_virtual_rbuf_cache_destroy(cache);
+
+	od_free(cache);
+
+	tls_vrb_cache = NULL;
+	tls_vrb_cache_initialized = 0;
 }
 
-static void init_vrb_cache(void)
+static mm_virtual_rbuf_cache_t *get_vrb_cache(void)
 {
+	if (tls_vrb_cache_initialized) {
+		return tls_vrb_cache;
+	}
+
+	tls_vrb_cache_initialized = 1;
+
+	mm_virtual_rbuf_cache_t *cache =
+		od_malloc(sizeof(mm_virtual_rbuf_cache_t));
+	if (cache == NULL) {
+		return NULL;
+	}
+
 	size_t size = (size_t)od_global_get_instance()->config.cache_coroutine;
-	int rc = mm_virtual_rbuf_cache_init(&vrb_cache, size);
+	int rc = mm_virtual_rbuf_cache_init(cache, size);
 	if (rc) {
+		od_free(cache);
+		tls_vrb_cache = NULL;
 		od_gfatal("readahead", NULL, NULL,
 			  "can't create vrb cache, errno = %d (%s)",
 			  machine_errno(), strerror(machine_errno()));
-		abort();
+		return NULL;
 	}
 
-	atexit(destroy_vrb_cache);
+	tls_vrb_cache = cache;
+
+	/* destroy when this machinarium thread exits */
+	mm_machine_atexit(destroy_vrb_cache, cache);
+
+	return cache;
 }
 
 int od_readahead_prepare(od_readahead_t *readahead)
 {
-	pthread_once(&vrb_cache_init_ctrl, init_vrb_cache);
+	mm_virtual_rbuf_cache_t *cache = get_vrb_cache();
+	if (cache == NULL) {
+		return -1;
+	}
 
-	readahead->buf = mm_virtual_rbuf_cache_get(&vrb_cache);
+	readahead->buf = mm_virtual_rbuf_cache_get(cache);
 	if (readahead->buf != NULL) {
 		return 0;
 	}
@@ -63,7 +105,12 @@ int od_readahead_prepare(od_readahead_t *readahead)
 void od_readahead_free(od_readahead_t *readahead)
 {
 	if (readahead->buf) {
-		mm_virtual_rbuf_cache_put(&vrb_cache, readahead->buf);
+		mm_virtual_rbuf_cache_t *cache = get_vrb_cache();
+		if (cache != NULL) {
+			mm_virtual_rbuf_cache_put(cache, readahead->buf);
+		} else {
+			mm_virtual_rbuf_free(readahead->buf);
+		}
 	}
 }
 

--- a/sources/system.c
+++ b/sources/system.c
@@ -199,17 +199,13 @@ static inline void od_system_server(void *arg)
 			continue;
 		}
 		od_id_generate(&client->id, "c");
-		rc = od_io_prepare(&client->io, client_io);
-		if (rc == -1) {
-			od_error(
-				&instance->logger, "server", NULL, NULL,
-				"failed to allocate client io object, errno = %d (%s)",
-				machine_errno(), strerror(machine_errno()));
-			mm_io_close(client_io);
-			mm_io_free(client_io);
-			od_client_free(client);
-			continue;
-		}
+		/*
+		 * Only assign the io handle here; defer readahead buffer
+		 * allocation to the worker thread so it comes from the
+		 * worker's thread-local vrb cache (avoids cross-thread
+		 * cache ownership).
+		 */
+		client->io.io = client_io;
 		client->rule = NULL;
 		client->source = server;
 		client->tls = server->tls;

--- a/sources/worker.c
+++ b/sources/worker.c
@@ -146,6 +146,27 @@ static inline void od_worker(void *arg)
 			client = *(od_client_t **)machine_msg_data(msg);
 			client->global = worker->global;
 
+			/*
+			 * Allocate readahead buffer from this worker's
+			 * thread-local vrb cache. od_io_prepare() was not
+			 * called in od_system (only io->io was assigned),
+			 * so the buffer is obtained here, in the worker
+			 * thread that owns it.
+			 */
+			rc = od_readahead_prepare(&client->io.readahead);
+			if (rc == -1) {
+				od_error(
+					&instance->logger, "worker", client,
+					NULL,
+					"failed to allocate readahead buffer, errno = %d (%s)",
+					machine_errno(),
+					strerror(machine_errno()));
+				od_io_close(&client->io);
+				od_client_free(client);
+				od_routing_slot_release(worker->global);
+				break;
+			}
+
 			/* for NULL-terminator and prefix, just in case */
 			char coro_name[10 + OD_ID_LEN];
 			od_id_write_to_string(&client->id, coro_name,


### PR DESCRIPTION
To avoid contention on locks.
    
Client's io readahead preparation was
moved to worker's od_frontend: this allows
to reuse readaheads from worker thread, not from
system thread.