### PR TITLE
fix: auth query crash on NULL passwords

### DIFF
--- a/sources/auth_query.c
+++ b/sources/auth_query.c
@@ -347,6 +347,11 @@ int od_auth_query(od_client_t *client, char *peer)
 
 	od_route_unlock(route);
 
+	if (cached->is_null) {
+		od_route_pswd_unref(cached);
+		return 0;
+	}
+
 	client->password.password = od_strdup(cached->value);
 	od_route_pswd_unref(cached);
 	if (client->password.password == NULL) {

--- a/sources/include/route.h
+++ b/sources/include/route.h
@@ -24,6 +24,7 @@
 
 typedef struct {
 	atomic_int_fast64_t refs;
+	bool is_null;
 	char value[];
 } od_route_pswd_t;
 

--- a/sources/route.c
+++ b/sources/route.c
@@ -197,7 +197,7 @@ void od_route_signal_locked(od_route_t *route, od_server_t *server)
 
 od_route_pswd_t *od_route_pswd_create(const char *value)
 {
-	size_t len = strlen(value);
+	size_t len = value == NULL ? 0 : strlen(value);
 	size_t t = sizeof(od_route_pswd_t) + len + 1;
 
 	od_route_pswd_t *p = od_malloc(t);
@@ -208,8 +208,11 @@ od_route_pswd_t *od_route_pswd_create(const char *value)
 	memset(p, 0, t);
 
 	atomic_store(&p->refs, 1);
+	p->is_null = value == NULL;
 
-	memcpy(p->value, value, len + 1);
+	if (!p->is_null) {
+		memcpy(p->value, value, len + 1);
+	}
 
 	return p;
 }

--- a/test/functional/bin/setup
+++ b/test/functional/bin/setup
@@ -31,6 +31,7 @@ host   ldap_db1        ldap_readonly                 127.0.0.1/32 password
 host   ldap_db2        ldap_rw                       127.0.0.1/32 md5
 host   auth_query_db   auth_query_user_scram_sha_256 127.0.0.1/32 trust
 host   auth_query_db   auth_query_user_md5           127.0.0.1/32 trust
+host   auth_query_db   auth_query_user_null_password 127.0.0.1/32 trust
 local  all             postgres                                   trust
 host   postgres        user1                         127.0.0.1/32 trust
 host   db1             user1                         127.0.0.1/32 trust
@@ -100,6 +101,14 @@ psql -h localhost -p 5432 -U postgres -c "create role user1 with login;create ro
 # Create users
 psql -h localhost -p 5432 -U postgres -c "set password_encryption TO 'md5'; create user auth_query_user_md5 with password 'passwd'" -d postgres >> $SETUP_LOG 2>&1 || {
     echo "ERROR: users creation failed, examine the log"
+    cat "$SETUP_LOG"
+    cat "$PG_LOG"
+    exit 1
+}
+
+# Create users
+psql -h localhost -p 5432 -U postgres -c "create role auth_query_user_null_password login password null" -d postgres >> $SETUP_LOG 2>&1 || {
+    echo "ERROR: null-password user creation failed, examine the log"
     cat "$SETUP_LOG"
     cat "$PG_LOG"
     exit 1

--- a/test/functional/tests/auth_query/config.conf
+++ b/test/functional/tests/auth_query/config.conf
@@ -41,6 +41,18 @@ database "auth_query_db" {
 
 		pool "session"
 	}
+
+	user "auth_query_user_null_password" {
+		authentication "md5"
+
+		auth_query "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"
+		auth_query_user "postgres"
+		auth_query_db "postgres"
+
+		storage "postgres_server"
+
+		pool "session"
+	}
 }
 
 daemonize yes

--- a/test/functional/tests/auth_query/runner.sh
+++ b/test/functional/tests/auth_query/runner.sh
@@ -5,6 +5,33 @@ set -ex
 /usr/bin/odyssey /tests/auth_query/config.conf
 sleep 1
 
+odyssey_pid=$(cat /var/run/odyssey.pid)
+
+check_null_password_rejected() {
+	if PGPASSWORD=passwd PGCONNECT_TIMEOUT=5 psql -h localhost -p 6432 \
+		-U auth_query_user_null_password -c "SELECT 1" auth_query_db; then
+		echo "ERROR: auth_query accepted a user with a NULL password"
+		cat /var/log/odyssey.log
+		exit 1
+	fi
+
+	if ! kill -0 "$odyssey_pid"; then
+		echo "ERROR: Odyssey crashed after auth_query returned a NULL password"
+		for i in /asan-output*; do
+			if [ -f "$i" ]; then
+				cat "$i"
+			fi
+		done
+		cat /var/log/odyssey.log
+		cat /var/log/postgresql/postgresql-16-main.log
+		exit 1
+	fi
+}
+
+# The first attempt populates the negative cache entry; the second reuses it.
+check_null_password_rejected
+check_null_password_rejected
+
 timeout 25s pgbench 'host=localhost port=6432 user=auth_query_user_scram_sha_256 dbname=auth_query_db password=passwd' -f /tests/auth_query/select.sql -T 21 --connect --no-vacuum -j2 -c2 --progress 1 || {
 	echo "ERROR: failed backend auth with correct password"
 	sleep 1


### PR DESCRIPTION
Auth queries may return SQL NULL for users without a password. The route cache passed this value to string operations, causing Odyssey to crash.
This change preserves NULL as a distinct cached value, rejects authentication normally, and adds functional coverage for initial and cached lookups.

## How to reproduce the problem
```sql
CREATE ROLE user_empty_pass LOGIN PASSWORD NULL;
```
attemt to connect to Ody by this role
```
Core was generated by `odyssey 1.5.3-rc1 (git 312eb0df) l'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
74      ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
[Current thread is 1 (Thread 0x7f70d6565640 (LWP 50771))]
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x000055b997e52e01 in od_route_pswd_create (value=0x0) at /home/yarchirkov/odyssey_groups/odyssey/sources/route.c:200
#2  0x000055b997e69f23 in pswd_update_task (a=0x7f70c4040a50) at /home/yarchirkov/odyssey_groups/odyssey/sources/auth_query.c:229
#3  0x000055b997e2368c in mm_scheduler_main (arg=0x7f70c4040d00) at /home/yarchirkov/odyssey_groups/odyssey/sources/machinarium/scheduler.c:23
#4  0x000055b997e22e2b in mm_context_runner () at /home/yarchirkov/odyssey_groups/odyssey/sources/machinarium/context.c:57
#5  0x0000000000000000 in ?? ()
(gdb) frame 2
#2  0x000055b997e69f23 in pswd_update_task (a=0x7f70c4040a50) at /home/yarchirkov/odyssey_groups/odyssey/sources/auth_query.c:229
229                     od_route_pswd_t *new = od_route_pswd_create(password.password);
(gdb) p arg->user
$1 = "user_empty_pass", '\000' <repeats 112 times>
(gdb) p password.password
$2 = 0x0
(gdb) p password.password_len
$3 = 0
```