### PR TITLE
Add application_name to log_format

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -174,6 +174,7 @@ Supported flags:
 %s = server ID
 %u = user name
 %d = database name
+%a = application_name
 %c = context
 %l = level (error, warning, debug)
 %m = message

--- a/sources/include/logger.h
+++ b/sources/include/logger.h
@@ -50,6 +50,7 @@ typedef enum {
 	OD_FMT_SERVER_ID, /* %s  */
 	OD_FMT_USER, /* %u  */
 	OD_FMT_DATABASE, /* %d  */
+	OD_FMT_APPLICATION_NAME, /* %a  */
 	OD_FMT_EXTERNAL_ID, /* %x  */
 	OD_FMT_CLIENT_HOST, /* %h  */
 	OD_FMT_CLIENT_PORT, /* %r  */

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -148,6 +148,8 @@ static inline od_fmt_token_type_t od_logger_format_parse_specifier(char c)
 		return OD_FMT_USER;
 	case 'd':
 		return OD_FMT_DATABASE;
+	case 'a':
+		return OD_FMT_APPLICATION_NAME;
 	case 'x':
 		return OD_FMT_EXTERNAL_ID;
 	case 'h':
@@ -677,6 +679,16 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 					dst_pos, dst_end, "none");
 			}
 			break;
+		case OD_FMT_APPLICATION_NAME: {
+			kiwi_var_t *var = NULL;
+			if (client) {
+				var = kiwi_vars_get(&client->vars,
+						    KIWI_VAR_APPLICATION_NAME);
+			}
+			dst_pos += od_logger_append_str(
+				dst_pos, dst_end, var ? var->value : "none");
+			break;
+		}
 		case OD_FMT_EXTERNAL_ID:
 			if (client && client->external_id != NULL) {
 				dst_pos += od_logger_append_str(


### PR DESCRIPTION
Add `%a` to `log_format` to include the client's current `application_name` in log messages. It prints `none` when no client or application name is available and preserves explicitly empty names

Fixes #709