### PR TITLE
Fix ucontext build configuration include order

### DIFF
--- a/sources/include/machinarium/context.h
+++ b/sources/include/machinarium/context.h
@@ -6,6 +6,8 @@
  * cooperative multitasking engine.
  */
 
+#include <machinarium/build.h>
+
 #ifdef USE_UCONTEXT
 #include <ucontext.h>
 #endif


### PR DESCRIPTION
Builds using ucontext, including ppc64el and loong64, fail with an unknown `ucontext_t` type and an implicit declaration of `swapcontext`.

Include `machinarium/build.h` before the first `USE_UCONTEXT` check in `context.h`. Previously, the macro became defined through `context_stack.h` only after the conditional inclusion of `<ucontext.h>` had been skipped.

Reproduced the header compilation failure. After the fix, standalone header compilation passes with GCC and Clang.

Fixes #1536
