### PR TITLE
SCRAM: use the actual salt length

### DIFF
--- a/sources/scram.c
+++ b/sources/scram.c
@@ -306,7 +306,7 @@ error:
 int read_server_first_message(od_scram_state_t *scram_state, char *auth_data,
 			      size_t auth_data_size, char **server_nonce_ptr,
 			      size_t *server_nonce_size_ptr, uint8_t **salt_ptr,
-			      int *iterations_ptr)
+			      int *salt_len_ptr, int *iterations_ptr)
 {
 	scram_state->server_first_message =
 		od_strdup_from_buf(auth_data, auth_data_size);
@@ -368,6 +368,7 @@ int read_server_first_message(od_scram_state_t *scram_state, char *auth_data,
 	*server_nonce_ptr = server_nonce;
 	*server_nonce_size_ptr = server_nonce_size;
 	*salt_ptr = salt;
+	*salt_len_ptr = salt_len;
 	*iterations_ptr = iterations;
 
 	return 0;
@@ -381,7 +382,7 @@ error:
 
 static int calculate_client_proof(od_scram_state_t *scram_state,
 				  const char *password, const uint8_t *salt,
-				  int iterations,
+				  int salt_len, int iterations,
 				  const char *client_final_message,
 				  uint8_t *client_proof)
 {
@@ -411,8 +412,8 @@ static int calculate_client_proof(od_scram_state_t *scram_state,
 			return -1;
 		}
 
-		od_scram_SaltedPassword(prepared_password, salt,
-					SCRAM_DEFAULT_SALT_LEN, iterations,
+		od_scram_SaltedPassword(prepared_password, salt, salt_len,
+					iterations,
 					scram_state->salted_password, &errstr);
 		od_scram_ClientKey(scram_state->salted_password, client_key,
 				   &errstr);
@@ -486,11 +487,12 @@ od_scram_create_client_final_message(od_scram_state_t *scram_state,
 	char *server_nonce;
 	size_t server_nonce_size;
 	uint8_t *salt;
+	int salt_len;
 	int iterations;
 
 	int rc = read_server_first_message(scram_state, auth_data,
 					   auth_data_size, &server_nonce,
-					   &server_nonce_size, &salt,
+					   &server_nonce_size, &salt, &salt_len,
 					   &iterations);
 	if (rc == -1) {
 		return NULL;
@@ -515,8 +517,8 @@ od_scram_create_client_final_message(od_scram_state_t *scram_state,
 	}
 
 	uint8_t client_proof[OD_SCRAM_MAX_KEY_LEN];
-	rc = calculate_client_proof(scram_state, password, salt, iterations,
-				    result, client_proof);
+	rc = calculate_client_proof(scram_state, password, salt, salt_len,
+				    iterations, result, client_proof);
 	od_free(salt);
 	if (rc == -1) {
 		goto error;

--- a/test/functional/tests/scram/test_scram_backend.sh
+++ b/test/functional/tests/scram/test_scram_backend.sh
@@ -61,3 +61,69 @@ for _ in $(seq 1 5); do
                 exit 1
         }
 done
+
+original_verifier=$(psql -h ip4-localhost -U postgres -d scram_db -At \
+        -v ON_ERROR_STOP=1 -c "SELECT rolpassword FROM pg_authid WHERE rolname = 'scram_user'") || exit 1
+
+restore_password() {
+        psql -h ip4-localhost -U postgres -d scram_db -v ON_ERROR_STOP=1 \
+                -v verifier="$original_verifier" <<'SQL' || exit 1
+ALTER ROLE scram_user PASSWORD :'verifier';
+SQL
+}
+trap restore_password EXIT
+
+for salt_len in 8 32; do
+        echo "Testing backend SCRAM with salt length $salt_len"
+        verifier=$(python3 - "$salt_len" <<'PY'
+import base64
+import hashlib
+import hmac
+import sys
+
+salt = bytes(range(int(sys.argv[1])))
+salted_password = hashlib.pbkdf2_hmac('sha256', b'scram_user_password', salt, 4096)
+client_key = hmac.digest(salted_password, b'Client Key', 'sha256')
+stored_key = hashlib.sha256(client_key).digest()
+server_key = hmac.digest(salted_password, b'Server Key', 'sha256')
+salt, stored_key, server_key = (
+    base64.b64encode(value).decode() for value in (salt, stored_key, server_key)
+)
+print(f'SCRAM-SHA-256$4096:{salt}${stored_key}:{server_key}')
+PY
+        ) || exit 1
+        psql -h ip4-localhost -U postgres -d scram_db -v ON_ERROR_STOP=1 \
+                -v verifier="$verifier" <<'SQL' || exit 1
+ALTER ROLE scram_user PASSWORD :'verifier';
+SQL
+
+        # Drop pooled connections so the new verifier is used for authentication.
+        ody-stop || exit 1
+        /usr/bin/odyssey /tests/scram/config.conf || exit 1
+        for _ in $(seq 1 50); do
+                pg_isready -q -h ip4-localhost -p 6432 -d scram_db \
+                        -U backend_auth_with_correct_password && break
+                sleep 0.1
+        done
+
+        PGPASSWORD=scram_user_password psql -w -v ON_ERROR_STOP=1 \
+                'host=ip4-localhost port=5432 user=scram_user dbname=scram_db sslmode=disable' -c "SELECT 1" || exit 1
+
+        for _ in $(seq 1 5); do
+                psql -w -v ON_ERROR_STOP=1 \
+                        'host=ip4-localhost port=6432 user=backend_auth_with_correct_password dbname=scram_db sslmode=disable' -c "SELECT 1" 2>&1 || {
+                        echo "ERROR: failed backend auth with salt length $salt_len"
+                        cat /var/log/odyssey.log
+                        exit 1
+                }
+        done
+
+        psql -w -v ON_ERROR_STOP=1 \
+                'host=ip4-localhost port=6432 user=backend_auth_with_incorrect_password dbname=scram_db sslmode=disable' -c "SELECT 1" 2>&1 && {
+                echo "ERROR: accepted incorrect password with salt length $salt_len"
+                cat /var/log/odyssey.log
+                exit 1
+        }
+done
+
+exit 0


### PR DESCRIPTION
Pass the decoded salt length to the client proof calculation instead of assuming SCRAM_DEFAULT_SALT_LEN

Fixes #1568
