### PR TITLE
Fix memory leak in backend_startup_options cleanup

### DIFF
--- a/sources/cfg/convert.c
+++ b/sources/cfg/convert.c
@@ -938,8 +938,8 @@ static int convert_rule_settings(const od_cfg_route_t *cfg, od_list_t *spools,
 		rule->backend_startup_vars_sz =
 			cfg->backend_startup_options.pairs_count;
 		rule->backend_startup_vars =
-			od_malloc(sizeof(untyped_kiwi_var_t) *
-				  rule->backend_startup_vars_sz);
+			od_calloc(rule->backend_startup_vars_sz,
+				  sizeof(untyped_kiwi_var_t));
 		if (rule->backend_startup_vars == NULL) {
 			od_cfg_diag_error(
 				diags, cfg->location,

--- a/sources/rules.c
+++ b/sources/rules.c
@@ -681,6 +681,13 @@ static void od_rules_rule_free_now(od_rule_t *rule)
 	if (rule->shared_pool) {
 		od_shared_pool_unref(rule->shared_pool);
 	}
+	if (rule->backend_startup_vars) {
+		for (size_t j = 0; j < rule->backend_startup_vars_sz; j++) {
+			od_free(rule->backend_startup_vars[j].name);
+			od_free(rule->backend_startup_vars[j].value);
+		}
+		od_free(rule->backend_startup_vars);
+	}
 
 	od_list_t *i, *n;
 	od_list_foreach_safe (&rule->auth_common_names, i, n) {


### PR DESCRIPTION
Rules containing `backend_startup_options` leak the parameter array and its duplicated name/value strings when released.

Free these allocations during rule cleanup and zero-initialize the array so partially constructed entries can be freed safely

Fixes #1584
