### PR TITLE
Fix application_name reset in session pooling

### DIFF
--- a/sources/backend.c
+++ b/sources/backend.c
@@ -338,7 +338,7 @@ int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
 
 #define DEFAULT_ARGV_SIZE 6
 
-	kiwi_fe_arg_t argv[DEFAULT_ARGV_SIZE +
+	kiwi_fe_arg_t argv[DEFAULT_ARGV_SIZE + 2 +
 			   2 * route->rule->backend_startup_vars_sz];
 
 	kiwi_fe_arg_t default_argv[] = {
@@ -380,6 +380,22 @@ int od_backend_startup(od_server_t *server, kiwi_params_t *route_params,
 		argv[argc + 1].name = "database";
 		argv[argc + 1].len = 9;
 		argc += 2;
+	}
+
+	kiwi_var_unset(&server->startup_application_name);
+	if (route_params == NULL && client != NULL &&
+	    client->type == OD_POOL_CLIENT_EXTERNAL &&
+	    client->rule->maintain_params &&
+	    client->rule->pool->pool_type == OD_RULE_POOL_SESSION) {
+		kiwi_var_t *app = &client->startup_application_name;
+		if (app->value_len > 0) {
+			argv[argc].name = app->name;
+			argv[argc].len = app->name_len;
+			argv[argc + 1].name = app->value;
+			argv[argc + 1].len = app->value_len;
+			argc += 2;
+			server->startup_application_name = *app;
+		}
 	}
 
 	machine_msg_t *msg;

--- a/sources/client.c
+++ b/sources/client.c
@@ -39,6 +39,8 @@ void od_client_init(od_client_t *client)
 
 	kiwi_be_startup_init(&client->startup);
 	kiwi_vars_init(&client->vars);
+	kiwi_var_init(&client->startup_application_name, "application_name",
+		      sizeof("application_name"));
 	kiwi_key_init(&client->key);
 
 	od_io_init(&client->io);

--- a/sources/frontend.c
+++ b/sources/frontend.c
@@ -520,6 +520,18 @@ static inline od_frontend_status_t od_frontend_attach_to_endpoint(
 				continue;
 			}
 		}
+		if (!od_backend_need_startup(server) && route_params == NULL &&
+		    client->rule->maintain_params &&
+		    client->rule->pool->pool_type == OD_RULE_POOL_SESSION &&
+		    !kiwi_var_compare(&client->startup_application_name,
+				      &server->startup_application_name)) {
+			od_debug(
+				&instance->logger, context, client, server,
+				"startup application_name differs, reconnecting");
+			od_router_close(router, client);
+			wait_for_idle = false;
+			continue;
+		}
 		od_debug(&instance->logger, context, client, server,
 			 "client %s%.*s attached to %s%.*s",
 			 client->id.id_prefix, (int)sizeof(client->id.id),
@@ -2963,6 +2975,8 @@ void od_frontend(void *arg)
 		if (rc == -1) {
 			goto cleanup;
 		}
+		client->startup_application_name =
+			*kiwi_vars_of(&client->vars, KIWI_VAR_APPLICATION_NAME);
 
 		/* set network options */
 		od_rule_t *rule = route->rule;

--- a/sources/include/client.h
+++ b/sources/include/client.h
@@ -49,6 +49,7 @@ struct od_client {
 
 	kiwi_be_startup_t startup;
 	kiwi_vars_t vars;
+	kiwi_var_t startup_application_name;
 	kiwi_key_t key;
 
 	/* do not set this field directly, use od_server_attach_client */

--- a/sources/include/server.h
+++ b/sources/include/server.h
@@ -71,6 +71,7 @@ struct od_server {
 	kiwi_key_t key;
 	kiwi_key_t key_client;
 	kiwi_vars_t vars;
+	kiwi_var_t startup_application_name;
 
 	machine_msg_t *error_connect;
 	/* do not set this field directly, use od_server_attach_client */
@@ -130,6 +131,8 @@ static inline void od_server_init(od_server_t *server, int reserve_prep_stmts)
 	kiwi_key_init(&server->key);
 	kiwi_key_init(&server->key_client);
 	kiwi_vars_init(&server->vars);
+	kiwi_var_init(&server->startup_application_name, "application_name",
+		      sizeof("application_name"));
 
 	od_io_init(&server->io);
 	od_list_init(&server->link);

--- a/test/functional/tests/session-params/odyssey.conf
+++ b/test/functional/tests/session-params/odyssey.conf
@@ -1,0 +1,26 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+log_format "%p %t %l (%c) %m\n"
+log_file "/var/log/odyssey.log"
+log_to_stdout no
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}
+
+storage "postgres" {
+	type "remote"
+	host "127.0.0.1:5432"
+}
+
+database "postgres" {
+	user "session_params" {
+		authentication "none"
+		storage "postgres"
+		storage_user "postgres"
+		pool "session"
+		pool_size 1
+		pool_timeout 5000
+	}
+}

--- a/test/functional/tests/session-params/runner.sh
+++ b/test/functional/tests/session-params/runner.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+results=$(mktemp -d)
+cleanup() {
+    local status=$?
+    ody-stop || status=1
+    rm -rf "$results"
+    exit "$status"
+}
+trap cleanup EXIT
+
+/usr/bin/odyssey /tests/session-params/odyssey.conf
+timeout 5 bash -c 'until pg_isready -h 127.0.0.1 -p 6432 -U session_params -d postgres >/dev/null; do sleep 0.05; done'
+
+sql=/tests/session-params/sql/reset.sql
+previous_app=
+previous_pid=
+for app in first_client first_client second_client; do
+    PGAPPNAME="$app" psql -X -Atq -v ON_ERROR_STOP=1 \
+        'host=127.0.0.1 port=5432 user=postgres dbname=postgres connect_timeout=5' \
+        -f "$sql" > "$results/direct.out"
+    PGAPPNAME="$app" psql -X -Atq -v ON_ERROR_STOP=1 \
+        'host=127.0.0.1 port=6432 user=session_params dbname=postgres connect_timeout=5' \
+        -f "$sql" > "$results/odyssey.out"
+
+    # The last row is the backend PID, checked separately for connection reuse.
+    diff -u <(sed '$d' "$results/direct.out") <(sed '$d' "$results/odyssey.out")
+    pid=$(tail -n 1 "$results/odyssey.out")
+    if [ "$app" = "$previous_app" ] && [ "$pid" != "$previous_pid" ]; then
+        echo "Backend was not reused with application_name=$app"
+        exit 1
+    fi
+    previous_app=$app
+    previous_pid=$pid
+done
+
+echo "session application_name reset: ok"

--- a/test/functional/tests/session-params/sql/reset.sql
+++ b/test/functional/tests/session-params/sql/reset.sql
@@ -1,0 +1,12 @@
+SHOW application_name;
+SET application_name = 'changed';
+RESET application_name;
+SHOW application_name;
+SET application_name = 'changed';
+RESET ALL;
+SHOW application_name;
+SET application_name = 'changed';
+DISCARD ALL;
+SHOW application_name;
+SELECT pg_backend_pid();
+SET application_name = 'left_by_previous_client';


### PR DESCRIPTION
In session pooling with `maintain_params yes`, `RESET application_name`, `RESET ALL` and `DISCARD ALL` reset `application_name` to an empty string instead of its initial value. Odyssey applies the client value through `SET`, which does not change PostgreSQL's reset value.

Pass the client's initial `application_name` in the backend startup message. Reconnect a pooled backend when the next client's initial name differs. Clients with the same initial name can reuse the connection.

Fixes #1516