### PR TITLE
Fix HBA matching for default database and user rules

### DIFF
--- a/sources/hba.c
+++ b/sources/hba.c
@@ -215,13 +215,14 @@ int od_hba_process(od_client_t *client)
 			}
 		}
 
-		if (!od_hba_validate_name(client->rule->db_name,
+		if (!od_hba_validate_name(client->startup.database.value,
 					  &rule->database,
-					  client->rule->user_name)) {
+					  client->startup.user.value)) {
 			continue;
 		}
-		if (!od_hba_validate_name(client->rule->user_name, &rule->user,
-					  client->rule->db_name)) {
+		if (!od_hba_validate_name(client->startup.user.value,
+					  &rule->user,
+					  client->startup.database.value)) {
 			continue;
 		}
 

--- a/test/functional/tests/hba/common.conf
+++ b/test/functional/tests/hba/common.conf
@@ -36,6 +36,17 @@ database "hba_db" {
         }
 }
 
+database default {
+    user default {
+        authentication "clear_text"
+        password "correct_password"
+        storage "postgres_server"
+        storage_db "hba_db"
+        storage_user "user_allow"
+        pool "session"
+    }
+}
+
 daemonize yes
 pid_file "/var/run/odyssey.pid"
 

--- a/test/functional/tests/hba/odyssey_hba.conf
+++ b/test/functional/tests/hba/odyssey_hba.conf
@@ -2,3 +2,6 @@ local   hba_db    user_allow     allow
 local   hba_db    user_reject    deny
 host    hba_db    user_allow     127.0.0.0/24     allow
 host    hba_db    user_reject    127.0.0.0/24     deny
+host    hba_default_db    hba_denied       127.0.0.0/24     deny
+host    hba_default_db    all              127.0.0.0/24     allow
+host    sameuser          all              127.0.0.0/24     allow

--- a/test/functional/tests/hba/runner.sh
+++ b/test/functional/tests/hba/runner.sh
@@ -85,6 +85,8 @@ PGPASSWORD=correct_password PGCONNECT_TIMEOUT=5 psql -h ip4-localhost -p 6432 -U
 	exit 1
 }
 
+bash /tests/hba/test_hba_names.sh ip4-localhost
+
 ody-stop
 
 #

--- a/test/functional/tests/hba/test_hba_names.sh
+++ b/test/functional/tests/hba/test_hba_names.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export PGPASSWORD=correct_password
+export PGCONNECT_TIMEOUT=5
+export PGSSLMODE=disable
+
+host=$1
+port=${PGPORT:-6432}
+
+query() {
+    psql -X -w -v ON_ERROR_STOP=1 -At -h "$host" -p "$port" \
+        -d "$1" -U "$2" -c 'SELECT current_user, current_database()'
+}
+
+check_allowed() {
+    local result
+    result=$(query "$1" "$2")
+    if [[ "$result" != 'user_allow|hba_db' ]]; then
+        echo "ERROR: unexpected backend identity for $1/$2: $result"
+        exit 1
+    fi
+    echo "OK: HBA allows $1/$2 via $host"
+}
+
+check_rejected() {
+    local result
+    if result=$(query "$1" "$2" 2>&1); then
+        echo "ERROR: HBA allowed $1/$2"
+        exit 1
+    fi
+    if [[ "$result" != *'host based authentication rejected'* ]]; then
+        echo "ERROR: expected HBA rejection for $1/$2: $result"
+        exit 1
+    fi
+    echo "OK: HBA rejects $1/$2 via $host"
+}
+
+check_allowed hba_default_db hba_allowed
+check_rejected hba_default_db hba_denied
+check_rejected hba_unknown_db hba_allowed
+check_allowed hba_sameuser hba_sameuser
+check_rejected hba_sameuser hba_otheruser


### PR DESCRIPTION
With `database default` or `user default`, HBA checks use the configured rule names instead of the client's database and username. This can reject connections that should match an HBA entry.

Use the client's startup parameters for database, user and `sameuser` matching.

Fixes #846
