### PR TITLE
Escape client fields in text logs

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -175,6 +175,7 @@ Supported flags:
 %u = user name
 %d = database name
 %a = application_name
+%x = external user ID
 %c = context
 %l = level (error, warning, debug)
 %m = message

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -396,6 +396,7 @@ set(od_test_src
     tests/odyssey/test_attribute.c
     tests/odyssey/test_tdigest.c
     tests/odyssey/test_util.c
+    tests/odyssey/test_logger_escape.c
     tests/odyssey/test_hba_parse.c
     tests/odyssey/test_address.c
     tests/odyssey/test_affinity.c

--- a/sources/logger.c
+++ b/sources/logger.c
@@ -372,17 +372,13 @@ static char od_logger_escape_tab[256] = {
 	['\r'] = 'r', ['\\'] = '\\', ['='] = '='
 };
 
-__attribute__((hot)) static inline int od_logger_escape(char *dest, int size,
-							char *fmt, va_list args)
+__attribute__((hot)) static inline int
+od_logger_escape(char *dest, int size, const char *src, int len)
 {
-	char prefmt[512];
-	int prefmt_len;
-	prefmt_len = od_vsnprintf(prefmt, sizeof(prefmt), fmt, args);
-
 	char *dst_pos = dest;
 	char *dst_end = dest + size;
-	char *msg_pos = prefmt;
-	char *msg_end = prefmt + prefmt_len;
+	const char *msg_pos = src;
+	const char *msg_end = src + len;
 
 	while (msg_pos < msg_end) {
 		char escaped_char;
@@ -404,6 +400,14 @@ __attribute__((hot)) static inline int od_logger_escape(char *dest, int size,
 		msg_pos++;
 	}
 	return dst_pos - dest;
+}
+
+__attribute__((hot)) static inline int
+od_logger_escape_message(char *dest, int size, char *fmt, va_list args)
+{
+	char prefmt[512];
+	int len = od_vsnprintf(prefmt, sizeof(prefmt), fmt, args);
+	return od_logger_escape(dest, size, prefmt, len);
 }
 
 /* should be faster than od_snprintf("%s") */
@@ -516,7 +520,8 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 		 va_list args, char *output, int output_len)
 {
 	char *dst_pos = output;
-	char *dst_end = output + output_len;
+	/* Reserve space for the final newline and the async slot's NUL. */
+	char *dst_end = output + output_len - 2;
 	char peer[128];
 
 	/* Fast path: iterate over pre-compiled tokens. */
@@ -530,6 +535,9 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 	int tm_parsed = 0;
 
 	for (int i = 0; i < n; i++) {
+		if (dst_pos == dst_end) {
+			goto format_done;
+		}
 		od_fmt_token_t *tok = &tokens[i];
 		switch (tok->type) {
 		case OD_FMT_LITERAL: {
@@ -634,8 +642,8 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 						args);
 			break;
 		case OD_FMT_MESSAGE_ESC:
-			dst_pos += od_logger_escape(dst_pos, dst_end - dst_pos,
-						    fmt, args);
+			dst_pos += od_logger_escape_message(
+				dst_pos, dst_end - dst_pos, fmt, args);
 			break;
 		case OD_FMT_CLIENT_ID:
 			if (client && client->id.id_prefix != NULL) {
@@ -661,9 +669,10 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 			break;
 		case OD_FMT_USER:
 			if (client && client->startup.user.value_len) {
-				dst_pos += od_logger_append_str(
-					dst_pos, dst_end,
-					client->startup.user.value);
+				dst_pos += od_logger_escape(
+					dst_pos, dst_end - dst_pos,
+					client->startup.user.value,
+					client->startup.user.value_len - 1);
 			} else {
 				dst_pos += od_logger_append_str(
 					dst_pos, dst_end, "none");
@@ -671,9 +680,10 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 			break;
 		case OD_FMT_DATABASE:
 			if (client && client->startup.database.value_len) {
-				dst_pos += od_logger_append_str(
-					dst_pos, dst_end,
-					client->startup.database.value);
+				dst_pos += od_logger_escape(
+					dst_pos, dst_end - dst_pos,
+					client->startup.database.value,
+					client->startup.database.value_len - 1);
 			} else {
 				dst_pos += od_logger_append_str(
 					dst_pos, dst_end, "none");
@@ -685,14 +695,23 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 				var = kiwi_vars_get(&client->vars,
 						    KIWI_VAR_APPLICATION_NAME);
 			}
-			dst_pos += od_logger_append_str(
-				dst_pos, dst_end, var ? var->value : "none");
+			if (var && var->value_len) {
+				dst_pos += od_logger_escape(dst_pos,
+							    dst_end - dst_pos,
+							    var->value,
+							    var->value_len - 1);
+			} else {
+				dst_pos += od_logger_append_str(
+					dst_pos, dst_end, "none");
+			}
 			break;
 		}
 		case OD_FMT_EXTERNAL_ID:
 			if (client && client->external_id != NULL) {
-				dst_pos += od_logger_append_str(
-					dst_pos, dst_end, client->external_id);
+				dst_pos += od_logger_escape(
+					dst_pos, dst_end - dst_pos,
+					client->external_id,
+					strlen(client->external_id));
 			} else {
 				dst_pos += od_logger_append_str(
 					dst_pos, dst_end, "none");
@@ -742,7 +761,7 @@ od_logger_format(od_logger_t *logger, od_logger_level_t level, char *context,
 
 format_done:
 	/* append new line, if format string doesn't have it */
-	if (dst_pos < dst_end && dst_pos > output && *(dst_pos - 1) != '\n') {
+	if (dst_pos > output && *(dst_pos - 1) != '\n') {
 		*dst_pos = '\n';
 		++dst_pos;
 	}

--- a/sources/tests/odyssey/test_logger_escape.c
+++ b/sources/tests/odyssey/test_logger_escape.c
@@ -1,0 +1,138 @@
+/*
+ * Odyssey.
+ *
+ * Scalable PostgreSQL connection pooler.
+ */
+
+#include <odyssey.h>
+
+#include <kiwi/kiwi.h>
+#include <client.h>
+#include <logger.h>
+
+#include <tests/odyssey_test.h>
+
+static void test_logger_output(od_client_t *client, char *format, char *message,
+			       const char *expected, size_t expected_len)
+{
+	for (int async = 0; async <= 1; ++async) {
+		od_logger_t logger;
+		test(od_logger_init(&logger, NULL) == OK_RESPONSE);
+		od_logger_set_stdout(&logger, 0);
+		od_logger_set_async(&logger, async);
+		od_logger_set_format(&logger, format);
+
+		FILE *file = tmpfile();
+		test(file != NULL);
+		int fd = dup(fileno(file));
+		test(fd != -1);
+		atomic_store(&logger.fd, fd);
+
+		od_logger_slot_t slot;
+		memset(&slot, 0, sizeof(slot));
+		if (async) {
+			mm_lf_stack_push(&logger.free_slots, &slot.link);
+			atomic_store(&logger.state, OD_LOGGER_ONLINE);
+		}
+
+		od_log(&logger, "test", client, NULL, "%s", message);
+		od_logger_flush(&logger);
+		if (async) {
+			test(slot.len < sizeof(slot.text));
+			test(slot.text[slot.len] == '\0');
+		}
+
+		char output[OD_LOGLINE_MAXLEN + 1];
+		ssize_t len = pread(fd, output, sizeof(output), 0);
+		test(len == (ssize_t)expected_len);
+		test(memcmp(output, expected, expected_len) == 0);
+		od_logger_close(&logger);
+		test(fclose(file) == 0);
+	}
+}
+
+void odyssey_test_logger_escape(void)
+{
+	od_client_t client;
+	memset(&client, 0, sizeof(client));
+	kiwi_be_startup_init(&client.startup);
+	kiwi_vars_init(&client.vars);
+
+	char *format = "tskv\\tuser=%u\\tdb=%d\\tapp=%a\\tid=%x\\tmsg=%M\\n";
+	char *missing = "tskv\tuser=none\tdb=none\tapp=none\tid=none\tmsg=ok\n";
+	test_logger_output(NULL, format, "ok", missing, strlen(missing));
+	test_logger_output(&client, format, "ok", missing, strlen(missing));
+
+	char too_long[KIWI_MAX_VAR_SIZE + 1];
+	memset(too_long, 'a', sizeof(too_long) - 1);
+	too_long[sizeof(too_long) - 1] = '\0';
+	test(kiwi_vars_set(&client.vars, KIWI_VAR_APPLICATION_NAME, too_long,
+			   sizeof(too_long)) == -1);
+	test_logger_output(&client, format, "ok", missing, strlen(missing));
+
+	struct {
+		char *input;
+		char *escaped;
+	} cases[] = {
+		{ "\nuser1", "\\nuser1" },
+		{ "\r\tkey=value\\", "\\r\\tkey\\=value\\\\" },
+		{ "\\n%u", "\\\\n%u" },
+		{ "user 'name' \"app\"", "user 'name' \"app\"" },
+		{ "пользователь", "пользователь" },
+		{ "", "" },
+	};
+	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+		char *input = cases[i].input;
+		char *escaped = cases[i].escaped;
+		int len = strlen(input) + 1;
+		test(kiwi_var_set(&client.startup.user, KIWI_VAR_UNDEF, input,
+				  len) == 0);
+		test(kiwi_var_set(&client.startup.database, KIWI_VAR_UNDEF,
+				  input, len) == 0);
+		test(kiwi_vars_set(&client.vars, KIWI_VAR_APPLICATION_NAME,
+				   input, len) == 0);
+		client.external_id = input;
+
+		char expected[OD_LOGLINE_MAXLEN];
+		int expected_len = snprintf(
+			expected, sizeof(expected),
+			"tskv\tuser=%s\tdb=%s\tapp=%s\tid=%s\tmsg=%s\n",
+			escaped, escaped, escaped, escaped, escaped);
+		test_logger_output(&client, format, input, expected,
+				   expected_len);
+		test(strcmp(client.startup.user.value, input) == 0);
+		test(strcmp(client.startup.database.value, input) == 0);
+		test(strcmp(kiwi_vars_get(&client.vars,
+					  KIWI_VAR_APPLICATION_NAME)
+				    ->value,
+			    input) == 0);
+	}
+}
+
+void odyssey_test_logger_escape_truncation(void)
+{
+	od_client_t client;
+	memset(&client, 0, sizeof(client));
+	char input[OD_LOGLINE_MAXLEN + 1];
+	memset(input, '\n', sizeof(input) - 1);
+	input[sizeof(input) - 1] = '\0';
+	client.external_id = input;
+
+	char expected[OD_LOGLINE_MAXLEN];
+	for (size_t i = 0; i < sizeof(expected) - 2; i += 2) {
+		expected[i] = '\\';
+		expected[i + 1] = 'n';
+	}
+	expected[sizeof(expected) - 2] = '\n';
+	test_logger_output(&client, "%x", "", expected, sizeof(expected) - 1);
+	test_logger_output(&client, "%x%m", "ignored", expected,
+			   sizeof(expected) - 1);
+	test_logger_output(NULL, "%M", input, expected, sizeof(expected) - 1);
+	expected[0] = '!';
+	for (size_t i = 1; i < sizeof(expected) - 3; i += 2) {
+		expected[i] = '\\';
+		expected[i + 1] = 'n';
+	}
+	expected[sizeof(expected) - 3] = '\n';
+	test_logger_output(&client, "!%x", "", expected, sizeof(expected) - 2);
+}

--- a/sources/tests/odyssey_test.c
+++ b/sources/tests/odyssey_test.c
@@ -117,6 +117,8 @@ extern void machinarium_test_mutex_timeout(void);
 extern void odyssey_test_tdigest(void);
 extern void odyssey_test_attribute(void);
 extern void odyssey_test_util(void);
+extern void odyssey_test_logger_escape(void);
+extern void odyssey_test_logger_escape_truncation(void);
 extern void odyssey_test_hba(void);
 extern void odyssey_test_address_parse(void);
 extern void odyssey_test_address_cmp(void);
@@ -237,6 +239,8 @@ int main(int argc, char *argv[])
 	odyssey_test(odyssey_test_tdigest);
 	odyssey_test(odyssey_test_attribute);
 	odyssey_test(odyssey_test_util);
+	odyssey_test(odyssey_test_logger_escape);
+	odyssey_test(odyssey_test_logger_escape_truncation);
 	odyssey_test(odyssey_test_hba);
 	odyssey_test(odyssey_test_address_parse);
 	odyssey_test(odyssey_test_address_cmp);

--- a/test/functional/tests/log-escaping/config.conf
+++ b/test/functional/tests/log-escaping/config.conf
@@ -1,0 +1,25 @@
+daemonize yes
+pid_file "/var/run/odyssey.pid"
+locks_dir "/tmp/odyssey"
+log_to_stdout no
+log_file "/var/log/odyssey.log"
+log_format "tskv\tuser=%u\tdb=%d\tapp=%a\tctx=%c\tmsg=%M\n"
+log_async yes
+
+listen {
+	host "127.0.0.1"
+	port 6432
+}
+
+storage "local" {
+	type "local"
+}
+
+database "console" {
+	user default {
+		authentication "none"
+		role "stat"
+		pool "session"
+		storage "local"
+	}
+}

--- a/test/functional/tests/log-escaping/runner.sh
+++ b/test/functional/tests/log-escaping/runner.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+config=$(mktemp)
+trap 'ody-stop; rm -f "$config"' EXIT
+
+for async in no yes; do
+    sed "s/log_async yes/log_async $async/" \
+        /tests/log-escaping/config.conf > "$config"
+    : > /var/log/odyssey.log
+    /usr/bin/odyssey "$config"
+    python3 /tests/log-escaping/test_log_escaping.py
+    ody-stop
+done

--- a/test/functional/tests/log-escaping/test_log_escaping.py
+++ b/test/functional/tests/log-escaping/test_log_escaping.py
@@ -1,0 +1,63 @@
+import socket
+import struct
+import time
+from pathlib import Path
+
+
+def connect():
+    deadline = time.monotonic() + 5
+    while True:
+        try:
+            return socket.create_connection(("127.0.0.1", 6432), timeout=5)
+        except ConnectionRefusedError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+def read(sock, size):
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        assert chunk, "Connection closed before ErrorResponse"
+        data += chunk
+    return data
+
+
+def main():
+    user = b"\nuser\t\\n"
+    database = b"db\r=one"
+    application = b"app\n\t\\name"
+    params = b"\0".join((
+        b"user", user, b"database", database,
+        b"application_name", application, b"", b"",
+    ))
+    with connect() as sock:
+        sock.sendall(struct.pack("!II", len(params) + 8, 196608) + params)
+        assert read(sock, 1) == b"E", "Expected routing error"
+        size = struct.unpack("!I", read(sock, 4))[0]
+        error = read(sock, size - 4)
+        assert b"C3D000\0" in error, error
+        assert (b"route for '" + database + b"." + user
+                + b"' is not found") in error, error
+
+    expected = (
+        b"tskv\tuser=\\nuser\\t\\\\n\tdb=db\\r\\=one"
+        b"\tapp=app\\n\\t\\\\name\tctx=startup"
+        b"\tmsg=route for 'db\\r\\=one.\\nuser\\t\\\\n' is not found for '"
+    )
+    deadline = time.monotonic() + 5
+    while True:
+        data = Path("/var/log/odyssey.log").read_bytes()
+        lines = data.split(b"\n")
+        if any(line.startswith(expected) for line in lines):
+            break
+        assert time.monotonic() < deadline, data
+        time.sleep(0.05)
+
+    assert all(line.startswith(b"tskv\t") for line in lines if line), data
+    assert b"\r" not in data, data
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Newlines and tabs in client values can split log records and TSKV fields. Apply the existing `%M` escaping rules to `%u`, `%d`, `%a`, and `%x`. The original client values are preserved; `%m` retains its raw output.

Reserve space for the final newline and the async buffer's NUL terminator when truncating text logs. Treat application_name without a stored value as missing.
